### PR TITLE
feat: OAuthUserInfoDto에 nickname 필드 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/auth/application/dto/OAuthUserInfoDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/application/dto/OAuthUserInfoDto.java
@@ -12,4 +12,5 @@ public class OAuthUserInfoDto {
     private String providerId;
     private String email;
     private String profileImageUrl;
+    private String nickname;
 }

--- a/src/main/java/ktb/leafresh/backend/domain/auth/infrastructure/client/KakaoProfileClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/infrastructure/client/KakaoProfileClient.java
@@ -28,7 +28,8 @@ public class KakaoProfileClient {
                         OAuthProvider.KAKAO,
                         profile.getId(),
                         profile.getKakaoAccountEmail(),
-                        profile.getProfileImageUrl()
+                        profile.getProfileImageUrl(),
+                        profile.getNickname()
                 ))
                 .blockOptional()
                 .orElseThrow(() -> new IllegalStateException("카카오 사용자 정보 조회 실패"));
@@ -49,6 +50,13 @@ public class KakaoProfileClient {
             Map<String, Object> profile = (Map<String, Object>) kakao_account.get("profile");
             if (profile == null) return null;
             return (String) profile.get("profile_image_url");
+        }
+
+        public String getNickname() {
+            if (kakao_account == null) return null;
+            Map<String, Object> profile = (Map<String, Object>) kakao_account.get("profile");
+            if (profile == null) return null;
+            return (String) profile.get("nickname");
         }
     }
 }


### PR DESCRIPTION
OAuth 로그인 시 사용자 닉네임 정보를 저장할 수 있도록 `OAuthUserInfoDto`에 `nickname` 필드를 추가하였습니다.  
이에 따라 카카오 프로필 응답 파싱 및 DTO 생성 로직, 로그인 로그 출력부에 해당 필드를 반영하였습니다.

### 주요 변경 사항
- `OAuthUserInfoDto` 클래스에 `nickname` 필드 추가
- `KakaoProfileClient`에서 nickname 파싱 및 전달
- `OAuthLoginService` 내 사용자 정보 로그에 nickname 출력 추가

### 기타
- 기존 로그인/회원가입 흐름에는 영향 없음
- 추후 회원 가입 시 닉네임 기본값으로 사용 가능