### PR TITLE
feat: 단체 챌린지 인증 내역 목록 조회 기능 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
@@ -2,13 +2,11 @@ package ktb.leafresh.backend.domain.challenge.group.application.service;
 
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeQueryRepository;
-import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeListResponseDto;
-import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeSummaryDto;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeVerificationQueryRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.*;
 import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
 import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
-import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeDetailResponseDto;
-import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeExampleImageDto;
 import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.ErrorCode;
@@ -30,6 +28,7 @@ public class GroupChallengeReadService {
     private final GroupChallengeQueryRepository groupChallengeQueryRepository;
     private final GroupChallengeRepository groupChallengeRepository;
     private final GroupChallengeVerificationRepository verificationRepository;
+    private final GroupChallengeVerificationQueryRepository groupChallengeVerificationQueryRepository;
 
     public GroupChallengeListResponseDto getGroupChallengesByCategory(
             Long categoryId, String input, Long cursorId, int size
@@ -87,5 +86,22 @@ public class GroupChallengeReadService {
                 .findTopByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_IdOrderByCreatedAtDesc(memberIdOrNull, challengeId)
                 .map(GroupChallengeVerification::getStatus)
                 .orElse(ChallengeStatus.NOT_SUBMITTED);
+    }
+
+    public GroupChallengeVerificationListResponseDto getVerifications(
+            Long challengeId, Long cursorId, int size
+    ) {
+        CursorPaginationResult<GroupChallengeVerificationSummaryDto> page = CursorPaginationHelper.paginate(
+                groupChallengeVerificationQueryRepository.findByChallengeId(challengeId, cursorId, size + 1),
+                size,
+                GroupChallengeVerificationSummaryDto::from,
+                GroupChallengeVerificationSummaryDto::id
+        );
+
+        return GroupChallengeVerificationListResponseDto.builder()
+                .verifications(page.items())
+                .hasNext(page.hasNext())
+                .lastCursorId(page.lastCursorId())
+                .build();
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeVerificationQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeVerificationQueryRepository.java
@@ -1,0 +1,9 @@
+package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+
+import java.util.List;
+
+public interface GroupChallengeVerificationQueryRepository {
+    List<GroupChallengeVerification> findByChallengeId(Long challengeId, Long cursorId, int size);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeVerificationQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeVerificationQueryRepositoryImpl.java
@@ -1,0 +1,35 @@
+package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.domain.entity.QGroupChallengeVerification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class GroupChallengeVerificationQueryRepositoryImpl implements GroupChallengeVerificationQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QGroupChallengeVerification gv = QGroupChallengeVerification.groupChallengeVerification;
+
+    @Override
+    public List<GroupChallengeVerification> findByChallengeId(Long challengeId, Long cursorId, int size) {
+        return queryFactory.selectFrom(gv)
+                .where(
+                        gv.participantRecord.groupChallenge.id.eq(challengeId),
+                        gv.deletedAt.isNull(),
+                        ltCursorId(cursorId)
+                )
+                .orderBy(gv.id.desc())
+                .limit(size)
+                .fetch();
+    }
+
+    private BooleanExpression ltCursorId(Long cursorId) {
+        return cursorId != null ? gv.id.lt(cursorId) : null;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
@@ -10,6 +10,7 @@ import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.Grou
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeCreateResponseDto;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeDetailResponseDto;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeListResponseDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeVerificationListResponseDto;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -83,5 +84,17 @@ public class GroupChallengeController {
         Long deletedId = groupChallengeDeleteService.delete(memberId, challengeId);
         return ResponseEntity.ok(ApiResponse.success("단체 챌린지가 성공적으로 삭제되었습니다.",
                 Map.of("deletedChallengeId", deletedId)));
+    }
+
+    @GetMapping("/{challengeId}/verifications")
+    public ResponseEntity<ApiResponse<GroupChallengeVerificationListResponseDto>> getVerifications(
+            @PathVariable Long challengeId,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "12") int size
+    ) {
+        GroupChallengeVerificationListResponseDto response = groupChallengeReadService
+                .getVerifications(challengeId, cursorId, size);
+
+        return ResponseEntity.ok(ApiResponse.success("단체 챌린지 인증 내역 조회에 성공했습니다.", response));
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeVerificationListResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeVerificationListResponseDto.java
@@ -1,0 +1,12 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GroupChallengeVerificationListResponseDto(
+        List<GroupChallengeVerificationSummaryDto> verifications,
+        boolean hasNext,
+        Long lastCursorId
+) {}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeVerificationSummaryDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeVerificationSummaryDto.java
@@ -1,0 +1,24 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import lombok.Builder;
+
+@Builder
+public record GroupChallengeVerificationSummaryDto(
+        Long id,
+        String nickname,
+        String profileImageUrl,
+        String verificationImageUrl,
+        String description
+) {
+    public static GroupChallengeVerificationSummaryDto from(GroupChallengeVerification verification) {
+        var member = verification.getParticipantRecord().getMember();
+        return GroupChallengeVerificationSummaryDto.builder()
+                .id(verification.getId())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getImageUrl())
+                .verificationImageUrl(verification.getImageUrl())
+                .description(verification.getContent())
+                .build();
+    }
+}


### PR DESCRIPTION
## 요약
단체 챌린지 상세 페이지에서 인증 내역을 무한 스크롤로 조회할 수 있도록, 인증 목록 조회 기능을 추가했습니다.

## 작업 내용
- Controller에 GET /{challengeId}/verifications 메서드 추가
- ReadService에 인증 내역 페이징 처리 로직 추가
- 인증 응답용 DTO (Summary/Response) 생성
- 인증 목록 조회 전용 QueryRepository 및 구현체 추가