### PR TITLE
feat: 카테고리 기반 단체 챌린지 조회 기능 개발 및 관련 초기화 리팩토링

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
@@ -1,6 +1,7 @@
 package ktb.leafresh.backend.domain.challenge.group.application.service;
 
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.enums.GroupChallengeCategoryName;
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeQueryRepository;
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeVerificationQueryRepository;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.*;
@@ -35,8 +36,10 @@ public class GroupChallengeReadService {
             throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
 
+        String internalCategoryName = resolveCategoryNameOrThrow(category);
+
         CursorPaginationResult<GroupChallengeSummaryDto> page = CursorPaginationHelper.paginate(
-                groupChallengeQueryRepository.findByFilter(input, category, cursorId, size + 1),
+                groupChallengeQueryRepository.findByFilter(input, internalCategoryName, cursorId, size + 1),
                 size,
                 GroupChallengeSummaryDto::from,
                 GroupChallengeSummaryDto::id
@@ -47,6 +50,14 @@ public class GroupChallengeReadService {
                 .hasNext(page.hasNext())
                 .lastCursorId(page.lastCursorId())
                 .build();
+    }
+
+    private String resolveCategoryNameOrThrow(String label) {
+        String name = GroupChallengeCategoryName.toEnglish(label);
+        if (name == null) {
+            throw new CustomException(ErrorCode.CHALLENGE_CATEGORY_NOT_FOUND);
+        }
+        return name;
     }
 
     public GroupChallengeDetailResponseDto getChallengeDetail(Long memberIdOrNull, Long challengeId) {

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/enums/GroupChallengeCategoryName.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/enums/GroupChallengeCategoryName.java
@@ -1,0 +1,57 @@
+package ktb.leafresh.backend.domain.challenge.group.domain.entity.enums;
+
+import java.util.Arrays;
+
+public enum GroupChallengeCategoryName {
+
+    ZERO_WASTE("제로웨이스트"),
+    PLOGGING("플로깅"),
+    CARBON_FOOTPRINT("탄소 발자국"),
+    ENERGY_SAVING("에너지 절약"),
+    UPCYCLING("업사이클"),
+    MEDIA("문화 공유"),
+    DIGITAL_CARBON("디지털 탄소"),
+    VEGAN("비건"),
+    ETC("기타");
+
+    private final String label; // 한글 라벨
+
+    GroupChallengeCategoryName(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public static String toEnglish(String koreanInput) {
+        return Arrays.stream(values())
+                .filter(v -> v.label.equals(koreanInput))
+                .map(Enum::name)
+                .findFirst()
+                .orElse(null);
+    }
+
+    public static String getImageUrl(String name) {
+        return switch (name) {
+            case "ZERO_WASTE" -> "imageUrl1";
+            case "PLOGGING" -> "imageUrl2";
+            case "CARBON_FOOTPRINT" -> "imageUrl3";
+            case "ENERGY_SAVING" -> "imageUrl4";
+            case "UPCYCLING" -> "imageUrl5";
+            case "MEDIA" -> "imageUrl6";
+            case "DIGITAL_CARBON" -> "imageUrl7";
+            case "VEGAN" -> "imageUrl8";
+            case "ETC" -> "imageUrl9";
+            default -> "defaultImageUrl";
+        };
+    }
+
+    public static int getSequence(String name) {
+        return GroupChallengeCategoryName.valueOf(name).ordinal() + 1;
+    }
+
+    public static GroupChallengeCategoryName[] seeds() {
+        return values();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/members/signup").permitAll()
 
                         .requestMatchers(HttpMethod.GET, "/api/challenges/group/categories").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/challenges/group/categories/{categoryId}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/challenges/group").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/challenges/group/{challengeId:\\d+}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/challenges/events").permitAll()
 

--- a/src/main/java/ktb/leafresh/backend/global/init/GroupChallengeCategoryInitializer.java
+++ b/src/main/java/ktb/leafresh/backend/global/init/GroupChallengeCategoryInitializer.java
@@ -1,6 +1,7 @@
 package ktb.leafresh.backend.global.init;
 
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.enums.GroupChallengeCategoryName;
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
@@ -26,31 +27,18 @@ public class GroupChallengeCategoryInitializer implements CommandLineRunner {
     @Override
     @Transactional
     public void run(String... args) {
-        List<GroupChallengeCategorySeed> seeds = List.of(
-                new GroupChallengeCategorySeed("ZERO_WASTE", "제로웨이스트", "imageUrl1", 1),
-                new GroupChallengeCategorySeed("PLOGGING", "플로깅", "imageUrl2", 2),
-                new GroupChallengeCategorySeed("CARBON_FOOTPRINT", "탄소 발자국", "imageUrl3", 3),
-                new GroupChallengeCategorySeed("ENERGY_SAVING", "에너지 절약", "imageUrl4", 4),
-                new GroupChallengeCategorySeed("UPCYCLING", "중고거래/업사이클", "imageUrl5", 5),
-                new GroupChallengeCategorySeed("MEDIA", "서적, 영화", "imageUrl6", 6),
-                new GroupChallengeCategorySeed("DIGITAL_CARBON", "디지털 탄소", "imageUrl7", 7),
-                new GroupChallengeCategorySeed("VEGAN", "비건", "imageUrl8", 8),
-                new GroupChallengeCategorySeed("ETC", "기타", "imageUrl9", 9)
-        );
-
-        for (GroupChallengeCategorySeed seed : seeds) {
-            if (categoryRepository.findByName(seed.name()).isEmpty()) {
+        for (GroupChallengeCategoryName seed : GroupChallengeCategoryName.seeds()) {
+            String name = seed.name();
+            if (categoryRepository.findByName(name).isEmpty()) {
                 categoryRepository.save(
                         GroupChallengeCategory.builder()
-                                .name(seed.name())
-                                .imageUrl(seed.imageUrl())
-                                .sequenceNumber(seed.sequenceNumber())
+                                .name(name)
+                                .imageUrl(GroupChallengeCategoryName.getImageUrl(name))
+                                .sequenceNumber(GroupChallengeCategoryName.getSequence(name))
                                 .activated(true)
                                 .build()
                 );
             }
         }
     }
-
-    private record GroupChallengeCategorySeed(String name, String label, String imageUrl, int sequenceNumber) {}
 }


### PR DESCRIPTION
## 주요 변경 사항

1. `GroupChallengeCategoryName` ENUM 생성
   - 한글 라벨, 이미지 URL, 시퀀스 번호 등 메타데이터 포함
   - `toEnglish`, `getImageUrl`, `seeds()` 유틸 메서드 제공

2. `GroupChallengeCategoryInitializer` 리팩토링
   - 기존 하드코딩된 시드 데이터를 ENUM 기반으로 대체

3. `GroupChallengeReadService`
   - 한글 카테고리명을 ENUM name으로 변환하는 `resolveCategoryNameOrThrow` 메서드 추가
   - 카테고리 기반 조회에서 사용

4. `SecurityConfig`
   - `/api/challenges/group`  경로 permitAll로 명시