### PR TITLE
feat: 개인 챌린지 인증 규약 조회 API 구현 및 LocalTime 응답 포맷 통일

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeReadService.java
@@ -2,10 +2,7 @@ package ktb.leafresh.backend.domain.challenge.personal.application.service;
 
 import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
 import ktb.leafresh.backend.domain.challenge.personal.infrastructure.repository.PersonalChallengeRepository;
-import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeDetailResponseDto;
-import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeExampleImageDto;
-import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeListResponseDto;
-import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeSummaryDto;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.*;
 import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
 import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
 import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
@@ -76,5 +73,16 @@ public class PersonalChallengeReadService {
                 .findTopByMemberIdAndPersonalChallengeIdAndCreatedAtBetween(memberIdOrNull, challengeId, startOfDay, endOfDay)
                 .map(PersonalChallengeVerification::getStatus)
                 .orElse(ChallengeStatus.NOT_SUBMITTED);
+    }
+
+    public PersonalChallengeRuleResponseDto getChallengeRules(Long challengeId) {
+        PersonalChallenge challenge = repository.findById(challengeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PERSONAL_CHALLENGE_NOT_FOUND));
+
+        List<PersonalChallengeExampleImageDto> exampleImages = challenge.getExampleImages().stream()
+                .map(PersonalChallengeExampleImageDto::from)
+                .toList();
+
+        return PersonalChallengeRuleResponseDto.of(challenge, exampleImages);
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/controller/PersonalChallengeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/controller/PersonalChallengeController.java
@@ -3,6 +3,7 @@ package ktb.leafresh.backend.domain.challenge.personal.presentation.controller;
 import ktb.leafresh.backend.domain.challenge.personal.application.service.PersonalChallengeReadService;
 import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeDetailResponseDto;
 import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeListResponseDto;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeRuleResponseDto;
 import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
@@ -34,5 +35,13 @@ public class PersonalChallengeController {
         Long memberId = (userDetails != null) ? userDetails.getMemberId() : null;
         PersonalChallengeDetailResponseDto response = readService.getChallengeDetail(memberId, challengeId);
         return ResponseEntity.ok(ApiResponse.success("개인 챌린지 상세 정보를 성공적으로 조회했습니다.", response));
+    }
+
+    @GetMapping("/{challengeId}/rules")
+    public ResponseEntity<ApiResponse<PersonalChallengeRuleResponseDto>> getPersonalChallengeRules(
+            @PathVariable Long challengeId
+    ) {
+        PersonalChallengeRuleResponseDto response = readService.getChallengeRules(challengeId);
+        return ResponseEntity.ok(ApiResponse.success("개인 챌린지 인증 규약 정보를 성공적으로 조회했습니다.", response));
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/dto/response/PersonalChallengeRuleResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/presentation/dto/response/PersonalChallengeRuleResponseDto.java
@@ -1,0 +1,36 @@
+package ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
+import lombok.Builder;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Builder
+public record PersonalChallengeRuleResponseDto(
+        CertificationPeriod certificationPeriod,
+        List<PersonalChallengeExampleImageDto> exampleImages
+) {
+
+    @Builder
+    public record CertificationPeriod(
+            DayOfWeek dayOfWeek,
+            LocalTime startTime,
+            LocalTime endTime
+    ) {}
+
+    public static PersonalChallengeRuleResponseDto of(PersonalChallenge challenge,
+                                                      List<PersonalChallengeExampleImageDto> images) {
+        return PersonalChallengeRuleResponseDto.builder()
+                .certificationPeriod(
+                        CertificationPeriod.builder()
+                                .dayOfWeek(challenge.getDayOfWeek())
+                                .startTime(challenge.getVerificationStartTime())
+                                .endTime(challenge.getVerificationEndTime())
+                                .build()
+                )
+                .exampleImages(images)
+                .build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/config/JacksonTimeFormatConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/JacksonTimeFormatConfig.java
@@ -1,0 +1,39 @@
+package ktb.leafresh.backend.global.config;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleSerializers;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+@Configuration
+public class JacksonTimeFormatConfig {
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer customLocalTimeFormat() {
+        return builder -> {
+            JavaTimeModule timeModule = new JavaTimeModule();
+            timeModule.addSerializer(LocalTime.class,
+                    new com.fasterxml.jackson.databind.JsonSerializer<>() {
+                        private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+
+                        @Override
+                        public void serialize(LocalTime value, com.fasterxml.jackson.core.JsonGenerator gen,
+                                              com.fasterxml.jackson.databind.SerializerProvider serializers)
+                                throws java.io.IOException {
+                            gen.writeString(value.format(formatter));
+                        }
+                    });
+
+            builder.modules(timeModule);
+        };
+    }
+}


### PR DESCRIPTION
## 주요 변경 사항
- 개인 챌린지 인증 규약 조회 API 추가
  - GET /api/challenges/personal/{challengeId}/rules
  - 인증 시간 및 예시 이미지 목록을 조회 (회원/비회원 모두 접근 가능)
  - Controller: getPersonalChallengeRules() 추가
  - Service: getChallengeRules() 추가
  - DTO: PersonalChallengeRuleResponseDto 생성

- LocalTime 직렬화 포맷 전역 통일
  - "HH:mm:ss" → "HH:mm"
  - JacksonTimeFormatConfig 등록을 통해 모든 LocalTime 필드에 일관된 포맷 적용

## 참고
- 프론트 요청에 따라 초(`:ss`) 제거