### PR TITLE
feat: 단체 챌린지 수정 기능 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeUpdateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeUpdateService.java
@@ -1,0 +1,36 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.application.service.updater.GroupChallengeCategoryUpdater;
+import ktb.leafresh.backend.domain.challenge.group.application.service.updater.GroupChallengeExampleImageUpdater;
+import ktb.leafresh.backend.domain.challenge.group.application.service.updater.GroupChallengeUpdater;
+import ktb.leafresh.backend.domain.challenge.group.application.validator.GroupChallengeDomainValidator;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.*;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GroupChallengeUpdateService {
+
+    private final GroupChallengeUpdater challengeUpdater;
+    private final GroupChallengeExampleImageUpdater imageUpdater;
+    private final GroupChallengeCategoryUpdater categoryUpdater;
+    private final GroupChallengeDomainValidator domainValidator;
+
+    @Transactional
+    public void update(Long memberId, Long challengeId, GroupChallengeUpdateRequestDto dto) {
+        // 유효성 검사
+        domainValidator.validate(dto);
+
+        // 챌린지 정보 + 작성자 본인 확인
+        GroupChallenge challenge = challengeUpdater.updateChallengeInfo(memberId, challengeId, dto);
+
+        // 카테고리 수정
+        categoryUpdater.updateCategory(challenge, dto.category());
+
+        // 예시 이미지 처리
+        imageUpdater.updateImages(challenge, dto.exampleImages());
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/updater/GroupChallengeCategoryUpdater.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/updater/GroupChallengeCategoryUpdater.java
@@ -1,0 +1,22 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service.updater;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GroupChallengeCategoryUpdater {
+
+    private final GroupChallengeCategoryRepository repository;
+
+    public void updateCategory(GroupChallenge challenge, String categoryName) {
+        GroupChallengeCategory newCategory = repository.findByName(categoryName)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHALLENGE_CATEGORY_NOT_FOUND));
+        challenge.changeCategory(newCategory);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/updater/GroupChallengeExampleImageUpdater.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/updater/GroupChallengeExampleImageUpdater.java
@@ -1,0 +1,35 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service.updater;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeExampleImage;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeExampleImageRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto;
+import ktb.leafresh.backend.global.util.image.ImageEntityUpdater;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class GroupChallengeExampleImageUpdater {
+
+    private final GroupChallengeExampleImageRepository repository;
+    private final ImageEntityUpdater imageEntityUpdater;
+
+    public void updateImages(GroupChallenge challenge, GroupChallengeUpdateRequestDto.ExampleImages exampleImages) {
+        List<ImageEntityUpdater.KeepImage> keepList = exampleImages.keep()
+                .stream()
+                .map(k -> new ImageEntityUpdater.KeepImage(k.id(), k.sequenceNumber()))
+                .toList();
+
+        List<GroupChallengeExampleImage> newEntities = exampleImages.newImages()
+                .stream()
+                .map(n -> GroupChallengeExampleImage.of(
+                        challenge, n.imageUrl(), n.type(), n.description(), n.sequenceNumber()
+                ))
+                .toList();
+
+        imageEntityUpdater.update(challenge, keepList, newEntities, exampleImages.deleted(), repository);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/updater/GroupChallengeUpdater.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/updater/GroupChallengeUpdater.java
@@ -1,0 +1,32 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service.updater;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GroupChallengeUpdater {
+
+    private final GroupChallengeRepository repository;
+
+    public GroupChallenge updateChallengeInfo(Long memberId, Long challengeId, GroupChallengeUpdateRequestDto dto) {
+        GroupChallenge challenge = repository.findById(challengeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.GROUP_CHALLENGE_NOT_FOUND));
+
+        if (!challenge.getMember().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        challenge.updateInfo(
+                dto.title(), dto.description(), dto.thumbnailImageUrl(), dto.maxParticipantCount(),
+                dto.startDate(), dto.endDate(), dto.verificationStartTime(), dto.verificationEndTime()
+        );
+
+        return challenge;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/validator/GroupChallengeDomainValidator.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/validator/GroupChallengeDomainValidator.java
@@ -2,6 +2,7 @@ package ktb.leafresh.backend.domain.challenge.group.application.validator;
 
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,29 @@ public class GroupChallengeDomainValidator {
     private final GroupChallengeCategoryRepository categoryRepository;
 
     public void validate(GroupChallengeCreateRequestDto dto) {
+        if (!dto.endDate().isAfter(dto.startDate())) {
+            throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
+        }
+
+        if (ChronoUnit.DAYS.between(dto.startDate(), dto.endDate()) < 1) {
+            throw new CustomException(ErrorCode.CHALLENGE_DURATION_TOO_SHORT);
+        }
+
+        if (!dto.verificationEndTime().isAfter(dto.verificationStartTime())) {
+            throw new CustomException(ErrorCode.INVALID_VERIFICATION_TIME);
+        }
+
+        if (Duration.between(dto.verificationStartTime(), dto.verificationEndTime()).toMinutes() < 10) {
+            throw new CustomException(ErrorCode.VERIFICATION_DURATION_TOO_SHORT);
+        }
+
+        boolean exists = categoryRepository.findByName(dto.category()).isPresent();
+        if (!exists) {
+            throw new CustomException(ErrorCode.CHALLENGE_CATEGORY_NOT_FOUND);
+        }
+    }
+
+    public void validate(GroupChallengeUpdateRequestDto dto) {
         if (!dto.endDate().isAfter(dto.startDate())) {
             throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
         }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/GroupChallenge.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/GroupChallenge.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
@@ -84,5 +85,29 @@ public class GroupChallenge extends BaseEntity {
         if (image.getGroupChallenge() == null) {
             image.setGroupChallenge(this);
         }
+    }
+
+    public void updateInfo(
+            String title,
+            String description,
+            String imageUrl,
+            int maxParticipantCount,
+            LocalDate startDate,
+            LocalDate endDate,
+            LocalTime verificationStart,
+            LocalTime verificationEnd
+    ) {
+        this.title = title;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.maxParticipantCount = maxParticipantCount;
+        this.startDate = startDate.atStartOfDay();
+        this.endDate = endDate.atTime(23, 59, 59);
+        this.verificationStartTime = verificationStart;
+        this.verificationEndTime = verificationEnd;
+    }
+
+    public void changeCategory(GroupChallengeCategory newCategory) {
+        this.category = newCategory;
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/GroupChallengeExampleImage.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/GroupChallengeExampleImage.java
@@ -3,6 +3,7 @@ package ktb.leafresh.backend.domain.challenge.group.domain.entity;
 import jakarta.persistence.*;
 import ktb.leafresh.backend.global.common.entity.BaseEntity;
 import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
+import ktb.leafresh.backend.global.util.image.ImageEntity;
 import lombok.*;
 
 @Entity
@@ -13,7 +14,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class GroupChallengeExampleImage extends BaseEntity {
+public class GroupChallengeExampleImage extends BaseEntity implements ImageEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,5 +55,28 @@ public class GroupChallengeExampleImage extends BaseEntity {
         image.setGroupChallenge(challenge);  // 연관관계만 설정
 
         return image;
+    }
+
+    @Override
+    public void updateSequenceNumber(int sequenceNumber) {
+        this.sequenceNumber = sequenceNumber;
+    }
+
+    @Override
+    public Long getId() {
+        return this.id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GroupChallengeExampleImage)) return false;
+        GroupChallengeExampleImage other = (GroupChallengeExampleImage) o;
+        return id != null && id.equals(other.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hashCode(id);
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeExampleImageRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeExampleImageRepository.java
@@ -1,0 +1,7 @@
+package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeExampleImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupChallengeExampleImageRepository extends JpaRepository<GroupChallengeExampleImage, Long> {
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
@@ -3,7 +3,9 @@ package ktb.leafresh.backend.domain.challenge.group.presentation.controller;
 import jakarta.validation.Valid;
 import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeCreateService;
 import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeReadService;
+import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeUpdateService;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeCreateResponseDto;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeDetailResponseDto;
 import ktb.leafresh.backend.global.response.ApiResponse;
@@ -21,6 +23,7 @@ public class GroupChallengeController {
 
     private final GroupChallengeCreateService groupChallengeCreateService;
     private final GroupChallengeReadService groupChallengeReadService;
+    private final GroupChallengeUpdateService groupChallengeUpdateService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<GroupChallengeCreateResponseDto>> createGroupChallenge(
@@ -41,5 +44,15 @@ public class GroupChallengeController {
         Long memberId = (userDetails != null) ? userDetails.getMemberId() : null;
         GroupChallengeDetailResponseDto response = groupChallengeReadService.getChallengeDetail(memberId, challengeId);
         return ResponseEntity.ok(ApiResponse.success("단체 챌린지 상세 정보를 성공적으로 조회했습니다.", response));
+    }
+
+    @PatchMapping("/{challengeId}")
+    public ResponseEntity<ApiResponse<Void>> updateGroupChallenge(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long challengeId,
+            @Valid @RequestBody GroupChallengeUpdateRequestDto request
+    ) {
+        groupChallengeUpdateService.update(userDetails.getMemberId(), challengeId, request);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/request/GroupChallengeUpdateRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/request/GroupChallengeUpdateRequestDto.java
@@ -1,0 +1,75 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Schema(description = "단체 챌린지 수정 요청")
+public record GroupChallengeUpdateRequestDto(
+        @NotBlank
+        @Schema(description = "제목") String title,
+
+        @NotBlank
+        @Schema(description = "설명") String description,
+
+        @NotBlank
+        @Schema(description = "카테고리 (ex. ZERO_WASTE)") String category,
+
+        @Positive
+        @Schema(description = "최대 인원 수") int maxParticipantCount,
+
+        @NotBlank
+        @Schema(description = "썸네일 이미지 URL") String thumbnailImageUrl,
+
+        @NotNull
+        @Schema(description = "시작일") LocalDate startDate,
+
+        @NotNull
+        @Schema(description = "종료일") LocalDate endDate,
+
+        @NotNull
+        @Schema(description = "인증 시작 시간") LocalTime verificationStartTime,
+
+        @NotNull
+        @Schema(description = "인증 종료 시간") LocalTime verificationEndTime,
+
+        @NotNull
+        @Valid
+        @Schema(description = "인증 예시 이미지 목록") ExampleImages exampleImages
+) {
+    public record ExampleImages(
+            @Size(max = 5)
+            @Schema(description = "기존 유지할 이미지 ID와 순서 목록") List<KeepImage> keep,
+
+            @Schema(description = "신규 추가할 이미지 목록") List<NewImage> newImages,
+
+            @Schema(description = "삭제할 이미지 ID 목록") List<Long> deleted
+    ) {
+        public record KeepImage(
+                @NotNull
+                @Schema(description = "유지할 이미지 ID") Long id,
+
+                @Min(1)
+                @Schema(description = "이미지 순서") int sequenceNumber
+        ) {}
+
+        public record NewImage(
+                @NotBlank
+                @Schema(description = "이미지 URL") String imageUrl,
+
+                @NotNull
+                @Schema(description = "이미지 타입") ExampleImageType type,
+
+                @NotBlank
+                @Schema(description = "이미지 설명") String description,
+
+                @Min(1)
+                @Schema(description = "이미지 순서") int sequenceNumber
+        ) {}
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/util/image/ImageEntity.java
+++ b/src/main/java/ktb/leafresh/backend/global/util/image/ImageEntity.java
@@ -1,0 +1,9 @@
+package ktb.leafresh.backend.global.util.image;
+
+/**
+ * 이미지 순서 변경 처리를 위한 공통 인터페이스
+ */
+public interface ImageEntity {
+    void updateSequenceNumber(int sequenceNumber);
+    Long getId();
+}

--- a/src/main/java/ktb/leafresh/backend/global/util/image/ImageEntityUpdater.java
+++ b/src/main/java/ktb/leafresh/backend/global/util/image/ImageEntityUpdater.java
@@ -1,0 +1,57 @@
+package ktb.leafresh.backend.global.util.image;
+
+import jakarta.transaction.Transactional;
+import ktb.leafresh.backend.global.common.entity.BaseEntity;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 이미지 관련 soft delete / 순서 변경 / 추가 로직을 공통 처리
+ */
+@Component
+@RequiredArgsConstructor
+public class ImageEntityUpdater {
+
+    @Transactional
+    public <E extends BaseEntity & ImageEntity, O> void update(
+            O owner,
+            List<KeepImage> keepList,
+            List<E> newEntities,
+            List<Long> deletedIds,
+            JpaRepository<E, Long> repository
+    ) {
+        handleDeletes(deletedIds, repository);
+        handleUpdates(keepList, repository);
+        handleInserts(newEntities, repository);
+    }
+
+    private <E extends BaseEntity & ImageEntity> void handleDeletes(List<Long> deletedIds, JpaRepository<E, Long> repository) {
+        if (deletedIds != null) {
+            deletedIds.forEach(id -> repository.findById(id)
+                    .ifPresent(BaseEntity::softDelete));
+        }
+    }
+
+    private <E extends BaseEntity & ImageEntity> void handleUpdates(List<KeepImage> keepList, JpaRepository<E, Long> repository) {
+        if (keepList != null) {
+            for (KeepImage keep : keepList) {
+                E entity = repository.findById(keep.id())
+                        .orElseThrow(() -> new CustomException(ErrorCode.ACCESS_DENIED));
+                entity.updateSequenceNumber(keep.sequenceNumber());
+            }
+        }
+    }
+
+    private <E extends BaseEntity & ImageEntity> void handleInserts(List<E> newEntities, JpaRepository<E, Long> repository) {
+        if (newEntities != null && !newEntities.isEmpty()) {
+            repository.saveAll(newEntities);
+        }
+    }
+
+    public record KeepImage(Long id, int sequenceNumber) {}
+}


### PR DESCRIPTION
## 작업 내용

- GroupChallenge 수정 기능의 비즈니스 책임 분리
  - GroupChallengeUpdateService → SRP에 맞춰 Updater 구성 요소로 책임 분할
  - GroupChallengeUpdater: 작성자 검증 + 필드 업데이트
  - GroupChallengeCategoryUpdater: 카테고리 검증 및 변경
  - GroupChallengeExampleImageUpdater: 예시 이미지 유지/삭제/추가 처리
- ImageEntityUpdater 공통 유틸 적용
  - soft delete, sequenceNumber 수정, saveAll 분기 처리
- GroupChallengeUpdateRequestDto에 Swagger 주석 및 유효성 검증 어노테이션 추가
- GroupChallengeExampleImage에 equals/hashCode 오버라이딩 및 getId(), updateSequenceNumber 구현 (ImageEntity 인터페이스 준수)

---

## 주요 고려 사항

- 유지 이미지: `List<KeepImage(id, sequenceNumber)>` 처리
- 삭제 이미지: ID 리스트 기반 soft delete 처리
- 추가 이미지: 새 엔티티 생성 후 cascade or repository 저장