### PR TITLE
feat: 개인/단체 챌린지 인증 결과 롱폴링 조회 기능 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultQueryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultQueryService.java
@@ -1,0 +1,36 @@
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.global.util.polling.ChallengeVerificationPollingExecutor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class GroupChallengeVerificationResultQueryService {
+
+    private final GroupChallengeVerificationRepository verificationRepository;
+    private final ChallengeVerificationPollingExecutor pollingExecutor;
+
+    @Transactional(readOnly = true)
+    public ChallengeStatus waitForResult(Long memberId, Long challengeId) {
+        return pollingExecutor.poll(() -> getLatestStatus(memberId, challengeId));
+    }
+
+    private ChallengeStatus getLatestStatus(Long memberId, Long challengeId) {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = LocalDate.now().atTime(23, 59, 59);
+
+        return verificationRepository
+                .findTopByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_IdAndCreatedAtBetween(
+                        memberId, challengeId, start, end)
+                .map(GroupChallengeVerification::getStatus)
+                .orElse(ChallengeStatus.NOT_SUBMITTED);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultQueryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultQueryService.java
@@ -1,0 +1,36 @@
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.global.util.polling.ChallengeVerificationPollingExecutor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PersonalChallengeVerificationResultQueryService {
+
+    private final PersonalChallengeVerificationRepository verificationRepository;
+    private final ChallengeVerificationPollingExecutor pollingExecutor;
+
+    @Transactional(readOnly = true)
+    public ChallengeStatus waitForResult(Long memberId, Long challengeId) {
+        return pollingExecutor.poll(() -> getLatestStatus(memberId, challengeId));
+    }
+
+    private ChallengeStatus getLatestStatus(Long memberId, Long challengeId) {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = LocalDate.now().atTime(23, 59, 59);
+
+        return verificationRepository
+                .findTopByMemberIdAndPersonalChallengeIdAndCreatedAtBetween(
+                        memberId, challengeId, start, end)
+                .map(PersonalChallengeVerification::getStatus)
+                .orElse(ChallengeStatus.NOT_SUBMITTED);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/domain/entity/GroupChallengeVerification.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/domain/entity/GroupChallengeVerification.java
@@ -41,4 +41,8 @@ public class GroupChallengeVerification extends BaseEntity {
         this.status = status;
         this.verifiedAt = LocalDateTime.now();
     }
+
+    public boolean isFinalized() {
+        return this.status != ChallengeStatus.PENDING_APPROVAL;
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/domain/entity/PersonalChallengeVerification.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/domain/entity/PersonalChallengeVerification.java
@@ -52,4 +52,8 @@ public class PersonalChallengeVerification extends BaseEntity {
         this.status = status;
         this.verifiedAt = LocalDateTime.now();
     }
+
+    public boolean isFinalized() {
+        return this.status != ChallengeStatus.PENDING_APPROVAL;
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/GroupChallengeVerificationRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/GroupChallengeVerificationRepository.java
@@ -3,6 +3,7 @@ package ktb.leafresh.backend.domain.verification.infrastructure.repository;
 import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,4 +21,11 @@ public interface GroupChallengeVerificationRepository extends JpaRepository<Grou
      * 단체 챌린지 상세 페이지에 보여줄 최신 인증 이미지 9개 조회
      */
     List<GroupChallengeVerification> findTop9ByParticipantRecord_GroupChallenge_IdOrderByCreatedAtDesc(Long challengeId);
+
+    Optional<GroupChallengeVerification> findTopByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_IdAndCreatedAtBetween(
+            Long memberId,
+            Long challengeId,
+            LocalDateTime start,
+            LocalDateTime end
+    );
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupChallengeVerificationController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupChallengeVerificationController.java
@@ -1,14 +1,22 @@
 package ktb.leafresh.backend.domain.verification.presentation.controller;
 
+import ktb.leafresh.backend.domain.verification.application.service.GroupChallengeVerificationResultQueryService;
 import ktb.leafresh.backend.domain.verification.application.service.GroupChallengeVerificationSubmitService;
 import ktb.leafresh.backend.domain.verification.presentation.dto.request.GroupChallengeVerificationRequestDto;
+import ktb.leafresh.backend.domain.verification.presentation.util.ChallengeStatusMessageResolver;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+import static ktb.leafresh.backend.global.exception.GlobalErrorCode.UNAUTHORIZED;
 
 @Slf4j
 @RestController
@@ -17,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class GroupChallengeVerificationController {
 
     private final GroupChallengeVerificationSubmitService submitService;
+    private final GroupChallengeVerificationResultQueryService resultQueryService;
 
     @PostMapping("/{challengeId}/verifications")
     public ResponseEntity<ApiResponse<Void>> submitVerification(
@@ -39,5 +48,28 @@ public class GroupChallengeVerificationController {
         log.info("[단체 인증 제출 완료] challengeId={}, memberId={}", challengeId, memberId);
 
         return ResponseEntity.ok(ApiResponse.success("단체 챌린지 인증 제출이 완료되었습니다."));
+    }
+
+    @GetMapping("/{challengeId}/verification/result")
+    public ResponseEntity<ApiResponse<Map<String, String>>> getVerificationResult(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long challengeId
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity
+                    .status(UNAUTHORIZED.getStatus())
+                    .body(ApiResponse.error(UNAUTHORIZED.getStatus(), UNAUTHORIZED.getMessage()));
+        }
+
+        Long memberId = userDetails.getMemberId();
+        ChallengeStatus status = resultQueryService.waitForResult(memberId, challengeId);
+
+        Map<String, String> data = Map.of("status", status.name());
+        String message = ChallengeStatusMessageResolver.resolveMessage(status);
+
+        HttpStatus httpStatus = (status == ChallengeStatus.PENDING_APPROVAL)
+                ? HttpStatus.ACCEPTED : HttpStatus.OK;
+
+        return ResponseEntity.status(httpStatus).body(ApiResponse.success(message, data));
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/PersonalChallengeVerificationController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/PersonalChallengeVerificationController.java
@@ -1,14 +1,22 @@
 package ktb.leafresh.backend.domain.verification.presentation.controller;
 
+import ktb.leafresh.backend.domain.verification.application.service.PersonalChallengeVerificationResultQueryService;
 import ktb.leafresh.backend.domain.verification.application.service.PersonalChallengeVerificationSubmitService;
 import ktb.leafresh.backend.domain.verification.presentation.dto.request.PersonalChallengeVerificationRequestDto;
+import ktb.leafresh.backend.domain.verification.presentation.util.ChallengeStatusMessageResolver;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+import static ktb.leafresh.backend.global.exception.GlobalErrorCode.UNAUTHORIZED;
 
 @Slf4j
 @RestController
@@ -17,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class PersonalChallengeVerificationController {
 
     private final PersonalChallengeVerificationSubmitService submitService;
+    private final PersonalChallengeVerificationResultQueryService resultQueryService;
 
     @PostMapping("/{challengeId}/verifications")
     public ResponseEntity<ApiResponse<Void>> submitVerification(
@@ -39,5 +48,28 @@ public class PersonalChallengeVerificationController {
         log.info("[인증 제출 완료] challengeId={}, memberId={}", challengeId, memberId);
 
         return ResponseEntity.ok(ApiResponse.success("인증 제출이 완료되었습니다."));
+    }
+
+    @GetMapping("/{challengeId}/verification/result")
+    public ResponseEntity<ApiResponse<Map<String, String>>> getVerificationResult(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long challengeId
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity
+                    .status(UNAUTHORIZED.getStatus())
+                    .body(ApiResponse.error(UNAUTHORIZED.getStatus(), UNAUTHORIZED.getMessage()));
+        }
+
+        Long memberId = userDetails.getMemberId();
+        ChallengeStatus status = resultQueryService.waitForResult(memberId, challengeId);
+
+        Map<String, String> data = Map.of("status", status.name());
+        String message = ChallengeStatusMessageResolver.resolveMessage(status);
+
+        HttpStatus httpStatus = (status == ChallengeStatus.PENDING_APPROVAL)
+                ? HttpStatus.ACCEPTED : HttpStatus.OK;
+
+        return ResponseEntity.status(httpStatus).body(ApiResponse.success(message, data));
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/util/ChallengeStatusMessageResolver.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/util/ChallengeStatusMessageResolver.java
@@ -1,0 +1,14 @@
+package ktb.leafresh.backend.domain.verification.presentation.util;
+
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+
+public class ChallengeStatusMessageResolver {
+    public static String resolveMessage(ChallengeStatus status) {
+        return switch (status) {
+            case SUCCESS -> "인증에 성공했습니다.";
+            case FAILURE -> "인증에 실패했습니다.";
+            case NOT_SUBMITTED -> "아직 인증을 제출하지 않았습니다.";
+            case PENDING_APPROVAL -> "아직 인증 결과가 도착하지 않았습니다.";
+        };
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/response/ApiResponse.java
+++ b/src/main/java/ktb/leafresh/backend/global/response/ApiResponse.java
@@ -35,6 +35,10 @@ public class ApiResponse<T> {
         return new ApiResponse<>(HttpStatus.CREATED, message, data);
     }
 
+    public static <T> ApiResponse<T> accepted(String message, T data) {
+        return new ApiResponse<>(HttpStatus.ACCEPTED, message, data);
+    }
+
     public static <T> ApiResponse<T> error(HttpStatus status, String message) {
         return new ApiResponse<>(status, message, null);
     }

--- a/src/main/java/ktb/leafresh/backend/global/util/polling/ChallengeVerificationPollingExecutor.java
+++ b/src/main/java/ktb/leafresh/backend/global/util/polling/ChallengeVerificationPollingExecutor.java
@@ -1,0 +1,34 @@
+package ktb.leafresh.backend.global.util.polling;
+
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Supplier;
+
+@Component
+public class ChallengeVerificationPollingExecutor {
+
+    private static final int TIMEOUT_MILLIS = 10000;
+    private static final int CHECK_INTERVAL_MILLIS = 500;
+
+    public ChallengeStatus poll(Supplier<ChallengeStatus> statusSupplier) {
+        long startTime = System.currentTimeMillis();
+
+        while (System.currentTimeMillis() - startTime < TIMEOUT_MILLIS) {
+            ChallengeStatus status = statusSupplier.get();
+
+            if (status != ChallengeStatus.PENDING_APPROVAL) {
+                return status;
+            }
+
+            try {
+                Thread.sleep(CHECK_INTERVAL_MILLIS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        return ChallengeStatus.PENDING_APPROVAL;
+    }
+}


### PR DESCRIPTION
## 요약
- 개인/단체 챌린지 인증 결과를 클라이언트에서 롱폴링 방식으로 조회할 수 있도록 기능 추가
- 인증 상태에 따른 응답 메시지를 일관되게 전달하기 위한 처리 도입

## 작업 내용
- `ChallengeVerificationPollingExecutor`: 10초 동안 polling 후 상태 반환하는 유틸 클래스 추가
- `GroupChallengeVerificationResultQueryService`, `PersonalChallengeVerificationResultQueryService`: polling 유틸 적용
- `GroupChallengeVerificationController`, `PersonalChallengeVerificationController`: 인증 상태 메시지 처리 로직 반영
- `ChallengeStatusMessageResolver`: 인증 상태(enum)에 따른 사용자 메시지 분리
- `isFinalized()` 도메인 메서드 추가로 `PENDING_APPROVAL` 여부 판단 일관화

## 테스트
- 인증 결과 조회 API 요청 시 심사 중이면 최대 10초 동안 polling 후 결과 반환
- 인증을 제출하지 않은 경우 → `NOT_SUBMITTED`
- 심사 중인 경우 → `PENDING_APPROVAL`
- 심사 완료된 경우 → `SUCCESS` 또는 `FAILURE` 응답 확인
