### PR TITLE
feat: 참여한 단체 챌린지 카운트 조회 기능 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeReadService.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -142,5 +143,12 @@ public class GroupChallengeReadService {
                 .hasNext(result.hasNext())
                 .lastCursorId(result.lastCursorId())
                 .build();
+    }
+
+    public GroupChallengeParticipationCountResponseDto getParticipationCounts(Long memberId) {
+        GroupChallengeParticipationCountSummaryDto summary =
+                groupChallengeQueryRepository.countParticipationByStatus(memberId, LocalDateTime.now());
+
+        return GroupChallengeParticipationCountResponseDto.from(summary);
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepository.java
@@ -1,11 +1,15 @@
 package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
 
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeParticipationCountSummaryDto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface GroupChallengeQueryRepository {
     List<GroupChallenge> findByFilter(String input, String category, Long cursorId, int size);
 
     List<GroupChallenge> findCreatedByMember(Long memberId, Long cursorId, int size);
+
+    GroupChallengeParticipationCountSummaryDto countParticipationByStatus(Long memberId, LocalDateTime now);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeQueryRepositoryImpl.java
@@ -3,12 +3,18 @@ package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.QGroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.QGroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeParticipationCountSummaryDto;
+import ktb.leafresh.backend.global.common.entity.enums.ParticipantStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static ktb.leafresh.backend.global.common.entity.enums.ParticipantStatus.*;
 
 @Repository
 @RequiredArgsConstructor
@@ -16,6 +22,7 @@ public class GroupChallengeQueryRepositoryImpl implements GroupChallengeQueryRep
 
     private final JPAQueryFactory queryFactory;
     private final QGroupChallenge gc = QGroupChallenge.groupChallenge;
+    private final QGroupChallengeParticipantRecord pr = QGroupChallengeParticipantRecord.groupChallengeParticipantRecord;
 
     @Override
     public List<GroupChallenge> findByFilter(String input, String category, Long cursorId, int size) {
@@ -57,5 +64,40 @@ public class GroupChallengeQueryRepositoryImpl implements GroupChallengeQueryRep
                 .orderBy(gc.id.desc())
                 .limit(size + 1)
                 .fetch();
+    }
+
+    @Override
+    public GroupChallengeParticipationCountSummaryDto countParticipationByStatus(Long memberId, LocalDateTime now) {
+        List<GroupChallengeParticipantRecord> records = queryFactory
+                .selectFrom(pr)
+                .join(pr.groupChallenge, gc).fetchJoin()
+                .where(
+                        pr.member.id.eq(memberId),
+                        pr.status.in(ACTIVE, FINISHED, WAITING), // 유효 참여 상태만 포함
+                        pr.deletedAt.isNull(),
+                        gc.deletedAt.isNull()
+                )
+                .fetch();
+
+        int notStarted = 0;
+        int ongoing = 0;
+        int completed = 0;
+
+        for (GroupChallengeParticipantRecord record : records) {
+            GroupChallenge challenge = record.getGroupChallenge();
+            ParticipantStatus status = record.getStatus();
+
+            if (status == FINISHED) {
+                completed++;
+            } else if (now.isBefore(challenge.getStartDate())) {
+                notStarted++;
+            } else if (now.isAfter(challenge.getEndDate())) {
+                completed++;
+            } else {
+                ongoing++;
+            }
+        }
+
+        return new GroupChallengeParticipationCountSummaryDto(notStarted, ongoing, completed);
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeParticipationCountResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeParticipationCountResponseDto.java
@@ -1,0 +1,12 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record GroupChallengeParticipationCountResponseDto(
+        GroupChallengeParticipationCountSummaryDto count
+) {
+    public static GroupChallengeParticipationCountResponseDto from(GroupChallengeParticipationCountSummaryDto summary) {
+        return new GroupChallengeParticipationCountResponseDto(summary);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeParticipationCountSummaryDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeParticipationCountSummaryDto.java
@@ -1,0 +1,7 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+public record GroupChallengeParticipationCountSummaryDto(
+        int notStarted,
+        int ongoing,
+        int completed
+) {}

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/GroupChallengeMemberController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/GroupChallengeMemberController.java
@@ -3,7 +3,7 @@ package ktb.leafresh.backend.domain.member.presentation.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import ktb.leafresh.backend.domain.challenge.group.application.service.GroupChallengeReadService;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeListResponseDto;
-import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeParticipationCountResponseDto;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -33,5 +33,15 @@ public class GroupChallengeMemberController {
                 groupChallengeReadService.getCreatedChallengesByMember(memberId, cursorId, size);
 
         return ResponseEntity.ok(ApiResponse.success("생성한 단체 챌린지 목록 조회에 성공했습니다.", response));
+    }
+
+    @GetMapping("/participations/count")
+    public ResponseEntity<ApiResponse<GroupChallengeParticipationCountResponseDto>> getParticipationCounts(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        GroupChallengeParticipationCountResponseDto response =
+                groupChallengeReadService.getParticipationCounts(userDetails.getMemberId());
+
+        return ResponseEntity.ok(ApiResponse.success("참여한 단체 챌린지 카운트를 성공적으로 조회했습니다.", response));
     }
 }


### PR DESCRIPTION
## 작업 내용
- 참여 상태별(참여 전 / 참여 중 / 참여 완료) 카운트 정보를 조회하는 기능 추가
- `GroupChallengeQueryRepositoryImpl`에 참여 상태 계산 로직 구현
- `GroupChallengeParticipationCountSummaryDto`: 참여 카운트 정보를 담는 Summary Dto 정의
- `GroupChallengeParticipationCountResponseDto`: 응답을 count로 감싼 Dto 정의
- `GroupChallengeReadService`에 조회 로직 추가
- `GroupChallengeMemberController`에 엔드포인트(`/api/members/challenges/group/participations/count`) 추가