### PR TITLE
feat: 단체 챌린지 목록 조회 시 category를 query param으로 받도록 리팩토링

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCategoryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCategoryService.java
@@ -18,7 +18,6 @@ public class GroupChallengeCategoryService {
         return categoryRepository.findAllByActivatedIsTrueOrderBySequenceNumberAsc()
                 .stream()
                 .map(category -> GroupChallengeCategoryResponseDto.builder()
-                        .id(category.getId())
                         .category(category.getName())
                         .label(getLabelFromCategoryName(category.getName()))
                         .imageUrl(category.getImageUrl())

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
@@ -30,11 +30,13 @@ public class GroupChallengeReadService {
     private final GroupChallengeVerificationRepository verificationRepository;
     private final GroupChallengeVerificationQueryRepository groupChallengeVerificationQueryRepository;
 
-    public GroupChallengeListResponseDto getGroupChallengesByCategory(
-            Long categoryId, String input, Long cursorId, int size
-    ) {
+    public GroupChallengeListResponseDto getGroupChallenges(String input, String category, Long cursorId, int size) {
+        if (category == null || category.trim().isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
         CursorPaginationResult<GroupChallengeSummaryDto> page = CursorPaginationHelper.paginate(
-                groupChallengeQueryRepository.findByCategoryWithSearch(categoryId, input, cursorId, size + 1),
+                groupChallengeQueryRepository.findByFilter(input, category, cursorId, size + 1),
                 size,
                 GroupChallengeSummaryDto::from,
                 GroupChallengeSummaryDto::id

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepository.java
@@ -5,5 +5,5 @@ import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
 import java.util.List;
 
 public interface GroupChallengeQueryRepository {
-    List<GroupChallenge> findByCategoryWithSearch(Long categoryId, String input, Long cursorId, int size);
+    List<GroupChallenge> findByFilter(String input, String category, Long cursorId, int size);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepositoryImpl.java
@@ -18,13 +18,13 @@ public class GroupChallengeQueryRepositoryImpl implements GroupChallengeQueryRep
     private final QGroupChallenge gc = QGroupChallenge.groupChallenge;
 
     @Override
-    public List<GroupChallenge> findByCategoryWithSearch(Long categoryId, String input, Long cursorId, int size) {
+    public List<GroupChallenge> findByFilter(String input, String category, Long cursorId, int size) {
         return queryFactory.selectFrom(gc)
                 .where(
-                        gc.category.id.eq(categoryId),
                         gc.deletedAt.isNull(),
                         gc.endDate.goe(LocalDateTime.now()),
                         likeInput(input),
+                        eqCategory(category),
                         ltCursorId(cursorId)
                 )
                 .orderBy(gc.id.desc())
@@ -36,6 +36,10 @@ public class GroupChallengeQueryRepositoryImpl implements GroupChallengeQueryRep
         if (input == null || input.trim().isEmpty()) return null;
         return gc.title.containsIgnoreCase(input)
                 .or(gc.description.containsIgnoreCase(input));
+    }
+
+    private BooleanExpression eqCategory(String category) {
+        return category != null ? gc.category.name.eq(category) : null;
     }
 
     private BooleanExpression ltCursorId(Long cursorId) {

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
@@ -31,15 +31,15 @@ public class GroupChallengeController {
     private final GroupChallengeUpdateService groupChallengeUpdateService;
     private final GroupChallengeDeleteService groupChallengeDeleteService;
 
-    @GetMapping("/categories/{categoryId}")
-    public ResponseEntity<ApiResponse<GroupChallengeListResponseDto>> getGroupChallengesByCategory(
-            @PathVariable Long categoryId,
+    @GetMapping
+    public ResponseEntity<ApiResponse<GroupChallengeListResponseDto>> getGroupChallenges(
             @RequestParam(required = false) String input,
+            @RequestParam(required = false) String category,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "12") int size
     ) {
         GroupChallengeListResponseDto response = groupChallengeReadService
-                .getGroupChallengesByCategory(categoryId, input, cursorId, size);
+                .getGroupChallenges(input, category, cursorId, size);
 
         return ResponseEntity.ok(ApiResponse.success("단체 챌린지 목록 조회에 성공하였습니다.", response));
     }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeCategoryResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeCategoryResponseDto.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class GroupChallengeCategoryResponseDto {
-    private Long id;
     private String category;
     private String label;
     private String imageUrl;


### PR DESCRIPTION
## 요약
기존의 /api/challenges/group/categories/{categoryId} URI 방식 대신
쿼리 파라미터 방식으로 category 값을 받도록 변경했습니다.

## 주요 변경 사항
- URI 기반 categoryId 조회 → query param 기반 category name 조회 방식으로 통일
- GroupChallengeController, GroupChallengeReadService에 category null validation 로직 추가
- GroupChallengeQueryRepository 및 구현체에 메서드명 및 파라미터 변경 (findByFilter)
- 카테고리 응답 DTO에서 id 제거 → name, label, imageUrl만 포함