### PR TITLE
chore: 빅뱅 배포 환경 대응을 위한 프로파일 및 AI 서버 연동 설정 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/client/HttpAiChallengeValidationClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/client/HttpAiChallengeValidationClient.java
@@ -2,17 +2,22 @@ package ktb.leafresh.backend.domain.challenge.group.infrastructure.client;
 
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.dto.request.AiChallengeValidationRequestDto;
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.dto.response.AiChallengeValidationResponseDto;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Component
-@Profile("!local") // local이 아닐 때만 이 구현 사용
-@RequiredArgsConstructor
+@Profile("!local")
 public class HttpAiChallengeValidationClient implements AiChallengeValidationClient {
 
     private final WebClient aiServerWebClient;
+
+    public HttpAiChallengeValidationClient(
+            @Qualifier("aiServerWebClient") WebClient aiServerWebClient
+    ) {
+        this.aiServerWebClient = aiServerWebClient;
+    }
 
     @Override
     public AiChallengeValidationResponseDto validateChallenge(AiChallengeValidationRequestDto requestDto) {

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/client/HttpAiChatbotBaseInfoClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/client/HttpAiChatbotBaseInfoClient.java
@@ -2,17 +2,22 @@ package ktb.leafresh.backend.domain.chatbot.infrastructure.client;
 
 import ktb.leafresh.backend.domain.chatbot.infrastructure.dto.request.AiChatbotBaseInfoRequestDto;
 import ktb.leafresh.backend.domain.chatbot.infrastructure.dto.response.AiChatbotBaseInfoResponseDto;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Component
 @Profile("!local")
-@RequiredArgsConstructor
 public class HttpAiChatbotBaseInfoClient implements AiChatbotBaseInfoClient {
 
     private final WebClient aiServerWebClient;
+
+    public HttpAiChatbotBaseInfoClient(
+            @Qualifier("aiServerWebClient") WebClient aiServerWebClient
+    ) {
+        this.aiServerWebClient = aiServerWebClient;
+    }
 
     @Override
     public AiChatbotBaseInfoResponseDto getRecommendation(AiChatbotBaseInfoRequestDto requestDto) {

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/client/HttpAiChatbotFreeTextClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/client/HttpAiChatbotFreeTextClient.java
@@ -2,17 +2,22 @@ package ktb.leafresh.backend.domain.chatbot.infrastructure.client;
 
 import ktb.leafresh.backend.domain.chatbot.infrastructure.dto.request.AiChatbotFreeTextRequestDto;
 import ktb.leafresh.backend.domain.chatbot.infrastructure.dto.response.AiChatbotFreeTextResponseDto;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Component
 @Profile("!local")
-@RequiredArgsConstructor
 public class HttpAiChatbotFreeTextClient implements AiChatbotFreeTextClient {
 
     private final WebClient aiServerWebClient;
+
+    public HttpAiChatbotFreeTextClient(
+            @Qualifier("aiServerWebClient") WebClient aiServerWebClient
+    ) {
+        this.aiServerWebClient = aiServerWebClient;
+    }
 
     @Override
     public AiChatbotFreeTextResponseDto getRecommendation(AiChatbotFreeTextRequestDto requestDto) {


### PR DESCRIPTION
## 요약
빅뱅 배포 환경(Backend와 AI 서버가 동일 인스턴스에 공존)에서의 통신을 지원하기 위해 프로파일 및 설정을 수정하였습니다.

## 주요 변경 사항
- `.env`에 `ai_server_base_url=http://localhost:8000` 설정 추가
- `application.yml`의 활성 프로파일을 `local` → `bigbang`으로 변경
- `ai-server.base-url: ${ai_server_base_url}` 구성
- WebClient가 AI 서버와 통신할 수 있도록 설정 정비
  - `HttpAiChatbotBaseInfoClient`에 `@Qualifier("aiServerWebClient")` 주입 방식 적용
  - `@RequiredArgsConstructor` 제거 후 명시적 생성자 작성

## 기타
- `@Profile("!local")` 조건을 유지하고 있으므로, 운영 배포에서 자동으로 실제 서버 호출 로직이 활성화됨
- 로컬 테스트 시에는 `local` 프로파일을 사용하여 `FakeAiChatbotBaseInfoClient`로 대체 가능