### PR TITLE
feat: 개인 챌린지 목록 조회 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeReadService.java
@@ -1,0 +1,30 @@
+package ktb.leafresh.backend.domain.challenge.personal.application.service;
+
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import ktb.leafresh.backend.domain.challenge.personal.infrastructure.repository.PersonalChallengeRepository;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeListResponseDto;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeSummaryDto;
+import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PersonalChallengeReadService {
+
+    private final PersonalChallengeRepository repository;
+
+    public PersonalChallengeListResponseDto getByDayOfWeek(DayOfWeek dayOfWeek) {
+        List<PersonalChallenge> challenges = repository.findAllByDayOfWeek(dayOfWeek);
+
+        if (challenges.isEmpty()) {
+            throw new CustomException(ErrorCode.NOT_FOUND, "현재 등록된 개인 챌린지가 없습니다.");
+        }
+
+        return new PersonalChallengeListResponseDto(PersonalChallengeSummaryDto.fromEntities(challenges));
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/infrastructure/repository/PersonalChallengeRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/infrastructure/repository/PersonalChallengeRepository.java
@@ -4,6 +4,10 @@ import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChal
 import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PersonalChallengeRepository extends JpaRepository<PersonalChallenge, Long> {
     int countByDayOfWeek(DayOfWeek dayOfWeek);
+
+    List<PersonalChallenge> findAllByDayOfWeek(DayOfWeek dayOfWeek);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/controller/PersonalChallengeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/controller/PersonalChallengeController.java
@@ -1,30 +1,25 @@
 package ktb.leafresh.backend.domain.challenge.personal.presentation.controller;
 
-import jakarta.validation.Valid;
-import ktb.leafresh.backend.domain.challenge.personal.application.service.PersonalChallengeCreateService;
-import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.request.PersonalChallengeCreateRequestDto;
-import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeCreateResponseDto;
+import ktb.leafresh.backend.domain.challenge.personal.application.service.PersonalChallengeReadService;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeListResponseDto;
+import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin/challenges/personal")
+@RequestMapping("/api/challenges/personal")
 public class PersonalChallengeController {
 
-    private final PersonalChallengeCreateService createService;
+    private final PersonalChallengeReadService readService;
 
-    @PostMapping
-    @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<ApiResponse<PersonalChallengeCreateResponseDto>> create(
-            @Valid @RequestBody PersonalChallengeCreateRequestDto request
+    @GetMapping
+    public ResponseEntity<ApiResponse<PersonalChallengeListResponseDto>> getPersonalChallengesByDay(
+            @RequestParam DayOfWeek dayOfWeek
     ) {
-        PersonalChallengeCreateResponseDto response = createService.create(request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.created("개인 챌린지 템플릿이 성공적으로 생성되었습니다.", response));
+        PersonalChallengeListResponseDto response = readService.getByDayOfWeek(dayOfWeek);
+        return ResponseEntity.ok(ApiResponse.success("개인챌린지 목록 조회에 성공하였습니다.", response));
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/dto/response/PersonalChallengeListResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/dto/response/PersonalChallengeListResponseDto.java
@@ -1,0 +1,10 @@
+package ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record PersonalChallengeListResponseDto(
+        List<PersonalChallengeSummaryDto> personalChallenges
+) {}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/dto/response/PersonalChallengeSummaryDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/dto/response/PersonalChallengeSummaryDto.java
@@ -1,0 +1,29 @@
+package ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record PersonalChallengeSummaryDto(
+        Long id,
+        String title,
+        String description,
+        String imageUrl,
+        int leafReward
+) {
+    public static PersonalChallengeSummaryDto from(PersonalChallenge challenge) {
+        return PersonalChallengeSummaryDto.builder()
+                .id(challenge.getId())
+                .title(challenge.getTitle())
+                .description(challenge.getDescription())
+                .imageUrl(challenge.getImageUrl())
+                .leafReward(challenge.getLeafReward())
+                .build();
+    }
+
+    public static List<PersonalChallengeSummaryDto> fromEntities(List<PersonalChallenge> challenges) {
+        return challenges.stream().map(PersonalChallengeSummaryDto::from).toList();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -68,6 +68,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/members/nickname").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/members/signup").permitAll()
 
+                        // 단체 챌린지
                         .requestMatchers(HttpMethod.GET, "/api/challenges/group/categories").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/challenges/group").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/challenges/group/{challengeId:\\d+}").permitAll()
@@ -75,6 +76,12 @@ public class SecurityConfig {
 
                         // 그 외 단체 챌린지 API는 인증 필요
                         .requestMatchers("/api/challenges/group/**").authenticated()
+
+                        // 개인 챌린지
+                        .requestMatchers(HttpMethod.GET, "/api/challenges/personal").permitAll()
+
+                        // 그 외 개인 챌린지 API는 인증 필요
+                        .requestMatchers("/api/challenges/personal/**").authenticated()
 
                         // Swagger/OpenAPI
                         .requestMatchers(


### PR DESCRIPTION
## 작업 내용
- 개인 챌린지 목록을 요일(DayOfWeek) 기준으로 조회하는 API를 구현했습니다.

## 상세 변경 사항
- `SecurityConfig.java`: `/api/challenges/personal` GET 요청 허용 URI로 추가
- `PersonalChallengeRepository.java`: `findAllByDayOfWeek()` 메서드 정의
- `PersonalChallengeReadService.java`: 개인 챌린지 목록 조회 서비스 로직 구현
- `PersonalChallengeController.java`: `/api/challenges/personal?dayOfWeek=...` API 구현
- `PersonalChallengeListResponseDto`, `PersonalChallengeSummaryDto`: 응답 DTO 생성

## 기타
- 빈 결과일 경우 `CustomException`을 통해 404 응답 반환