### PR TITLE
feat: 회원이 생성한 단체 챌린지 목록 조회 기능 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
@@ -129,4 +129,18 @@ public class GroupChallengeReadService {
 
         return GroupChallengeRuleResponseDto.of(challenge, exampleImages);
     }
+
+    public GroupChallengeListResponseDto getCreatedChallengesByMember(Long memberId, Long cursorId, int size) {
+        List<GroupChallenge> entities =
+                groupChallengeQueryRepository.findCreatedByMember(memberId, cursorId, size + 1);
+
+        CursorPaginationResult<GroupChallengeSummaryDto> result =
+                CursorPaginationHelper.paginate(entities, size, GroupChallengeSummaryDto::from, GroupChallengeSummaryDto::id);
+
+        return GroupChallengeListResponseDto.builder()
+                .groupChallenges(result.items())
+                .hasNext(result.hasNext())
+                .lastCursorId(result.lastCursorId())
+                .build();
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepository.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface GroupChallengeQueryRepository {
     List<GroupChallenge> findByFilter(String input, String category, Long cursorId, int size);
+
+    List<GroupChallenge> findCreatedByMember(Long memberId, Long cursorId, int size);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepositoryImpl.java
@@ -45,4 +45,17 @@ public class GroupChallengeQueryRepositoryImpl implements GroupChallengeQueryRep
     private BooleanExpression ltCursorId(Long cursorId) {
         return cursorId != null ? gc.id.lt(cursorId) : null;
     }
+
+    @Override
+    public List<GroupChallenge> findCreatedByMember(Long memberId, Long cursorId, int size) {
+        return queryFactory.selectFrom(gc)
+                .where(
+                        gc.deletedAt.isNull(),
+                        gc.member.id.eq(memberId),
+                        ltCursorId(cursorId)
+                )
+                .orderBy(gc.id.desc())
+                .limit(size + 1)
+                .fetch();
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/GroupChallengeMemberController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/GroupChallengeMemberController.java
@@ -1,0 +1,37 @@
+package ktb.leafresh.backend.domain.member.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeReadService;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeListResponseDto;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members/challenges/group")
+public class GroupChallengeMemberController {
+
+    private final GroupChallengeReadService groupChallengeReadService;
+
+    @GetMapping("/creations")
+    @Operation(summary = "생성한 단체 챌린지 목록 조회", description = "회원이 생성한 단체 챌린지를 커서 기반으로 조회합니다.")
+    public ResponseEntity<ApiResponse<GroupChallengeListResponseDto>> getCreatedChallenges(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "12") int size
+    ) {
+        Long memberId = userDetails.getMemberId();
+        GroupChallengeListResponseDto response =
+                groupChallengeReadService.getCreatedChallengesByMember(memberId, cursorId, size);
+
+        return ResponseEntity.ok(ApiResponse.success("생성한 단체 챌린지 목록 조회에 성공했습니다.", response));
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 회원이 생성한 단체 챌린지 목록을 조회하는 API (`GET /api/members/challenges/group/creations`)를 추가했습니다.
- 커서 기반 페이지네이션 방식 적용 (기본 size=12, cursorId 사용)
- `GroupChallengeQueryRepository`에 QueryDSL 기반 쿼리 메서드 추가
- `GroupChallengeReadService`에서 로직 구현
- 컨트롤러에서는 `CustomUserDetails` 기반 인증 회원 ID 사용