### PR TITLE
feat: 개인 챌린지 상세 조회 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeReadService.java
@@ -2,21 +2,33 @@ package ktb.leafresh.backend.domain.challenge.personal.application.service;
 
 import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
 import ktb.leafresh.backend.domain.challenge.personal.infrastructure.repository.PersonalChallengeRepository;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeDetailResponseDto;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeExampleImageDto;
 import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeListResponseDto;
 import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeSummaryDto;
+import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
 import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PersonalChallengeReadService {
 
     private final PersonalChallengeRepository repository;
+    private final PersonalChallengeVerificationRepository verificationRepository;
 
     public PersonalChallengeListResponseDto getByDayOfWeek(DayOfWeek dayOfWeek) {
         List<PersonalChallenge> challenges = repository.findAllByDayOfWeek(dayOfWeek);
@@ -26,5 +38,43 @@ public class PersonalChallengeReadService {
         }
 
         return new PersonalChallengeListResponseDto(PersonalChallengeSummaryDto.fromEntities(challenges));
+    }
+
+    public PersonalChallengeDetailResponseDto getChallengeDetail(Long memberIdOrNull, Long challengeId) {
+        PersonalChallenge challenge = repository.findById(challengeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PERSONAL_CHALLENGE_NOT_FOUND));
+
+        List<PersonalChallengeExampleImageDto> exampleImages = challenge.getExampleImages().stream()
+                .map(PersonalChallengeExampleImageDto::from)
+                .toList();
+
+        ChallengeStatus status = resolveChallengeStatus(memberIdOrNull, challengeId);
+
+        return PersonalChallengeDetailResponseDto.of(challenge, exampleImages, status);
+    }
+
+    private ChallengeStatus resolveChallengeStatus(Long memberIdOrNull, Long challengeId) {
+        if (memberIdOrNull == null) {
+            log.info("비회원 접근 - 인증 상태 조회 생략");
+            return ChallengeStatus.NOT_SUBMITTED;
+        }
+
+        // 1. 챌린지 가져오기
+        PersonalChallenge challenge = repository.findById(challengeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PERSONAL_CHALLENGE_NOT_FOUND));
+
+        // 2. 요일 계산
+        java.time.DayOfWeek javaDayOfWeek = java.time.DayOfWeek.valueOf(challenge.getDayOfWeek().name()); // enum 변환
+        java.time.LocalDate challengeDate = java.time.LocalDate.now()
+                .with(java.time.temporal.TemporalAdjusters.previousOrSame(javaDayOfWeek));
+
+        LocalDateTime startOfDay = challengeDate.atStartOfDay();
+        LocalDateTime endOfDay = challengeDate.atTime(LocalTime.MAX);
+
+        // 3. 인증 여부 확인
+        return verificationRepository
+                .findTopByMemberIdAndPersonalChallengeIdAndCreatedAtBetween(memberIdOrNull, challengeId, startOfDay, endOfDay)
+                .map(PersonalChallengeVerification::getStatus)
+                .orElse(ChallengeStatus.NOT_SUBMITTED);
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/controller/PersonalChallengeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/controller/PersonalChallengeController.java
@@ -1,11 +1,14 @@
 package ktb.leafresh.backend.domain.challenge.personal.presentation.controller;
 
 import ktb.leafresh.backend.domain.challenge.personal.application.service.PersonalChallengeReadService;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeDetailResponseDto;
 import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeListResponseDto;
 import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
 import ktb.leafresh.backend.global.response.ApiResponse;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,5 +24,15 @@ public class PersonalChallengeController {
     ) {
         PersonalChallengeListResponseDto response = readService.getByDayOfWeek(dayOfWeek);
         return ResponseEntity.ok(ApiResponse.success("개인챌린지 목록 조회에 성공하였습니다.", response));
+    }
+
+    @GetMapping("/{challengeId}")
+    public ResponseEntity<ApiResponse<PersonalChallengeDetailResponseDto>> getPersonalChallengeDetail(
+            @PathVariable Long challengeId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long memberId = (userDetails != null) ? userDetails.getMemberId() : null;
+        PersonalChallengeDetailResponseDto response = readService.getChallengeDetail(memberId, challengeId);
+        return ResponseEntity.ok(ApiResponse.success("개인 챌린지 상세 정보를 성공적으로 조회했습니다.", response));
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/dto/response/PersonalChallengeDetailResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/dto/response/PersonalChallengeDetailResponseDto.java
@@ -1,0 +1,40 @@
+package ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
+import lombok.Builder;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Builder
+public record PersonalChallengeDetailResponseDto(
+        Long id,
+        String title,
+        String description,
+        String imageUrl,
+        DayOfWeek dayOfWeek,
+        LocalTime verificationStartTime,
+        LocalTime verificationEndTime,
+        Integer leafReward,
+        List<PersonalChallengeExampleImageDto> exampleImages,
+        ChallengeStatus status
+) {
+    public static PersonalChallengeDetailResponseDto of(PersonalChallenge challenge,
+                                                        List<PersonalChallengeExampleImageDto> images,
+                                                        ChallengeStatus status) {
+        return PersonalChallengeDetailResponseDto.builder()
+                .id(challenge.getId())
+                .title(challenge.getTitle())
+                .description(challenge.getDescription())
+                .imageUrl(challenge.getImageUrl())
+                .dayOfWeek(challenge.getDayOfWeek())
+                .verificationStartTime(challenge.getVerificationStartTime())
+                .verificationEndTime(challenge.getVerificationEndTime())
+                .leafReward(challenge.getLeafReward())
+                .exampleImages(images)
+                .status(status)
+                .build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/dto/response/PersonalChallengeExampleImageDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/dto/response/PersonalChallengeExampleImageDto.java
@@ -1,0 +1,24 @@
+package ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallengeExampleImage;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
+import lombok.Builder;
+
+@Builder
+public record PersonalChallengeExampleImageDto(
+        Long id,
+        String imageUrl,
+        ExampleImageType type,
+        String description,
+        Integer sequenceNumber
+) {
+    public static PersonalChallengeExampleImageDto from(PersonalChallengeExampleImage image) {
+        return PersonalChallengeExampleImageDto.builder()
+                .id(image.getId())
+                .imageUrl(image.getImageUrl())
+                .type(image.getType())
+                .description(image.getDescription())
+                .sequenceNumber(image.getSequenceNumber())
+                .build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/PersonalChallengeVerificationRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/PersonalChallengeVerificationRepository.java
@@ -1,0 +1,17 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface PersonalChallengeVerificationRepository extends JpaRepository<PersonalChallengeVerification, Long> {
+
+    Optional<PersonalChallengeVerification> findTopByMemberIdAndPersonalChallengeIdAndCreatedAtBetween(
+            Long memberId,
+            Long challengeId,
+            LocalDateTime startOfDay,
+            LocalDateTime endOfDay
+    );
+}

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -79,6 +79,7 @@ public class SecurityConfig {
 
                         // 개인 챌린지
                         .requestMatchers(HttpMethod.GET, "/api/challenges/personal").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/challenges/personal/{challengeId:\\d+}").permitAll()
 
                         // 그 외 개인 챌린지 API는 인증 필요
                         .requestMatchers("/api/challenges/personal/**").authenticated()

--- a/src/main/java/ktb/leafresh/backend/global/exception/ErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/ErrorCode.java
@@ -35,7 +35,8 @@ public enum ErrorCode {
     CHALLENGE_CREATION_REJECTED_BY_AI(HttpStatus.UNPROCESSABLE_ENTITY, "AI 판단 결과 챌린지 생성이 거부되었습니다."),
     CHALLENGE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 단체 챌린지입니다."),
     CHALLENGE_HAS_PARTICIPANTS(HttpStatus.BAD_REQUEST, "해당 챌린지에 참여자가 있어 삭제할 수 없습니다."),
-    EXCEEDS_DAILY_PERSONAL_CHALLENGE_LIMIT(HttpStatus.BAD_REQUEST, "요일별 챌린지는 최대 3개까지만 등록할 수 있습니다.");
+    EXCEEDS_DAILY_PERSONAL_CHALLENGE_LIMIT(HttpStatus.BAD_REQUEST, "요일별 챌린지는 최대 3개까지만 등록할 수 있습니다."),
+    PERSONAL_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "개인 챌린지를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 요약
- 개인 챌린지 상세 정보를 조회하는 API를 개발했습니다.

## 작업 내용
- `SecurityConfig`: `/api/challenges/personal/{id}` URI 패턴을 인증 없이 접근 가능하도록 허용
- `ErrorCode`: PERSONAL_CHALLENGE_NOT_FOUND 에러 코드 추가
- `PersonalChallengeController`: GET /api/challenges/personal/{challengeId} 엔드포인트 추가
- `PersonalChallengeReadService`: 비회원 및 회원에 따른 인증 상태 로직 구현 포함
- `PersonalChallengeVerificationRepository`: 인증 상태 조회를 위한 findTopByMemberIdAndPersonalChallengeIdOrderByCreatedAtDesc 메서드 정의
- `PersonalChallengeDetailResponseDto`, `PersonalChallengeExampleImageDto`: 상세 응답 구조 정의

## 기타
- 매주 요일별로 반복되는 개인 챌린지 구조에 맞춰 인증 제출 여부를 조회합니다.