### PR TITLE
feat: 이벤트 챌린지 목록 조회 API 구현Feature/29 all event challenge

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/EventChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/EventChallengeReadService.java
@@ -1,0 +1,29 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.EventChallengeResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventChallengeReadService {
+
+    private final GroupChallengeRepository groupChallengeRepository;
+
+    public List<EventChallengeResponseDto> getEventChallenges() {
+        LocalDateTime now = LocalDateTime.now();
+        List<GroupChallenge> challenges = groupChallengeRepository.findOngoingEventChallenges(now);
+        return challenges.stream()
+                .map(EventChallengeResponseDto::from)
+                .collect(toList());
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeRepository.java
@@ -15,4 +15,10 @@ public interface GroupChallengeRepository extends JpaRepository<GroupChallenge, 
             "WHERE gc.endDate >= :today " +
             "AND gc.deletedAt IS NULL")
     List<GroupChallenge> findAllValidAndOngoing(@Param("today") LocalDateTime today);
+
+    @Query("SELECT gc FROM GroupChallenge gc " +
+            "WHERE gc.eventFlag = true " +
+            "AND gc.deletedAt IS NULL " +
+            "AND gc.endDate >= :now")
+    List<GroupChallenge> findOngoingEventChallenges(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/EventChallengeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/EventChallengeController.java
@@ -1,0 +1,30 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.controller;
+
+import ktb.leafresh.backend.domain.challenge.group.application.service.EventChallengeReadService;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.EventChallengeResponseDto;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/challenges/events")
+public class EventChallengeController {
+
+    private final EventChallengeReadService eventChallengeReadService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<HashMap<String, List<EventChallengeResponseDto>>>> getEventChallenges() {
+        List<EventChallengeResponseDto> challenges = eventChallengeReadService.getEventChallenges();
+        return ResponseEntity.ok(ApiResponse.success(
+                "이벤트 챌린지 목록 조회에 성공하였습니다.",
+                new HashMap<>() {{
+                    put("eventChallenges", challenges);
+                }}
+        ));
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/EventChallengeResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/EventChallengeResponseDto.java
@@ -1,0 +1,19 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+
+public record EventChallengeResponseDto(
+        Long id,
+        String title,
+        String description,
+        String imageUrl
+) {
+    public static EventChallengeResponseDto from(GroupChallenge challenge) {
+        return new EventChallengeResponseDto(
+                challenge.getId(),
+                challenge.getTitle(),
+                challenge.getDescription(),
+                challenge.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -68,8 +68,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/members/nickname").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/members/signup").permitAll()
 
-                        // 단체 챌린지 상세 조회만 비회원 허용
                         .requestMatchers(HttpMethod.GET, "/api/challenges/group/{challengeId:\\d+}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/challenges/events").permitAll()
+
                         // 그 외 단체 챌린지 API는 인증 필요
                         .requestMatchers("/api/challenges/group/**").authenticated()
 


### PR DESCRIPTION
### 주요 변경 사항
- `/api/challenges/events` GET API 생성
- 진행 중이며 삭제되지 않았고 종료되지 않은(event_flag = true) 챌린지만 조회
- `EventChallengeController`, `EventChallengeReadService`, `EventChallengeResponseDto` 새로 생성
- `GroupChallengeRepository`에 전용 조회 메서드(findOngoingEventChallenges) 추가
- SecurityConfig에 해당 URI를 허용 경로로 등록