### PR TITLE
[feat] AI 서버 연동 테스트를 위한 임시 보안 설정 및 테스트 컨트롤러 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/global/TestController.java
+++ b/src/main/java/ktb/leafresh/backend/global/TestController.java
@@ -1,0 +1,42 @@
+package ktb.leafresh.backend.global;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/spring")
+@RequiredArgsConstructor
+public class TestController {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    // FastAPI → Spring: GET 수신
+    @GetMapping("/hello")
+    public String receiveFromFastApiGet() {
+        return "Hello from Spring!";
+    }
+
+    // FastAPI → Spring: POST 수신
+    @PostMapping("/echo")
+    public Map<String, String> receiveFromFastApiPost(@RequestBody Map<String, String> body) {
+        return Map.of("spring_received", body.get("message"));
+    }
+
+    // Spring → FastAPI: GET 요청
+    @GetMapping("/call-fastapi")
+    public Map<String, String> callFastApiGet() {
+        String response = restTemplate.getForObject("http://localhost:8000/fastapi/hello", String.class);
+        return Map.of("from_fastapi", response);
+    }
+
+    // Spring → FastAPI: POST 요청
+    @PostMapping("/call-fastapi")
+    public Map<String, String> callFastApiPost() {
+        Map<String, String> body = Map.of("message", "방가방가!");
+        String response = restTemplate.postForObject("http://localhost:8000/fastapi/echo", body, String.class);
+        return Map.of("from_fastapi", response);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -60,13 +60,13 @@ public class SecurityConfig {
 
                 // 인증, 인가 설정
                 .authorizeHttpRequests(auth -> auth
+                        // 테스트 컨트롤러용 허용 경로 추가
+                        .requestMatchers("/spring/**").permitAll()
+
                         // 소셜 로그인 요청(리다이렉트), 콜백, 로그아웃 모두 허용
                         .requestMatchers("/oauth/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/nickname").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/members/signup").permitAll()
-
-                        // 닉네임 중복 검사 허용
-                        .requestMatchers(HttpMethod.GET, "/api/members/nickname").permitAll()
 
                         // Swagger/OpenAPI
                         .requestMatchers(


### PR DESCRIPTION
## 작업 내용

- AI 서버와 통신 테스트를 위해 임시로 `SecurityConfig`에 허용 경로 추가
  - `/spring/hello` (GET)
  - `/spring/echo` (POST)
  - `/spring/call-fastapi` (GET)
  - `/spring/call-fastapi-post` (POST)
- `TestController` 작성
  - FastAPI 서버에서 요청 받을 수 있도록 Spring → FastAPI, FastAPI → Spring 테스트 엔드포인트 구현
- 테스트 시 AI 서버 IP로 FastAPI 요청 URL 변경 가능하도록 처리

---

## 목적

- AI 서버(Python FastAPI)와의 통신 연동을 개발 환경에서 빠르게 검증하기 위함

---

## 주의사항

- 추후 운영 환경에서는 해당 테스트용 컨트롤러 및 보안 설정 제거 예정
- `SecurityConfig` 변경은 임시이므로 관련 로직이 있는 경우 충돌 주의

---

## 관련 이슈
- Close #43
