### PR TITLE
feat: 단체 챌린지 카테고리 목록 조회 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCategoryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCategoryService.java
@@ -1,0 +1,42 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeCategoryResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GroupChallengeCategoryService {
+
+    private final GroupChallengeCategoryRepository categoryRepository;
+
+    public List<GroupChallengeCategoryResponseDto> getCategories() {
+        return categoryRepository.findAllByActivatedIsTrueOrderBySequenceNumberAsc()
+                .stream()
+                .map(category -> GroupChallengeCategoryResponseDto.builder()
+                        .category(category.getName())
+                        .label(getLabelFromCategoryName(category.getName()))
+                        .imageUrl(category.getImageUrl())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private String getLabelFromCategoryName(String name) {
+        return switch (name) {
+            case "ZERO_WASTE" -> "제로웨이스트";
+            case "PLOGGING" -> "플로깅";
+            case "CARBON_FOOTPRINT" -> "탄소 발자국";
+            case "ENERGY_SAVING" -> "에너지 절약";
+            case "UPCYCLING" -> "중고거래/업사이클";
+            case "MEDIA" -> "서적, 영화";
+            case "DIGITAL_CARBON" -> "디지털 탄소";
+            case "VEGAN" -> "비건";
+            case "ETC" -> "기타";
+            default -> name;
+        };
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeCategoryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeCategoryRepository.java
@@ -4,7 +4,11 @@ import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeC
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.List;
 
 public interface GroupChallengeCategoryRepository extends JpaRepository<GroupChallengeCategory, Long> {
+
     Optional<GroupChallengeCategory> findByName(String name);
+
+    List<GroupChallengeCategory> findAllByActivatedIsTrueOrderBySequenceNumberAsc();
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeCategoryController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeCategoryController.java
@@ -1,0 +1,30 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.controller;
+
+import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeCategoryService;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeCategoryResponseDto;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/challenges/group/categories")
+public class GroupChallengeCategoryController {
+
+    private final GroupChallengeCategoryService groupChallengeCategoryService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Map<String, List<GroupChallengeCategoryResponseDto>>>> getGroupChallengeCategories() {
+        List<GroupChallengeCategoryResponseDto> categories = groupChallengeCategoryService.getCategories();
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "단체 챌린지 카테고리 목록 조회에 성공하였습니다.",
+                        Map.of("categories", categories)
+                )
+        );
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeCategoryResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeCategoryResponseDto.java
@@ -1,0 +1,14 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GroupChallengeCategoryResponseDto {
+    private String category;
+    private String label;
+    private String imageUrl;
+}

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -68,6 +68,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/members/nickname").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/members/signup").permitAll()
 
+                        .requestMatchers(HttpMethod.GET, "/api/challenges/group/categories").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/challenges/group/{challengeId:\\d+}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/challenges/events").permitAll()
 


### PR DESCRIPTION
### 개요
단체 챌린지 생성 시 사용할 수 있는 카테고리 목록 조회 API 추가

### 주요 변경 사항
- `GroupChallengeCategoryController`, `GroupChallengeCategoryService`, `GroupChallengeCategoryResponseDto` 생성
- `GroupChallengeCategoryRepository`에 활성화된 카테고리를 순서대로 조회하는 메서드 (`findAllByActivatedIsTrueOrderBySequenceNumberAsc`) 추가
- 인증 없이 카테고리 목록을 조회할 수 있도록 `SecurityConfig`에 예외 URI 설정 추가