### PR TITLE
feat: 단체 챌린지 인증 규약 조회 기능 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
@@ -117,4 +117,15 @@ public class GroupChallengeReadService {
                 .lastCursorId(page.lastCursorId())
                 .build();
     }
+
+    public GroupChallengeRuleResponseDto getChallengeRules(Long challengeId) {
+        GroupChallenge challenge = groupChallengeRepository.findById(challengeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.GROUP_CHALLENGE_NOT_FOUND));
+
+        List<GroupChallengeExampleImageDto> exampleImages = challenge.getExampleImages().stream()
+                .map(GroupChallengeExampleImageDto::from)
+                .toList();
+
+        return GroupChallengeRuleResponseDto.of(challenge, exampleImages);
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
@@ -7,10 +7,7 @@ import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChal
 import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeUpdateService;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto;
-import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeCreateResponseDto;
-import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeDetailResponseDto;
-import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeListResponseDto;
-import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeVerificationListResponseDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.*;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -96,5 +93,13 @@ public class GroupChallengeController {
                 .getVerifications(challengeId, cursorId, size);
 
         return ResponseEntity.ok(ApiResponse.success("단체 챌린지 인증 내역 조회에 성공했습니다.", response));
+    }
+
+    @GetMapping("/{challengeId}/rules")
+    public ResponseEntity<ApiResponse<GroupChallengeRuleResponseDto>> getGroupChallengeRules(
+            @PathVariable Long challengeId
+    ) {
+        GroupChallengeRuleResponseDto response = groupChallengeReadService.getChallengeRules(challengeId);
+        return ResponseEntity.ok(ApiResponse.success("단체 챌린지 인증 규약 정보를 성공적으로 조회했습니다.", response));
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeExampleImageDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeExampleImageDto.java
@@ -7,17 +7,17 @@ import lombok.Builder;
 public record GroupChallengeExampleImageDto(
         Long id,
         String imageUrl,
-        String type,
         String description,
-        int sequenceNumber
+        int sequenceNumber,
+        String type
 ) {
     public static GroupChallengeExampleImageDto from(GroupChallengeExampleImage image) {
         return GroupChallengeExampleImageDto.builder()
                 .id(image.getId())
                 .imageUrl(image.getImageUrl())
-                .type(image.getType().name())
                 .description(image.getDescription())
                 .sequenceNumber(image.getSequenceNumber())
+                .type(image.getType().name())
                 .build();
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeRuleResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeRuleResponseDto.java
@@ -1,0 +1,38 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Builder
+public record GroupChallengeRuleResponseDto(
+        CertificationPeriod certificationPeriod,
+        List<GroupChallengeExampleImageDto> exampleImages
+) {
+
+    @Builder
+    public record CertificationPeriod(
+            LocalDate startDate,
+            LocalDate endDate,
+            LocalTime startTime,
+            LocalTime endTime
+    ) {}
+
+    public static GroupChallengeRuleResponseDto of(GroupChallenge challenge, List<GroupChallengeExampleImageDto> images) {
+        return GroupChallengeRuleResponseDto.builder()
+                .certificationPeriod(
+                        CertificationPeriod.builder()
+                                .startDate(challenge.getStartDate().toLocalDate())
+                                .endDate(challenge.getEndDate().toLocalDate())
+                                .startTime(challenge.getVerificationStartTime())
+                                .endTime(challenge.getVerificationEndTime())
+                                .build()
+                )
+                .exampleImages(images)
+                .build();
+    }
+}


### PR DESCRIPTION
## 요약
- 단체 챌린지 인증 규약 조회 기능을 구현했습니다.
- `GET /api/challenges/group/{challengeId}/rules` 엔드포인트 추가
  - 인증 가능 기간 및 예시 이미지 목록 제공

## 작업 내용
- `GroupChallengeController`
  - `getGroupChallengeRules(Long challengeId)` 메서드 추가

- `GroupChallengeReadService`
  - 인증 규약을 반환하는 `getChallengeRules(Long challengeId)` 메서드 구현

- `GroupChallengeRuleResponseDto`
  - 인증 가능 시작/종료 일자 및 시간 포함 응답 DTO 정의
  - 예시 이미지 목록 포함

## 비고

- Jackson 시간 포맷은 `HH:mm` 기준으로 출력됩니다.
- 단체 챌린지에 예시 이미지가 없는 경우 빈 배열로 반환됩니다.
