### PR TITLE
feat: access token 만료 시 refresh token으로 재발급 로직 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/auth/application/service/oauth/OAuthLoginService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/application/service/oauth/OAuthLoginService.java
@@ -14,6 +14,7 @@ import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -27,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OAuthLoginService {

--- a/src/main/java/ktb/leafresh/backend/domain/auth/application/service/oauth/OAuthReissueTokenService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/application/service/oauth/OAuthReissueTokenService.java
@@ -1,0 +1,56 @@
+package ktb.leafresh.backend.domain.auth.application.service.oauth;
+
+import ktb.leafresh.backend.domain.auth.domain.entity.RefreshToken;
+import ktb.leafresh.backend.domain.auth.presentation.dto.response.OAuthTokenResponseDto;
+import ktb.leafresh.backend.domain.auth.application.factory.OAuthTokenFactory;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.RefreshTokenRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ErrorCode;
+import ktb.leafresh.backend.global.security.TokenProvider;
+import ktb.leafresh.backend.global.security.TokenDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthReissueTokenService {
+
+    private final TokenProvider tokenProvider;
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final OAuthTokenFactory tokenFactory;
+
+    @Transactional(readOnly = true)
+    public OAuthTokenResponseDto reissue(String refreshToken) {
+        String memberId = tokenProvider.getSubject(refreshToken);
+
+        RefreshToken savedToken = validateRefreshToken(refreshToken, memberId);
+        Member member = findMemberOrThrow(Long.parseLong(memberId));
+
+        TokenDto newToken = tokenProvider.generateTokenDto(member.getId());
+        return tokenFactory.create(member, newToken);
+    }
+
+    private RefreshToken validateRefreshToken(String refreshToken, String memberId) {
+        if (!tokenProvider.validateToken(refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN, "유효하지 않은 Refresh Token입니다.");
+        }
+
+        RefreshToken saved = refreshTokenRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND, "Refresh Token을 찾을 수 없습니다."));
+
+        if (!saved.getRtValue().equals(refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN, "Refresh Token이 일치하지 않습니다.");
+        }
+
+        return saved;
+    }
+
+    private Member findMemberOrThrow(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND, "존재하지 않는 회원입니다."));
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/exception/ErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     IMAGE_ORDER_INDEX_MISMATCH(HttpStatus.BAD_REQUEST, "이미지 개수와 orderIndex 개수가 맞지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없습니다."),
     INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 OAuth 공급자입니다."),


### PR DESCRIPTION
JWT 기반 인증 흐름에서 access token이 만료된 경우, refresh token을 이용해 access token을 재발급받을 수 있는 기능을 구현하였습니다.

### 주요 구현 내용
- access token 만료 시 클라이언트가 refresh token을 함께 전송하도록 처리
- refresh token 유효성 검증 및 저장된 값과 일치 여부 검사
- 유효한 경우 새로운 access token 및 refresh token 발급 후 응답
- 유저 정보 기반 인증 객체(SecurityContext) 갱신

### 테스트
- access token 만료 후 refresh token으로 토큰 재발급 요청 → 정상 동작 확인
- refresh token 불일치 또는 만료 시 재발급 거부 → 예외 처리 정상 확인

### 비고
- 토큰 응답 시 HttpOnly 쿠키에 access/refresh token 저장 방식 유지