### PR TITLE
chore: 빅뱅 배포 환경 대응을 위한 프로파일 및 AI 서버 연동 설정 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/HttpAiGroupChallengeVerificationClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/HttpAiGroupChallengeVerificationClient.java
@@ -1,17 +1,22 @@
 package ktb.leafresh.backend.domain.verification.infrastructure.client;
 
 import ktb.leafresh.backend.domain.verification.infrastructure.dto.request.AiGroupChallengeVerificationRequestDto;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Component
 @Profile("!local")
-@RequiredArgsConstructor
 public class HttpAiGroupChallengeVerificationClient implements AiGroupChallengeVerificationClient {
 
     private final WebClient aiServerWebClient;
+
+    public HttpAiGroupChallengeVerificationClient(
+            @Qualifier("aiServerWebClient") WebClient aiServerWebClient
+    ) {
+        this.aiServerWebClient = aiServerWebClient;
+    }
 
     @Override
     public void verifyImage(AiGroupChallengeVerificationRequestDto requestDto) {


### PR DESCRIPTION
## 요약
빅뱅 배포 환경(Backend와 AI 서버가 동일 인스턴스에 공존)에서의 통신을 지원하기 위해 프로파일 및 설정을 수정하였습니다.

## 주요 변경 사항
- `.env`에 `ai_server_base_url=http://localhost:8000` 설정 추가
- `application.yml`의 활성 프로파일을 `local` → `bigbang`으로 변경
- `ai-server.base-url: ${ai_server_base_url}` 구성
- WebClient가 AI 서버와 통신할 수 있도록 설정 정비
  - `HttpAiChatbotBaseInfoClient`에 `@Qualifier("aiServerWebClient")` 주입 방식 적용
  - `@RequiredArgsConstructor` 제거 후 명시적 생성자 작성

## 기타
- `@Profile("!local")` 조건을 유지하고 있으므로, 운영 배포에서 자동으로 실제 서버 호출 로직이 활성화됨
- 로컬 테스트 시에는 `local` 프로파일을 사용하여 `FakeAiChatbotBaseInfoClient`로 대체 가능