### PR TITLE
feat: 단체 챌린지 삭제 API 구현 및 예시 이미지 동시 soft delete 처리

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeDeleteService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeDeleteService.java
@@ -1,0 +1,60 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeParticipantRecordRepository;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroupChallengeDeleteService {
+
+    private final GroupChallengeRepository groupChallengeRepository;
+    private final GroupChallengeParticipantRecordRepository participantRecordRepository;
+
+    @Transactional
+    public Long delete(Long memberId, Long challengeId) {
+        log.info("단체 챌린지 삭제 요청 시작 - memberId: {}, challengeId: {}", memberId, challengeId);
+
+        GroupChallenge challenge = groupChallengeRepository.findById(challengeId)
+                .orElseThrow(() -> {
+                    log.warn("단체 챌린지 삭제 실패 - 존재하지 않음: challengeId: {}", challengeId);
+                    return new CustomException(ErrorCode.GROUP_CHALLENGE_NOT_FOUND);
+                });
+
+        if (challenge.getDeletedAt() != null) {
+            log.warn("단체 챌린지 삭제 실패 - 이미 삭제됨: challengeId: {}", challengeId);
+            throw new CustomException(ErrorCode.INVALID_REQUEST, "이미 삭제된 단체 챌린지입니다.");
+        }
+
+        if (!challenge.getMember().getId().equals(memberId)) {
+            log.warn("단체 챌린지 삭제 실패 - 삭제 권한 없음: 요청자 ID={}, 작성자 ID={}", memberId, challenge.getMember().getId());
+            throw new CustomException(ErrorCode.ACCESS_DENIED, "챌린지 삭제 권한이 없습니다.");
+        }
+
+        boolean hasParticipants = participantRecordRepository.existsByGroupChallengeIdAndDeletedAtIsNull(challengeId);
+        if (hasParticipants) {
+            log.warn("단체 챌린지 삭제 실패 - 참여자 존재: challengeId: {}", challengeId);
+            throw new CustomException(ErrorCode.INVALID_REQUEST, "해당 챌린지에 참여자가 있어 삭제할 수 없습니다.");
+        }
+
+        // soft delete: 챌린지
+        challenge.softDelete();
+        log.info("단체 챌린지 soft delete 완료 - challengeId: {}", challengeId);
+
+        // soft delete: 예시 이미지
+        challenge.getExampleImages().forEach(image -> {
+            image.softDelete();
+            log.debug("예시 이미지 soft delete - imageId: {}, imageUrl: {}", image.getId(), image.getImageUrl());
+        });
+
+        log.info("단체 챌린지 삭제 전체 완료 - challengeId: {}", challengeId);
+        return challengeId;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeParticipantRecordRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeParticipantRecordRepository.java
@@ -1,0 +1,8 @@
+package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupChallengeParticipantRecordRepository extends JpaRepository<GroupChallengeParticipantRecord, Long> {
+    boolean existsByGroupChallengeIdAndDeletedAtIsNull(Long groupChallengeId);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
@@ -2,6 +2,7 @@ package ktb.leafresh.backend.domain.challenge.group.presentation.controller;
 
 import jakarta.validation.Valid;
 import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeCreateService;
+import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeDeleteService;
 import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeReadService;
 import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeUpdateService;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto;
@@ -16,6 +17,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/challenges/group")
@@ -24,6 +27,7 @@ public class GroupChallengeController {
     private final GroupChallengeCreateService groupChallengeCreateService;
     private final GroupChallengeReadService groupChallengeReadService;
     private final GroupChallengeUpdateService groupChallengeUpdateService;
+    private final GroupChallengeDeleteService groupChallengeDeleteService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<GroupChallengeCreateResponseDto>> createGroupChallenge(
@@ -54,5 +58,16 @@ public class GroupChallengeController {
     ) {
         groupChallengeUpdateService.update(userDetails.getMemberId(), challengeId, request);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @DeleteMapping("/{challengeId}")
+    public ResponseEntity<ApiResponse<Map<String, Long>>> deleteGroupChallenge(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long challengeId
+    ) {
+        Long memberId = userDetails.getMemberId();
+        Long deletedId = groupChallengeDeleteService.delete(memberId, challengeId);
+        return ResponseEntity.ok(ApiResponse.success("단체 챌린지가 성공적으로 삭제되었습니다.",
+                Map.of("deletedChallengeId", deletedId)));
     }
 }

--- a/src/main/java/ktb/leafresh/backend/global/exception/ErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/ErrorCode.java
@@ -32,7 +32,9 @@ public enum ErrorCode {
     VERIFICATION_DURATION_TOO_SHORT(HttpStatus.BAD_REQUEST, "인증 가능 시간은 최소 10분 이상이어야 합니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작일은 종료일보다 이전이어야 합니다."),
     INVALID_VERIFICATION_TIME(HttpStatus.BAD_REQUEST, "인증 시작 시간은 종료 시간보다 이전이어야 합니다."),
-    CHALLENGE_CREATION_REJECTED_BY_AI(HttpStatus.UNPROCESSABLE_ENTITY, "AI 판단 결과 챌린지 생성이 거부되었습니다.");
+    CHALLENGE_CREATION_REJECTED_BY_AI(HttpStatus.UNPROCESSABLE_ENTITY, "AI 판단 결과 챌린지 생성이 거부되었습니다."),
+    CHALLENGE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 단체 챌린지입니다."),
+    CHALLENGE_HAS_PARTICIPANTS(HttpStatus.BAD_REQUEST, "해당 챌린지에 참여자가 있어 삭제할 수 없습니다.");
 
 
     private final HttpStatus status;


### PR DESCRIPTION
## 작업 내용

- 단체 챌린지 삭제 API (`DELETE /api/challenges/group/{challengeId}`) 구현
  - 작성자 본인만 삭제 가능
  - 참여자가 존재하는 경우 삭제 제한
  - 이미 삭제된 챌린지 재삭제 방지

- `GroupChallengeDeleteService`에 삭제 비즈니스 로직 구현
  - 삭제 전 유효성 검증: 존재 여부, 작성자 일치, 참여자 유무
  - soft delete 적용 (`deletedAt` 설정)
  - 예시 이미지 (`exampleImages`)도 함께 soft delete 처리

- `GroupChallengeParticipantRecordRepository`에 참여자 존재 여부 확인 메서드 추가
  - `existsByGroupChallengeIdAndDeletedAtIsNull(challengeId)` 사용

- 삭제 성공 시 `deletedChallengeId`를 포함하는 JSON 응답 반환

## 주요 고려 사항

- 실제 삭제가 아닌 soft delete 방식으로 처리되며, `deletedAt IS NULL` 조건으로 필터링된 쿼리를 사용하는 구조 전제
- 연관된 예시 이미지 soft delete 시점은 챌린지 soft delete 이후지만, 물리 삭제가 아니므로 무결성에 영향 없음
- 슬라이싱된 로그(`Slf4j`)로 삭제 흐름 디버깅 가능
