### PR TITLE
feat: 카테고리 기반 단체 챌린지 목록 조회 API 및 커서 페이지네이션 기능 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepository.java
@@ -1,0 +1,9 @@
+package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+
+import java.util.List;
+
+public interface GroupChallengeQueryRepository {
+    List<GroupChallenge> findByCategoryWithSearch(Long categoryId, String input, Long cursorId, int size);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepositoryImpl.java
@@ -1,0 +1,44 @@
+package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.QGroupChallenge;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class GroupChallengeQueryRepositoryImpl implements GroupChallengeQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QGroupChallenge gc = QGroupChallenge.groupChallenge;
+
+    @Override
+    public List<GroupChallenge> findByCategoryWithSearch(Long categoryId, String input, Long cursorId, int size) {
+        return queryFactory.selectFrom(gc)
+                .where(
+                        gc.category.id.eq(categoryId),
+                        gc.deletedAt.isNull(),
+                        gc.endDate.goe(LocalDateTime.now()),
+                        likeInput(input),
+                        ltCursorId(cursorId)
+                )
+                .orderBy(gc.id.desc())
+                .limit(size)
+                .fetch();
+    }
+
+    private BooleanExpression likeInput(String input) {
+        if (input == null || input.trim().isEmpty()) return null;
+        return gc.title.containsIgnoreCase(input)
+                .or(gc.description.containsIgnoreCase(input));
+    }
+
+    private BooleanExpression ltCursorId(Long cursorId) {
+        return cursorId != null ? gc.id.lt(cursorId) : null;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
@@ -9,6 +9,7 @@ import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.Grou
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeCreateResponseDto;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeDetailResponseDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeListResponseDto;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,19 @@ public class GroupChallengeController {
     private final GroupChallengeReadService groupChallengeReadService;
     private final GroupChallengeUpdateService groupChallengeUpdateService;
     private final GroupChallengeDeleteService groupChallengeDeleteService;
+
+    @GetMapping("/categories/{categoryId}")
+    public ResponseEntity<ApiResponse<GroupChallengeListResponseDto>> getGroupChallengesByCategory(
+            @PathVariable Long categoryId,
+            @RequestParam(required = false) String input,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "12") int size
+    ) {
+        GroupChallengeListResponseDto response = groupChallengeReadService
+                .getGroupChallengesByCategory(categoryId, input, cursorId, size);
+
+        return ResponseEntity.ok(ApiResponse.success("단체 챌린지 목록 조회에 성공하였습니다.", response));
+    }
 
     @PostMapping
     public ResponseEntity<ApiResponse<GroupChallengeCreateResponseDto>> createGroupChallenge(

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeListResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeListResponseDto.java
@@ -1,0 +1,12 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GroupChallengeListResponseDto(
+        List<GroupChallengeSummaryDto> groupChallenges,
+        boolean hasNext,
+        Long lastCursorId
+) {}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeSummaryDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeSummaryDto.java
@@ -1,0 +1,33 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GroupChallengeSummaryDto(
+        Long id,
+        String title,
+        String imageUrl,
+        int leafReward,
+        String startDate,
+        String endDate,
+        int currentParticipantCount
+) {
+    public static GroupChallengeSummaryDto from(GroupChallenge entity) {
+        return GroupChallengeSummaryDto.builder()
+                .id(entity.getId())
+                .title(entity.getTitle())
+                .imageUrl(entity.getImageUrl())
+                .leafReward(entity.getLeafReward())
+                .startDate(entity.getStartDate().toLocalDate().toString())
+                .endDate(entity.getEndDate().toLocalDate().toString())
+                .currentParticipantCount(entity.getCurrentParticipantCount())
+                .build();
+    }
+
+    public static List<GroupChallengeSummaryDto> fromEntities(List<GroupChallenge> entities) {
+        return entities.stream().map(GroupChallengeSummaryDto::from).toList();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/config/QuerydslConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package ktb.leafresh.backend.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/members/signup").permitAll()
 
                         .requestMatchers(HttpMethod.GET, "/api/challenges/group/categories").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/challenges/group/categories/{categoryId}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/challenges/group/{challengeId:\\d+}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/challenges/events").permitAll()
 

--- a/src/main/java/ktb/leafresh/backend/global/util/pagination/CursorPaginationHelper.java
+++ b/src/main/java/ktb/leafresh/backend/global/util/pagination/CursorPaginationHelper.java
@@ -1,0 +1,31 @@
+package ktb.leafresh.backend.global.util.pagination;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class CursorPaginationHelper {
+
+    public static <T, D> CursorPaginationResult<D> paginate(
+            List<T> entities,
+            int size,
+            Function<T, D> mapper,
+            Function<D, Long> idExtractor
+    ) {
+        boolean hasNext = entities.size() > size;
+        if (hasNext) {
+            entities = entities.subList(0, size);
+        }
+
+        List<D> dtos = entities.stream()
+                .map(mapper)
+                .toList();
+
+        Long lastCursorId = dtos.isEmpty() ? null : idExtractor.apply(dtos.get(dtos.size() - 1));
+
+        return CursorPaginationResult.<D>builder()
+                .items(dtos)
+                .hasNext(hasNext)
+                .lastCursorId(lastCursorId)
+                .build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/util/pagination/CursorPaginationResult.java
+++ b/src/main/java/ktb/leafresh/backend/global/util/pagination/CursorPaginationResult.java
@@ -1,0 +1,13 @@
+package ktb.leafresh.backend.global.util.pagination;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CursorPaginationResult<T>(
+        List<T> items,
+        boolean hasNext,
+        Long lastCursorId
+) {
+}


### PR DESCRIPTION
## 요약

- 단체 챌린지를 카테고리별로 조회하는 API를 구현하고,
- 커서 기반 페이지네이션 기능을 유틸리티로 추출해 적용했습니다.

## 주요 변경사항

### 기능 구현
- `/api/challenges/group/categories/{categoryId}` GET API 추가
- 커서 기반 페이지네이션 유틸리티(`CursorPaginationHelper`) 도입
- 마지막 커서를 추출하기 위한 id 추출 함수 적용

### 접근 허용 처리
- `SecurityConfig`에 해당 경로를 비회원도 접근할 수 있도록 설정

### 구조 개선
- QueryDSL 기반 Repository (`GroupChallengeQueryRepository`) 생성
- 응답 DTO (`GroupChallengeSummaryDto`, `GroupChallengeListResponseDto`) 정의

## 테스트
- Postman으로 목록 조회 확인 완료
- 커서 기반 조회 및 hasNext 정상 동작 확인