### PR TITLE
[feat] 소셜 로그아웃 기능 구현 및 OAuthProvider 분리

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/auth/application/dto/OAuthUserInfoDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/application/dto/OAuthUserInfoDto.java
@@ -1,5 +1,6 @@
 package ktb.leafresh.backend.domain.auth.application.dto;
 
+import ktb.leafresh.backend.domain.auth.domain.entity.enums.OAuthProvider;
 import ktb.leafresh.backend.domain.member.domain.entity.enums.LoginType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,7 +8,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class OAuthUserInfoDto {
-    private LoginType provider;
+    private OAuthProvider provider;
     private String providerId;
     private String email;
     private String profileImageUrl;

--- a/src/main/java/ktb/leafresh/backend/domain/auth/application/factory/OAuthTokenFactory.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/application/factory/OAuthTokenFactory.java
@@ -13,7 +13,6 @@ public class OAuthTokenFactory {
 
     public OAuthTokenResponseDto create(Member member, TokenDto tokenDto) {
         String providerId = member.getAuths().stream()
-                .filter(auth -> auth.getProvider() == member.getLoginType()) // loginType 기반으로 추출
                 .findFirst()
                 .map(OAuth::getProviderId)
                 .orElse(null);

--- a/src/main/java/ktb/leafresh/backend/domain/auth/application/service/jwt/JwtLogoutService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/application/service/jwt/JwtLogoutService.java
@@ -1,0 +1,53 @@
+package ktb.leafresh.backend.domain.auth.application.service.jwt;
+
+import ktb.leafresh.backend.domain.auth.domain.entity.RefreshToken;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.RefreshTokenRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ErrorCode;
+import ktb.leafresh.backend.global.security.JwtProvider;
+import ktb.leafresh.backend.global.security.TokenBlacklistService;
+import ktb.leafresh.backend.global.security.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class JwtLogoutService {
+
+    private final TokenProvider tokenProvider;
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenBlacklistService tokenBlacklistService;
+
+    @Transactional
+    public void logout(String accessToken, String refreshToken) {
+        validateRefreshToken(refreshToken);
+
+        String memberId = tokenProvider.getAuthentication(accessToken).getName();
+
+        deleteRefreshToken(memberId);
+        blacklistAccessToken(accessToken);
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        if (!tokenProvider.validateToken(refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN, "유효하지 않은 RefreshToken입니다.");
+        }
+    }
+
+    private void deleteRefreshToken(String memberId) {
+        RefreshToken refreshToken = refreshTokenRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND, "이미 로그아웃된 사용자입니다."));
+        refreshTokenRepository.delete(refreshToken);
+    }
+
+    private void blacklistAccessToken(String accessToken) {
+        long now = System.currentTimeMillis();
+        long exp = jwtProvider.getExpiration(accessToken);
+        long remainingTime = exp - now;
+        if (remainingTime > 0) {
+            tokenBlacklistService.blacklistAccessToken(accessToken, remainingTime);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/auth/domain/entity/OAuth.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/domain/entity/OAuth.java
@@ -2,7 +2,7 @@ package ktb.leafresh.backend.domain.auth.domain.entity;
 
 import jakarta.persistence.*;
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
-import ktb.leafresh.backend.domain.member.domain.entity.enums.LoginType;
+import ktb.leafresh.backend.domain.auth.domain.entity.enums.OAuthProvider;
 import ktb.leafresh.backend.global.common.entity.BaseEntity;
 import lombok.*;
 
@@ -24,7 +24,7 @@ public class OAuth extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    private LoginType provider;
+    private OAuthProvider provider;
 
     @Column(nullable = false, length = 128)
     private String providerId;

--- a/src/main/java/ktb/leafresh/backend/domain/auth/domain/entity/enums/OAuthProvider.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/domain/entity/enums/OAuthProvider.java
@@ -1,0 +1,17 @@
+package ktb.leafresh.backend.domain.auth.domain.entity.enums;
+
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ErrorCode;
+
+import java.util.Arrays;
+
+public enum OAuthProvider {
+    KAKAO, NAVER, GOOGLE;
+
+    public static OAuthProvider from(String name) {
+        return Arrays.stream(values())
+                .filter(p -> p.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_PROVIDER));
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/auth/infrastructure/client/KakaoProfileClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/infrastructure/client/KakaoProfileClient.java
@@ -1,7 +1,7 @@
 package ktb.leafresh.backend.domain.auth.infrastructure.client;
 
 import ktb.leafresh.backend.domain.auth.application.dto.OAuthUserInfoDto;
-import ktb.leafresh.backend.domain.member.domain.entity.enums.LoginType;
+import ktb.leafresh.backend.domain.auth.domain.entity.enums.OAuthProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -25,7 +25,7 @@ public class KakaoProfileClient {
                 .retrieve()
                 .bodyToMono(KakaoProfileResponse.class)
                 .map(profile -> new OAuthUserInfoDto(
-                        LoginType.KAKAO,
+                        OAuthProvider.KAKAO,
                         profile.getId(),
                         profile.getKakaoAccountEmail(),
                         profile.getProfileImageUrl()

--- a/src/main/java/ktb/leafresh/backend/domain/auth/presentation/dto/request/OAuthSignupRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/presentation/dto/request/OAuthSignupRequestDto.java
@@ -1,7 +1,7 @@
 package ktb.leafresh.backend.domain.auth.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import ktb.leafresh.backend.domain.member.domain.entity.enums.LoginType;
+import ktb.leafresh.backend.domain.auth.domain.entity.enums.OAuthProvider;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
@@ -28,7 +28,7 @@ public record OAuthSignupRequestDto(
         public record Provider(
                 @NotNull(message = "OAuth 제공자 이름은 필수입니다.")
                 @Schema(description = "OAuth 제공자 이름", example = "KAKAO")
-                LoginType name,
+                OAuthProvider name,
 
                 @NotBlank(message = "providerId는 필수입니다.")
                 @Schema(description = "OAuth 제공자에서 발급한 고유 ID", example = "1234567890")

--- a/src/main/java/ktb/leafresh/backend/domain/auth/presentation/dto/result/OAuthSignupResult.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/presentation/dto/result/OAuthSignupResult.java
@@ -1,0 +1,11 @@
+package ktb.leafresh.backend.domain.auth.presentation.dto.result;
+
+import ktb.leafresh.backend.domain.auth.presentation.dto.response.OAuthSignupResponseDto;
+import ktb.leafresh.backend.global.security.TokenDto;
+import lombok.Builder;
+
+@Builder
+public record OAuthSignupResult(
+        OAuthSignupResponseDto signupResponse,
+        TokenDto tokenDto
+) {}

--- a/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/enums/LoginType.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/enums/LoginType.java
@@ -1,23 +1,5 @@
 package ktb.leafresh.backend.domain.member.domain.entity.enums;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
-
 public enum LoginType {
-    KAKAO, NAVER, GOOGLE;
-
-    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static LoginType from(String value) {
-        for (LoginType type : values()) {
-            if (type.name().equalsIgnoreCase(value)) {
-                return type;
-            }
-        }
-        throw new RuntimeException("지원하지 않는 provider입니다: " + value); // 무조건 예외 잡힘
-    }
-
-    @JsonValue
-    public String toJson() {
-        return name();
-    }
+    LOCAL, SOCIAL;
 }

--- a/src/main/java/ktb/leafresh/backend/global/security/AuthCookieProvider.java
+++ b/src/main/java/ktb/leafresh/backend/global/security/AuthCookieProvider.java
@@ -1,5 +1,6 @@
 package ktb.leafresh.backend.global.security;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
@@ -8,30 +9,42 @@ import java.time.Duration;
 @Component
 public class AuthCookieProvider {
 
-    private static final String ACCESS_TOKEN_NAME = "accessToken";
-    private static final String REFRESH_TOKEN_NAME = "refreshToken";
+    @Value("${cookie.secure}")
+    private boolean secure;
 
-    public ResponseCookie createAccessTokenCookie(String accessToken, long expiresInMillis) {
-        return ResponseCookie.from(ACCESS_TOKEN_NAME, accessToken)
-                .httpOnly(true).secure(true).path("/").sameSite("Strict")
-                .maxAge(Duration.ofMillis(expiresInMillis)).build();
+    public ResponseCookie createCookie(String name, String value, Duration maxAge) {
+        return ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(secure)
+                .path("/")
+                .sameSite("Strict")
+                .maxAge(maxAge)
+                .build();
     }
 
-    public ResponseCookie createRefreshTokenCookie(String refreshToken) {
-        return ResponseCookie.from(REFRESH_TOKEN_NAME, refreshToken)
-                .httpOnly(true).secure(true).path("/").sameSite("Strict")
-                .maxAge(Duration.ofDays(7)).build(); // 7일 고정
+    public ResponseCookie clearCookie(String name) {
+        return ResponseCookie.from(name, "")
+                .httpOnly(true)
+                .secure(secure)
+                .path("/")
+                .sameSite("Strict")
+                .maxAge(0)
+                .build();
+    }
+
+    public ResponseCookie createAccessTokenCookie(String token, long expiresInMillis) {
+        return createCookie("accessToken", token, Duration.ofMillis(expiresInMillis));
+    }
+
+    public ResponseCookie createRefreshTokenCookie(String token) {
+        return createCookie("refreshToken", token, Duration.ofDays(7));
     }
 
     public ResponseCookie clearAccessTokenCookie() {
-        return ResponseCookie.from(ACCESS_TOKEN_NAME, "")
-                .httpOnly(true).secure(true).path("/").sameSite("Strict")
-                .maxAge(0).build();
+        return clearCookie("accessToken");
     }
 
     public ResponseCookie clearRefreshTokenCookie() {
-        return ResponseCookie.from(REFRESH_TOKEN_NAME, "")
-                .httpOnly(true).secure(true).path("/").sameSite("Strict")
-                .maxAge(0).build();
+        return clearCookie("refreshToken");
     }
 }

--- a/src/main/java/ktb/leafresh/backend/global/security/TokenProvider.java
+++ b/src/main/java/ktb/leafresh/backend/global/security/TokenProvider.java
@@ -55,7 +55,7 @@ public class TokenProvider {
                 .getSubject();
     }
 
-    public OAuthTokenResponseDto generateTokenDto(Long memberId) {
+    public TokenDto generateTokenDto(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND, "존재하지 않는 회원입니다."));
 
@@ -69,14 +69,7 @@ public class TokenProvider {
 
         TokenDto tokenDto = generateTokenDto(authentication, memberId);
 
-        return OAuthTokenResponseDto.builder()
-                .grantType(tokenDto.getGrantType())
-                .accessToken(tokenDto.getAccessToken())
-                .accessTokenExpiresIn(tokenDto.getAccessTokenExpiresIn())
-                .refreshToken(tokenDto.getRefreshToken())
-                .nickname(member.getNickname())
-                .imageUrl(member.getImageUrl())
-                .build();
+        return generateTokenDto(authentication, memberId);
     }
 
     public long getTokenExpiration(String token) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${local_db_host}:${db_port}/${local_db_name}
+    username: ${local_db_user}
+    password: ${local_db_password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  data:
+    redis:
+      host: ${local_cache_host}
+      port: ${local_cache_port}
+
+cookie:
+  secure: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${prod_db_host}:${db_port}/${prod_db_name}
+    username: ${prod_db_user}
+    password: ${prod_db_password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  data:
+    redis:
+      host: ${prod_cache_host}
+      port: ${prod_cache_port}
+
+cookie:
+  secure: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,15 +2,12 @@ spring:
   application:
     name: backend
 
+  profiles:
+    active: local
+
   security:
     basic:
       enabled: false
-
-  datasource:
-    url: jdbc:mysql://${local_db_host}:${db_port}/${local_db_name}
-    username: ${local_db_user}
-    password: ${local_db_password}
-    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
@@ -26,11 +23,6 @@ spring:
       enabled: true
       max-file-size: 10MB
       max-request-size: 50MB
-
-  data:
-    redis:
-      host: ${local_cache_host}
-      port: ${local_cache_port}
 
 springdoc:
   api-docs:
@@ -50,6 +42,7 @@ logging:
           descriptor:
             sql:
               BasicBinder: TRACE
+    org.springframework.web.servlet.DispatcherServlet: DEBUG
 
 jwt:
   secret: ${jwt_secret}
@@ -58,3 +51,6 @@ kakao:
   client-id: ${kakao_client_id}
   redirect-uri: ${kakao_redirect_uri}
   client-secret: ${kakao_client_secret}
+
+cookie:
+  secure: true


### PR DESCRIPTION
## 작업 내용

- 로그아웃 기능 구현
  - `JwtLogoutService` 생성
  - `OAuthLoginService`에 로그아웃 로직 추가
  - `OAuthController`에 로그아웃 엔드포인트 구현

- 로그인/회원가입 구조 개선
  - `OAuthProvider` enum 생성 및 도입
  - `LoginType`은 로그인 방식(LOCAL/SOCIAL)으로, `OAuthProvider`는 실제 OAuth 플랫폼(KAKAO/GOOGLE/NAVER)으로 분리
  - 기존 `LoginType` 기반 코드 전반 수정
  - `OAuthSignupService` 및 `OAuthTokenFactory`에서 provider 처리 로직 수정
  - `OAuthUserInfoDto`에 provider 필드 타입 변경

- DTO 및 유틸 정비
  - `OAuthSignupResult` 생성 → 응답 데이터와 토큰 정보를 함께 전달
  - `AuthCookieProvider` 내부 로직 리팩토링
  - `TokenProvider` 중복 코드 제거 및 정리

- 환경 분리
  - `application.yml` 분리 → `application-local.yml`, `application-prod.yml` 추가

---

## 이슈 번호

- Close #18
- Close #19

---

## 기타 참고 사항

- `develop` 브랜치에 직접 커밋한 변경사항을 본 브랜치(`feature/18-19-logout`)로 옮기기 위해 현재 커밋을 재정리 중입니다.
- 커밋 단위는 기능 중심으로 분리하여 올렸습니다.