### PR TITLE
feat: 개인 챌린지 템플릿 생성 기능 개선 및 정적 팩토리 패턴 적용 방식 통일

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/factory/PersonalChallengeExampleImageAssembler.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/factory/PersonalChallengeExampleImageAssembler.java
@@ -1,0 +1,26 @@
+package ktb.leafresh.backend.domain.challenge.personal.application.factory;
+
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallengeExampleImage;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.request.PersonalChallengeCreateRequestDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PersonalChallengeExampleImageAssembler {
+
+    public void assemble(PersonalChallenge challenge, PersonalChallengeCreateRequestDto dto) {
+        dto.exampleImages().forEach(imageDto -> {
+            // 정적 팩토리 메서드로 생성 (연관관계는 내부에서 set만 함)
+            PersonalChallengeExampleImage image = PersonalChallengeExampleImage.of(
+                    challenge,
+                    imageDto.imageUrl(),
+                    imageDto.type(),
+                    imageDto.description(),
+                    imageDto.sequenceNumber()
+            );
+
+            // 양방향 연결을 명시적으로 처리
+            challenge.addExampleImage(image);
+        });
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/factory/PersonalChallengeFactory.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/factory/PersonalChallengeFactory.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalTime;
 
+
 @Component
 public class PersonalChallengeFactory {
 
@@ -14,10 +15,10 @@ public class PersonalChallengeFactory {
                 .title(dto.title())
                 .description(dto.description())
                 .dayOfWeek(dto.dayOfWeek())
-                .imageUrl(dto.imageUrl())
-                .leafReward(dto.leafReward())
-                .verificationStartTime(LocalTime.of(6, 0))
-                .verificationEndTime(LocalTime.of(23, 59))
+                .imageUrl(dto.thumbnailImageUrl())
+                .verificationStartTime(dto.verificationStartTime())
+                .verificationEndTime(dto.verificationEndTime())
+                .leafReward(30)
                 .build();
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeCreateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeCreateService.java
@@ -1,5 +1,6 @@
 package ktb.leafresh.backend.domain.challenge.personal.application.service;
 
+import ktb.leafresh.backend.domain.challenge.personal.application.factory.PersonalChallengeExampleImageAssembler;
 import ktb.leafresh.backend.domain.challenge.personal.application.factory.PersonalChallengeFactory;
 import ktb.leafresh.backend.domain.challenge.personal.application.validator.PersonalChallengeDomainValidator;
 import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
@@ -16,12 +17,16 @@ public class PersonalChallengeCreateService {
 
     private final PersonalChallengeDomainValidator validator;
     private final PersonalChallengeFactory factory;
+    private final PersonalChallengeExampleImageAssembler assembler;
     private final PersonalChallengeRepository repository;
 
     @Transactional
     public PersonalChallengeCreateResponseDto create(PersonalChallengeCreateRequestDto dto) {
         validator.validate(dto.dayOfWeek());
+
         PersonalChallenge challenge = factory.create(dto);
+        assembler.assemble(challenge, dto);
+
         repository.save(challenge);
         return new PersonalChallengeCreateResponseDto(challenge.getId());
     }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/validator/PersonalChallengeDomainValidator.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/validator/PersonalChallengeDomainValidator.java
@@ -1,9 +1,9 @@
 package ktb.leafresh.backend.domain.challenge.personal.application.validator;
 
 import ktb.leafresh.backend.domain.challenge.personal.infrastructure.repository.PersonalChallengeRepository;
-import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.ErrorCode;
+import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/domain/entity/PersonalChallenge.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/domain/entity/PersonalChallenge.java
@@ -5,6 +5,7 @@ import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeV
 import jakarta.persistence.*;
 import ktb.leafresh.backend.global.common.entity.BaseEntity;
 import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
 import lombok.*;
 
 import java.time.LocalTime;
@@ -23,9 +24,11 @@ public class PersonalChallenge extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Builder.Default
     @OneToMany(mappedBy = "personalChallenge", cascade = CascadeType.ALL)
     private List<PersonalChallengeExampleImage> exampleImages = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "personalChallenge", cascade = CascadeType.ALL)
     private List<PersonalChallengeVerification> verifications = new ArrayList<>();
 
@@ -50,4 +53,24 @@ public class PersonalChallenge extends BaseEntity {
 
     @Column(nullable = false)
     private LocalTime verificationEndTime;
+
+    public static PersonalChallengeExampleImage of(
+            PersonalChallenge challenge, String imageUrl, ExampleImageType type, String description, int sequenceNumber) {
+        PersonalChallengeExampleImage image = PersonalChallengeExampleImage.builder()
+                .imageUrl(imageUrl)
+                .type(type)
+                .description(description)
+                .sequenceNumber(sequenceNumber)
+                .build();
+
+        image.setPersonalChallenge(challenge);
+        return image;
+    }
+
+    public void addExampleImage(PersonalChallengeExampleImage image) {
+        this.exampleImages.add(image);
+        if (image.getPersonalChallenge() == null) {
+            image.setPersonalChallenge(this);
+        }
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/domain/entity/PersonalChallengeExampleImage.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/domain/entity/PersonalChallengeExampleImage.java
@@ -21,6 +21,7 @@ public class PersonalChallengeExampleImage extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "personal_challenge_id", nullable = false)
+    @Setter
     private PersonalChallenge personalChallenge;
 
     @Column(nullable = false, length = 512)
@@ -35,4 +36,22 @@ public class PersonalChallengeExampleImage extends BaseEntity {
 
     @Column(nullable = false)
     private Integer sequenceNumber;
+
+    public static PersonalChallengeExampleImage of(
+            PersonalChallenge challenge,
+            String imageUrl,
+            ExampleImageType type,
+            String description,
+            int sequenceNumber
+    ) {
+        PersonalChallengeExampleImage image = PersonalChallengeExampleImage.builder()
+                .imageUrl(imageUrl)
+                .type(type)
+                .description(description)
+                .sequenceNumber(sequenceNumber)
+                .build();
+
+        image.setPersonalChallenge(challenge);
+        return image;
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/controller/PersonalChallengeAdminController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/controller/PersonalChallengeAdminController.java
@@ -25,6 +25,6 @@ public class PersonalChallengeAdminController {
     ) {
         PersonalChallengeCreateResponseDto response = createService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.created("개인 챌린지 템플릿이 성공적으로 생성되었습니다.", response));
+                .body(ApiResponse.created("개인 챌린지가 성공적으로 생성되었습니다.", response));
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/dto/request/PersonalChallengeCreateRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/dto/request/PersonalChallengeCreateRequestDto.java
@@ -3,15 +3,20 @@ package ktb.leafresh.backend.domain.challenge.personal.presentation.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
 
-@Schema(description = "개인 챌린지 템플릿 생성 요청")
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Schema(description = "개인 챌린지 생성 요청 DTO")
 public record PersonalChallengeCreateRequestDto(
         @NotBlank
-        @Schema(description = "챌린지 제목")
+        @Schema(description = "제목")
         String title,
 
         @NotBlank
-        @Schema(description = "챌린지 설명")
+        @Schema(description = "설명")
         String description,
 
         @NotNull
@@ -20,9 +25,24 @@ public record PersonalChallengeCreateRequestDto(
 
         @NotBlank
         @Schema(description = "썸네일 이미지 URL")
-        String imageUrl,
+        String thumbnailImageUrl,
 
-        @PositiveOrZero
-        @Schema(description = "지급 리워드")
-        int leafReward
-) {}
+        @NotNull
+        @Schema(description = "인증 시작 시간")
+        LocalTime verificationStartTime,
+
+        @NotNull
+        @Schema(description = "인증 종료 시간")
+        LocalTime verificationEndTime,
+
+        @Size(max = 5)
+        @Schema(description = "인증 예시 이미지 목록")
+        List<ExampleImageRequestDto> exampleImages
+) {
+        public record ExampleImageRequestDto(
+                @NotBlank String imageUrl,
+                @NotNull ExampleImageType type,
+                @NotBlank String description,
+                @Min(1) int sequenceNumber
+        ) {}
+}


### PR DESCRIPTION
## 변경 내용
- 개인 챌린지 생성 요청 시 발생하던 NPE 및 leafReward 누락 오류 수정
- 정적 팩토리 패턴 적용 방식(GroupChallenge와 동일한 방식)으로 통일
- 예시 이미지 목록(exampleImages) 생성 시 addExampleImage 방식 적용
- leafReward 기본값 설정 (현재 30으로 고정)
- DTO 필드명 및 구조 재확인 (thumbnailImageUrl 등)

## 기타 
- 단체 챌린지 방식과의 구조 통일을 고려하여 정적 팩토리 내부에서 연관관계 설정 후, 명시적 `addExampleImage()` 호출로 양방향 유지