### PR TITLE
feat: 단체 챌린지 참여/취소 기능 구현 및 도메인 분리

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeParticipationService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeParticipationService.java
@@ -1,0 +1,27 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.service.GroupChallengeParticipantManager;
+import ktb.leafresh.backend.domain.challenge.group.domain.support.policy.GroupChallengePromotionPolicy;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GroupChallengeParticipationService {
+
+    private final GroupChallengeParticipantManager participantManager;
+    private final GroupChallengePromotionPolicy promotionPolicy;
+
+    @Transactional
+    public Long participate(Long memberId, Long challengeId) {
+        return participantManager.participate(memberId, challengeId);
+    }
+
+    @Transactional
+    public void drop(Long memberId, Long challengeId) {
+        participantManager.drop(memberId, challengeId);
+        promotionPolicy.promoteNextWaitingParticipant(challengeId);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/GroupChallenge.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/GroupChallenge.java
@@ -110,4 +110,18 @@ public class GroupChallenge extends BaseEntity {
     public void changeCategory(GroupChallengeCategory newCategory) {
         this.category = newCategory;
     }
+
+    public void increaseParticipantCount() {
+        this.currentParticipantCount++;
+    }
+
+    public void decreaseParticipantCount() {
+        if (this.currentParticipantCount > 0) {
+            this.currentParticipantCount--;
+        }
+    }
+
+    public boolean isFull() {
+        return this.currentParticipantCount >= this.maxParticipantCount;
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/GroupChallengeParticipantRecord.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/GroupChallengeParticipantRecord.java
@@ -39,4 +39,20 @@ public class GroupChallengeParticipantRecord extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private ParticipantStatus status;
+
+    public void changeStatus(ParticipantStatus newStatus) {
+        this.status = newStatus;
+    }
+
+    public static GroupChallengeParticipantRecord create(Member member, GroupChallenge challenge, ParticipantStatus status) {
+        return GroupChallengeParticipantRecord.builder()
+                .member(member)
+                .groupChallenge(challenge)
+                .status(status)
+                .build();
+    }
+
+    public boolean isActive() {
+        return this.status == ParticipantStatus.ACTIVE;
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/service/GroupChallengeParticipantManager.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/service/GroupChallengeParticipantManager.java
@@ -1,0 +1,69 @@
+package ktb.leafresh.backend.domain.challenge.group.domain.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.challenge.group.domain.support.validator.GroupChallengeParticipationValidator;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeParticipantRecordRepository;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ParticipantStatus;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GroupChallengeParticipantManager {
+
+    private final GroupChallengeRepository groupChallengeRepository;
+    private final GroupChallengeParticipantRecordRepository participantRepository;
+    private final MemberRepository memberRepository;
+    private final GroupChallengeParticipationValidator validator;
+
+    public Long participate(Long memberId, Long challengeId) {
+        Member member = findMember(memberId);
+        GroupChallenge challenge = findChallenge(challengeId);
+
+        validator.validateNotAlreadyParticipated(challengeId, memberId);
+
+        boolean isFull = challenge.isFull();
+        ParticipantStatus status = isFull ? ParticipantStatus.WAITING : ParticipantStatus.ACTIVE;
+
+        if (status == ParticipantStatus.ACTIVE) {
+            challenge.increaseParticipantCount();
+        }
+
+        GroupChallengeParticipantRecord record = GroupChallengeParticipantRecord.create(member, challenge, status);
+        participantRepository.save(record);
+
+        return record.getId();
+    }
+
+    public void drop(Long memberId, Long challengeId) {
+        GroupChallengeParticipantRecord record = participantRepository
+                .findByGroupChallengeIdAndMemberIdAndDeletedAtIsNull(challengeId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHALLENGE_ALREADY_DELETED));
+
+        validator.validateDroppable(record);
+
+        GroupChallenge challenge = record.getGroupChallenge();
+
+        if (record.isActive()) {
+            challenge.decreaseParticipantCount();
+        }
+
+        record.changeStatus(ParticipantStatus.DROPPED);
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private GroupChallenge findChallenge(Long challengeId) {
+        return groupChallengeRepository.findById(challengeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.GROUP_CHALLENGE_NOT_FOUND));
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/support/policy/GroupChallengePromotionPolicy.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/support/policy/GroupChallengePromotionPolicy.java
@@ -1,0 +1,28 @@
+package ktb.leafresh.backend.domain.challenge.group.domain.support.policy;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeParticipantRecordRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ParticipantStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class GroupChallengePromotionPolicy {
+
+    private final GroupChallengeParticipantRecordRepository participantRepository;
+
+    /**
+     * 대기자 중 가장 오래된 사람을 ACTIVE로 승격시키고, 현재 인원 수 증가
+     */
+    @Transactional
+    public void promoteNextWaitingParticipant(Long challengeId) {
+        participantRepository.findFirstByGroupChallengeIdAndStatusOrderByCreatedAtAsc(challengeId, ParticipantStatus.WAITING)
+                .ifPresent(waiting -> {
+                    waiting.changeStatus(ParticipantStatus.ACTIVE);
+                    GroupChallenge challenge = waiting.getGroupChallenge();
+                    challenge.increaseParticipantCount();
+                });
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/support/validator/GroupChallengeParticipationValidator.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/support/validator/GroupChallengeParticipationValidator.java
@@ -1,0 +1,33 @@
+package ktb.leafresh.backend.domain.challenge.group.domain.support.validator;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeParticipantRecordRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ParticipantStatus;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ErrorCode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GroupChallengeParticipationValidator {
+
+    private final GroupChallengeParticipantRecordRepository participantRepository;
+
+    public GroupChallengeParticipationValidator(GroupChallengeParticipantRecordRepository participantRepository) {
+        this.participantRepository = participantRepository;
+    }
+
+    // 이미 참여했는지 확인
+    public void validateNotAlreadyParticipated(Long challengeId, Long memberId) {
+        if (participantRepository.existsByGroupChallengeIdAndMemberIdAndDeletedAtIsNull(challengeId, memberId)) {
+            throw new CustomException(ErrorCode.CHALLENGE_ALREADY_PARTICIPATED);
+        }
+    }
+
+    // DROPPED, FINISHED, BANNED는 중복 취소 불가
+    public void validateDroppable(GroupChallengeParticipantRecord record) {
+        ParticipantStatus status = record.getStatus();
+        if (status == ParticipantStatus.DROPPED || status == ParticipantStatus.FINISHED || status == ParticipantStatus.BANNED) {
+            throw new CustomException(ErrorCode.CHALLENGE_ALREADY_DROPPED);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeParticipantRecordRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeParticipantRecordRepository.java
@@ -1,8 +1,17 @@
 package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
 
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.global.common.entity.enums.ParticipantStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface GroupChallengeParticipantRecordRepository extends JpaRepository<GroupChallengeParticipantRecord, Long> {
     boolean existsByGroupChallengeIdAndDeletedAtIsNull(Long groupChallengeId);
+
+    boolean existsByGroupChallengeIdAndMemberIdAndDeletedAtIsNull(Long groupChallengeId, Long memberId);
+
+    Optional<GroupChallengeParticipantRecord> findFirstByGroupChallengeIdAndStatusOrderByCreatedAtAsc(Long challengeId, ParticipantStatus status);
+
+    Optional<GroupChallengeParticipantRecord> findByGroupChallengeIdAndMemberIdAndDeletedAtIsNull(Long groupChallengeId, Long memberId);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeController.java
@@ -1,10 +1,7 @@
 package ktb.leafresh.backend.domain.challenge.group.presentation.controller;
 
 import jakarta.validation.Valid;
-import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeCreateService;
-import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeDeleteService;
-import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeReadService;
-import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeUpdateService;
+import ktb.leafresh.backend.domain.challenge.group.application.service.*;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.*;
@@ -27,6 +24,7 @@ public class GroupChallengeController {
     private final GroupChallengeReadService groupChallengeReadService;
     private final GroupChallengeUpdateService groupChallengeUpdateService;
     private final GroupChallengeDeleteService groupChallengeDeleteService;
+    private final GroupChallengeParticipationService groupChallengeParticipationService;
 
     @GetMapping
     public ResponseEntity<ApiResponse<GroupChallengeListResponseDto>> getGroupChallenges(
@@ -101,5 +99,26 @@ public class GroupChallengeController {
     ) {
         GroupChallengeRuleResponseDto response = groupChallengeReadService.getChallengeRules(challengeId);
         return ResponseEntity.ok(ApiResponse.success("단체 챌린지 인증 규약 정보를 성공적으로 조회했습니다.", response));
+    }
+
+    @PostMapping("/{challengeId}/participations")
+    public ResponseEntity<ApiResponse<Map<String, Long>>> participateGroupChallenge(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long challengeId
+    ) {
+        Long memberId = userDetails.getMemberId();
+        Long recordId = groupChallengeParticipationService.participate(memberId, challengeId);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("단체 챌린지에 참여하였습니다.", Map.of("id", recordId)));
+    }
+
+    @DeleteMapping("/{challengeId}/participations")
+    public ResponseEntity<ApiResponse<Void>> cancelParticipation(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long challengeId
+    ) {
+        groupChallengeParticipationService.drop(userDetails.getMemberId(), challengeId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/ktb/leafresh/backend/global/exception/ErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/ErrorCode.java
@@ -36,7 +36,11 @@ public enum ErrorCode {
     CHALLENGE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 단체 챌린지입니다."),
     CHALLENGE_HAS_PARTICIPANTS(HttpStatus.BAD_REQUEST, "해당 챌린지에 참여자가 있어 삭제할 수 없습니다."),
     EXCEEDS_DAILY_PERSONAL_CHALLENGE_LIMIT(HttpStatus.BAD_REQUEST, "요일별 챌린지는 최대 3개까지만 등록할 수 있습니다."),
-    PERSONAL_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "개인 챌린지를 찾을 수 없습니다.");
+    PERSONAL_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "개인 챌린지를 찾을 수 없습니다."),
+    CHALLENGE_ALREADY_PARTICIPATED(HttpStatus.BAD_REQUEST, "이미 참여한 챌린지입니다."),
+    CHALLENGE_FULL(HttpStatus.FORBIDDEN, "참여 인원이 초과되었습니다."),
+    CHALLENGE_ALREADY_DROPPED(HttpStatus.BAD_REQUEST, "이미 취소된 참여 이력입니다.");
+
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 요약
단체 챌린지 참여 및 취소 기능을 DDD 원칙에 따라 도메인 계층 중심으로 구현하고, 참여/취소 및 대기자 승격 로직을 처리했습니다.

## 작업 내용
- `GroupChallengeParticipantManager`: 참여 및 취소 로직 처리
- `GroupChallengePromotionPolicy`: 대기자 중 가장 오래된 유저를 ACTIVE로 승격
- `GroupChallengeParticipationValidator`: 참여 중복/취소 불가 상태 검증
- `GroupChallengeParticipationService`: 도메인 서비스 위임
- `GroupChallengeController`: 참여/취소 API 연동
- `GroupChallenge`: `isFull()` 메서드 추가
- `GroupChallengeParticipantRecord`: `create()` 및 `isActive()` 메서드 추가
- `GroupChallengeParticipantRecordRepository`: 대기자 조회 쿼리 메서드 추가
- `ErrorCode`: 메시지 상수화 및 신규 에러 코드 등록

## 기타
- 참여자 수는 ACTIVE 상태에서만 증가하며, 취소 시 대기자를 승격시킵니다.
- 하드코딩된 메시지는 `ErrorCode`로 이동하여 통일성을 확보했습니다.
