### PR TITLE
feat: 단체 챌린지 생성 시 기간 및 인증 시간 유효성 검증 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/validator/GroupChallengeDomainValidator.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/validator/GroupChallengeDomainValidator.java
@@ -7,6 +7,9 @@ import ktb.leafresh.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
 @Component
 @RequiredArgsConstructor
 public class GroupChallengeDomainValidator {
@@ -14,12 +17,20 @@ public class GroupChallengeDomainValidator {
     private final GroupChallengeCategoryRepository categoryRepository;
 
     public void validate(GroupChallengeCreateRequestDto dto) {
-        if (dto.startDate().isAfter(dto.endDate())) {
+        if (!dto.endDate().isAfter(dto.startDate())) {
             throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
         }
 
-        if (dto.verificationStartTime().isAfter(dto.verificationEndTime())) {
+        if (ChronoUnit.DAYS.between(dto.startDate(), dto.endDate()) < 1) {
+            throw new CustomException(ErrorCode.CHALLENGE_DURATION_TOO_SHORT);
+        }
+
+        if (!dto.verificationEndTime().isAfter(dto.verificationStartTime())) {
             throw new CustomException(ErrorCode.INVALID_VERIFICATION_TIME);
+        }
+
+        if (Duration.between(dto.verificationStartTime(), dto.verificationEndTime()).toMinutes() < 10) {
+            throw new CustomException(ErrorCode.VERIFICATION_DURATION_TOO_SHORT);
         }
 
         boolean exists = categoryRepository.findByName(dto.category()).isPresent();

--- a/src/main/java/ktb/leafresh/backend/global/exception/ErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/ErrorCode.java
@@ -28,6 +28,8 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "저장된 리프레시 토큰이 없습니다."),
     CHALLENGE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 챌린지 카테고리입니다."),
     GROUP_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "단체 챌린지를 찾을 수 없습니다."),
+    CHALLENGE_DURATION_TOO_SHORT(HttpStatus.BAD_REQUEST, "챌린지 기간은 최소 1일 이상이어야 합니다."),
+    VERIFICATION_DURATION_TOO_SHORT(HttpStatus.BAD_REQUEST, "인증 가능 시간은 최소 10분 이상이어야 합니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작일은 종료일보다 이전이어야 합니다."),
     INVALID_VERIFICATION_TIME(HttpStatus.BAD_REQUEST, "인증 시작 시간은 종료 시간보다 이전이어야 합니다."),
     CHALLENGE_CREATION_REJECTED_BY_AI(HttpStatus.UNPROCESSABLE_ENTITY, "AI 판단 결과 챌린지 생성이 거부되었습니다.");


### PR DESCRIPTION
- GroupChallengeDomainValidator 에 다음 유효성 검증 로직 추가:
  - 인증 시작/종료 시간 간 10분 이상 차이
  - 챌린지 시작일과 종료일 간 최소 1일 이상 차이
  - 기존 종료일 < 시작일, 인증 종료 < 인증 시작 로직 유지
- ErrorCode에 관련 예외 코드 2종 추가
