### PR TITLE
feat: AI 챌린지 유사도 검증을 위한 현재 진행 중 챌린지 목록 조회 기능 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/validator/AiChallengePolicyValidator.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/validator/AiChallengePolicyValidator.java
@@ -1,28 +1,52 @@
 package ktb.leafresh.backend.domain.challenge.group.application.validator;
 
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.client.AiChallengeValidationClient;
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.dto.AiChallengeValidationRequestDto;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.dto.AiChallengeValidationRequestDto.ChallengeSummary;
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.dto.AiChallengeValidationResponseDto;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class AiChallengePolicyValidator {
 
     private final AiChallengeValidationClient aiChallengeValidationClient;
+    private final GroupChallengeRepository groupChallengeRepository;
 
     public void validate(Long memberId, GroupChallengeCreateRequestDto dto) {
+        // 현재 및 예정 챌린지 목록 조회
+        List<GroupChallenge> activeChallenges = groupChallengeRepository.findAllValidAndOngoing(LocalDateTime.now());
+
+        // 챌린지 목록을 DTO 형태로 변환
+        List<ChallengeSummary> challengeSummaries = activeChallenges.stream()
+                .map(ch -> new ChallengeSummary(
+                        ch.getId(),
+                        ch.getTitle(),
+                        ch.getStartDate().toString(),
+                        ch.getEndDate().toString()
+                ))
+                .toList();
+
+        // AI 요청 생성
         AiChallengeValidationRequestDto aiRequest = new AiChallengeValidationRequestDto(
                 memberId,
                 dto.title(),
                 dto.startDate().toString(),
-                dto.endDate().toString()
+                dto.endDate().toString(),
+                challengeSummaries
         );
 
+        // AI 서버에 유사 챌린지 존재 여부 요청
         AiChallengeValidationResponseDto aiResponse = aiChallengeValidationClient.validateChallenge(aiRequest);
 
         if (!aiResponse.result()) {

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/dto/AiChallengeValidationRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/dto/AiChallengeValidationRequestDto.java
@@ -1,8 +1,18 @@
 package ktb.leafresh.backend.domain.challenge.group.infrastructure.dto;
 
+import java.util.List;
+
 public record AiChallengeValidationRequestDto(
         Long memberId,
         String challengeName,
         String startDate,
-        String endDate
-) {}
+        String endDate,
+        List<ChallengeSummary> challenge
+) {
+    public record ChallengeSummary(
+            Long id,
+            String name,
+            String startDate,
+            String endDate
+    ) {}
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeRepository.java
@@ -2,6 +2,17 @@ package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
 
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface GroupChallengeRepository extends JpaRepository<GroupChallenge, Long> {
+
+    @Query("SELECT gc FROM GroupChallenge gc " +
+            "WHERE gc.endDate >= :today " +
+            "AND gc.deletedAt IS NULL")
+    List<GroupChallenge> findAllValidAndOngoing(@Param("today") LocalDateTime today);
 }


### PR DESCRIPTION
## 작업 내용
- `AiChallengePolicyValidator`에서 기존 챌린지 목록을 AI 서버에 전달하도록 기능 추가
- `GroupChallengeRepository`에 JPQL 기반의 `findAllValidAndOngoing(LocalDateTime)` 메서드 구현
- `AiChallengeValidationRequestDto`에 ChallengeSummary 리스트 필드 추가 및 활용

## 변경 이유
- AI 서버가 유사 챌린지 검증을 위해 기존 챌린지 정보를 필요로 함
- 유사 챌린지가 있을 경우 챌린지 생성을 제한하기 위한 정책 도입

## 영향 범위
- 그룹 챌린지 생성 API (`POST /api/challenges/group`)
- AI 서버와의 통신 로직 (`AiChallengeValidationClient`)

## 기타 참고 사항
- 현재 시각 기준으로 `endDate >= now()`인 챌린지를 유효한 챌린지로 간주
- `LocalDate` → `LocalDateTime` 타입 일치 문제 해결 완료
