### PR TITLE
feat: 단체 챌린지 상세 조회 기능 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
@@ -1,0 +1,68 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeDetailResponseDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeExampleImageDto;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GroupChallengeReadService {
+
+    private final GroupChallengeRepository groupChallengeRepository;
+    private final GroupChallengeVerificationRepository verificationRepository;
+
+    public GroupChallengeDetailResponseDto getChallengeDetail(Long memberIdOrNull, Long challengeId) {
+        GroupChallenge challenge = getChallengeOrThrow(challengeId);
+        List<String> verificationImages = getVerificationImages(challengeId);
+        List<GroupChallengeExampleImageDto> exampleImages = getExampleImages(challenge);
+        ChallengeStatus status = resolveChallengeStatus(memberIdOrNull, challengeId);
+
+        return GroupChallengeDetailResponseDto.of(challenge, exampleImages, verificationImages, status);
+    }
+
+    private GroupChallenge getChallengeOrThrow(Long challengeId) {
+        return groupChallengeRepository.findById(challengeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.GROUP_CHALLENGE_NOT_FOUND));
+    }
+
+    private List<String> getVerificationImages(Long challengeId) {
+        return verificationRepository
+                .findTop9ByParticipantRecord_GroupChallenge_IdOrderByCreatedAtDesc(challengeId)
+                .stream()
+                .map(GroupChallengeVerification::getImageUrl)
+                .toList();
+    }
+
+    private List<GroupChallengeExampleImageDto> getExampleImages(GroupChallenge challenge) {
+        return challenge.getExampleImages().stream()
+                .map(GroupChallengeExampleImageDto::from)
+                .toList();
+    }
+
+    private ChallengeStatus resolveChallengeStatus(Long memberIdOrNull, Long challengeId) {
+        if (memberIdOrNull == null) {
+            log.info("비로그인 상태 - 인증 상태 조회 생략");
+            return ChallengeStatus.NOT_SUBMITTED;
+        }
+
+        log.info("로그인 상태 - memberId = {}", memberIdOrNull);
+        return verificationRepository
+                .findTopByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_IdOrderByCreatedAtDesc(memberIdOrNull, challengeId)
+                .map(GroupChallengeVerification::getStatus)
+                .orElse(ChallengeStatus.NOT_SUBMITTED);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
@@ -2,8 +2,10 @@ package ktb.leafresh.backend.domain.challenge.group.presentation.controller;
 
 import jakarta.validation.Valid;
 import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeCreateService;
+import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeReadService;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeCreateResponseDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeDetailResponseDto;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class GroupChallengeController {
 
     private final GroupChallengeCreateService groupChallengeCreateService;
+    private final GroupChallengeReadService groupChallengeReadService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<GroupChallengeCreateResponseDto>> createGroupChallenge(
@@ -28,5 +31,15 @@ public class GroupChallengeController {
         GroupChallengeCreateResponseDto response = groupChallengeCreateService.create(memberId, request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("단체 챌린지가 생성되었습니다.", response));
+    }
+
+    @GetMapping("/{challengeId}")
+    public ResponseEntity<ApiResponse<GroupChallengeDetailResponseDto>> getGroupChallengeDetail(
+            @PathVariable Long challengeId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long memberId = (userDetails != null) ? userDetails.getMemberId() : null;
+        GroupChallengeDetailResponseDto response = groupChallengeReadService.getChallengeDetail(memberId, challengeId);
+        return ResponseEntity.ok(ApiResponse.success("단체 챌린지 상세 정보를 성공적으로 조회했습니다.", response));
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeDetailResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeDetailResponseDto.java
@@ -1,0 +1,49 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Builder
+public record GroupChallengeDetailResponseDto(
+        Long id,
+        String title,
+        String description,
+        LocalDate startDate,
+        LocalDate endDate,
+        LocalTime verificationStartTime,
+        LocalTime verificationEndTime,
+        Integer leafReward,
+        String thumbnailUrl,
+        List<GroupChallengeExampleImageDto> exampleImages,
+        List<String> verificationImages,
+        int maxParticipantCount,
+        int currentParticipantCount,
+        ChallengeStatus status
+) {
+    public static GroupChallengeDetailResponseDto of(GroupChallenge challenge,
+                                                     List<GroupChallengeExampleImageDto> exampleImages,
+                                                     List<String> verificationImages,
+                                                     ChallengeStatus status) {
+        return GroupChallengeDetailResponseDto.builder()
+                .id(challenge.getId())
+                .title(challenge.getTitle())
+                .description(challenge.getDescription())
+                .startDate(challenge.getStartDate().toLocalDate())
+                .endDate(challenge.getEndDate().toLocalDate())
+                .verificationStartTime(challenge.getVerificationStartTime())
+                .verificationEndTime(challenge.getVerificationEndTime())
+                .leafReward(challenge.getLeafReward())
+                .thumbnailUrl(challenge.getImageUrl())
+                .exampleImages(exampleImages)
+                .verificationImages(verificationImages)
+                .maxParticipantCount(challenge.getMaxParticipantCount())
+                .currentParticipantCount(challenge.getCurrentParticipantCount())
+                .status(status)
+                .build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeExampleImageDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeExampleImageDto.java
@@ -1,0 +1,23 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeExampleImage;
+import lombok.Builder;
+
+@Builder
+public record GroupChallengeExampleImageDto(
+        Long id,
+        String imageUrl,
+        String type,
+        String description,
+        int sequenceNumber
+) {
+    public static GroupChallengeExampleImageDto from(GroupChallengeExampleImage image) {
+        return GroupChallengeExampleImageDto.builder()
+                .id(image.getId())
+                .imageUrl(image.getImageUrl())
+                .type(image.getType().name())
+                .description(image.getDescription())
+                .sequenceNumber(image.getSequenceNumber())
+                .build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/GroupChallengeVerificationRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/GroupChallengeVerificationRepository.java
@@ -1,0 +1,23 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GroupChallengeVerificationRepository extends JpaRepository<GroupChallengeVerification, Long> {
+
+    /**
+     * 특정 회원이 특정 단체 챌린지에 대해 마지막으로 인증한 기록을 조회
+     */
+    Optional<GroupChallengeVerification> findTopByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_IdOrderByCreatedAtDesc(
+            Long memberId,
+            Long challengeId
+    );
+
+    /**
+     * 단체 챌린지 상세 페이지에 보여줄 최신 인증 이미지 9개 조회
+     */
+    List<GroupChallengeVerification> findTop9ByParticipantRecord_GroupChallenge_IdOrderByCreatedAtDesc(Long challengeId);
+}

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -68,6 +68,11 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/members/nickname").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/members/signup").permitAll()
 
+                        // 단체 챌린지 상세 조회만 비회원 허용
+                        .requestMatchers(HttpMethod.GET, "/api/challenges/group/{challengeId:\\d+}").permitAll()
+                        // 그 외 단체 챌린지 API는 인증 필요
+                        .requestMatchers("/api/challenges/group/**").authenticated()
+
                         // Swagger/OpenAPI
                         .requestMatchers(
                                 "/swagger-ui/**",

--- a/src/main/java/ktb/leafresh/backend/global/exception/ErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     TREE_LEVEL_NOT_FOUND(HttpStatus.NOT_FOUND, "기본 TreeLevel이 존재하지 않습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "저장된 리프레시 토큰이 없습니다."),
     CHALLENGE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 챌린지 카테고리입니다."),
+    GROUP_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "단체 챌린지를 찾을 수 없습니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작일은 종료일보다 이전이어야 합니다."),
     INVALID_VERIFICATION_TIME(HttpStatus.BAD_REQUEST, "인증 시작 시간은 종료 시간보다 이전이어야 합니다."),
     CHALLENGE_CREATION_REJECTED_BY_AI(HttpStatus.UNPROCESSABLE_ENTITY, "AI 판단 결과 챌린지 생성이 거부되었습니다.");

--- a/src/main/java/ktb/leafresh/backend/global/security/SecurityUtil.java
+++ b/src/main/java/ktb/leafresh/backend/global/security/SecurityUtil.java
@@ -21,7 +21,6 @@ public class SecurityUtil {
 
         if (authentication == null
                 || authentication.getName() == null
-//                || authentication.getName().equals("anonymousUser")) {
                 || "anonymousUser".equals(authentication.getName())) {
             throw new AuthenticationCredentialsNotFoundException("인증이 필요합니다.");  // 401 Unauthorized 처리
         }
@@ -42,5 +41,25 @@ public class SecurityUtil {
         } catch (Exception e) {
             throw new AuthenticationCredentialsNotFoundException("인증 정보 처리 중 오류가 발생했습니다.");
         }
+    }
+
+    public Long getCurrentMemberIdIfPresent() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getName())) {
+            return null;
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UserDetails userDetails) {
+            try {
+                return Long.parseLong(userDetails.getUsername());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## 작업 개요

단체 챌린지 상세 조회 기능을 구현하고, 서비스 로직을 역할별로 분리하여 SRP(Single Responsibility Principle)를 적용하였습니다.  
비회원도 접근 가능한 API이며, 로그인 여부에 따라 인증 상태를 분기하여 응답합니다.

---

## 주요 변경 사항

### 기능 추가
- `GET /api/challenges/group/{challengeId}` API 추가 (비로그인 사용자 접근 허용)
- 로그인된 경우 본인의 최신 인증 상태 조회 (성공/실패/대기/미제출)

### 리팩토링
- `GroupChallengeReadService`의 역할을 다음과 같이 분리
  - `getChallengeOrThrow`: 챌린지 조회
  - `getExampleImages`: 예시 이미지 DTO 변환
  - `getVerificationImages`: 인증 이미지 리스트 조회
  - `resolveChallengeStatus`: 인증 상태 결정
- `ChallengeStatus` Enum 응답값으로 직접 사용

### 기타 변경
- `SecurityConfig`: 해당 URI 비회원 접근 허용 설정
- `ErrorCode`: `CHALLENGE_NOT_FOUND` 상수 추가
- `GroupChallengeVerificationRepository`: 인증 상태 조회용 쿼리 메서드 추가

---

## 테스트

- [x] 비로그인 상태에서 챌린지 상세 조회 가능
- [x] 로그인 상태에서 본인의 인증 상태가 포함된 상세 응답 확인
- [x] DTO에 Enum이 문자열로 반환되는지 확인 (e.g. `"NOT_SUBMITTED"`)