### PR TITLE
refactor: 챗봇 API에서 인증 제거 및 memberId 파라미터 제거

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationService.java
@@ -21,8 +21,8 @@ public class ChatbotRecommendationService {
     private final AiChatbotBaseInfoClient aiChatbotBaseInfoClientClient;
     private final AiChatbotFreeTextClient aiChatbotFreeTextClient;
 
-    public ChatbotBaseInfoResponseDto recommendByBaseInfo(Long memberId, ChatbotBaseInfoRequestDto dto) {
-        var aiRequest = new AiChatbotBaseInfoRequestDto(memberId, dto.location(), dto.workType(), dto.category());
+    public ChatbotBaseInfoResponseDto recommendByBaseInfo(ChatbotBaseInfoRequestDto dto) {
+        var aiRequest = new AiChatbotBaseInfoRequestDto(dto.location(), dto.workType(), dto.category());
         var aiResponse = aiChatbotBaseInfoClientClient.getRecommendation(aiRequest);
 
         List<ChallengeDto> challenges = aiResponse.challenges().stream()
@@ -38,8 +38,8 @@ public class ChatbotRecommendationService {
                 .build();
     }
 
-    public ChatbotFreeTextResponseDto recommendByFreeText(Long memberId, ChatbotFreeTextRequestDto dto) {
-        var aiRequest = new AiChatbotFreeTextRequestDto(memberId, dto.location(), dto.workType(), dto.message());
+    public ChatbotFreeTextResponseDto recommendByFreeText(ChatbotFreeTextRequestDto dto) {
+        var aiRequest = new AiChatbotFreeTextRequestDto(dto.location(), dto.workType(), dto.message());
         var aiResponse = aiChatbotFreeTextClient.getRecommendation(aiRequest);
 
         var challenges = aiResponse.challenges().stream()

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/dto/request/AiChatbotBaseInfoRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/dto/request/AiChatbotBaseInfoRequestDto.java
@@ -1,7 +1,6 @@
 package ktb.leafresh.backend.domain.chatbot.infrastructure.dto.request;
 
 public record AiChatbotBaseInfoRequestDto(
-        Long memberId,
         String location,
         String workType,
         String category

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/dto/request/AiChatbotFreeTextRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/dto/request/AiChatbotFreeTextRequestDto.java
@@ -1,7 +1,6 @@
 package ktb.leafresh.backend.domain.chatbot.infrastructure.dto.request;
 
 public record AiChatbotFreeTextRequestDto(
-        Long memberId,
         String location,
         String workType,
         String message

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/presentation/controller/ChatbotRecommendationController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/presentation/controller/ChatbotRecommendationController.java
@@ -24,21 +24,12 @@ public class ChatbotRecommendationController {
 
     @PostMapping("/base-info")
     public ResponseEntity<ApiResponse<ChatbotBaseInfoResponseDto>> recommendByBaseInfo(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid ChatbotBaseInfoRequestDto requestDto
     ) {
         log.info("[챗봇 추천 요청 - 기본 정보] location={}, workType={}, category={}",
                 requestDto.location(), requestDto.workType(), requestDto.category());
 
-        if (userDetails == null) {
-            log.warn("[챗봇 추천 실패] 인증 정보가 없습니다.");
-            throw new IllegalStateException("로그인 정보가 존재하지 않습니다.");
-        }
-
-        Long memberId = userDetails.getMemberId();
-        log.info("[챗봇 추천 요청 - 기본 정보] memberId={}", memberId);
-
-        ChatbotBaseInfoResponseDto response = recommendationService.recommendByBaseInfo(memberId, requestDto);
+        ChatbotBaseInfoResponseDto response = recommendationService.recommendByBaseInfo(requestDto);
         log.info("[챗봇 추천 완료 - 기본 정보] 추천 결과: {}", response.recommend());
 
         return ResponseEntity.ok(ApiResponse.success("사용자 기본 정보 키워드 선택을 기반으로 챌린지를 추천합니다.", response));
@@ -46,21 +37,12 @@ public class ChatbotRecommendationController {
 
     @PostMapping("/free-text")
     public ResponseEntity<ApiResponse<ChatbotFreeTextResponseDto>> recommendByFreeText(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid ChatbotFreeTextRequestDto requestDto
     ) {
         log.info("[챗봇 추천 요청 - 자유 텍스트] location={}, workType={}, message={}",
                 requestDto.location(), requestDto.workType(), requestDto.message());
 
-        if (userDetails == null) {
-            log.warn("[챗봇 추천 실패] 인증 정보가 없습니다.");
-            throw new IllegalStateException("로그인 정보가 존재하지 않습니다.");
-        }
-
-        Long memberId = userDetails.getMemberId();
-        log.info("[챗봇 추천 요청 - 자유 텍스트] memberId={}", memberId);
-
-        ChatbotFreeTextResponseDto response = recommendationService.recommendByFreeText(memberId, requestDto);
+        ChatbotFreeTextResponseDto response = recommendationService.recommendByFreeText(requestDto);
         log.info("[챗봇 추천 완료 - 자유 텍스트] 추천 결과: {}", response.recommend());
 
         return ResponseEntity.ok(ApiResponse.success("사용자 자유 메시지를 기반으로 챌린지를 추천합니다.", response));

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -87,6 +87,10 @@ public class SecurityConfig {
                         // AI로부터 챌린지 인증 결과 받는 API
                         .requestMatchers(HttpMethod.POST, "/api/verifications/*/result").permitAll()
 
+                        // 챗봇
+                        .requestMatchers(HttpMethod.POST, "/api/chatbot/recommendation/base-info").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/chatbot/recommendation/free-text").permitAll()
+
                         // Swagger/OpenAPI
                         .requestMatchers(
                                 "/swagger-ui/**",


### PR DESCRIPTION
## 요약
- 챗봇 추천 기능에서 인증 없이 사용 가능하도록 memberId 의존성을 제거했습니다.

## 작업 내용
- `ChatbotRecommendationController`: @AuthenticationPrincipal 제거
- `ChatbotRecommendationService`: memberId 제거 및 AI 요청 변경
- `AiChatbotBaseInfoRequestDto`: memberId 필드 제거
- `HttpAiChatbotBaseInfoClient`, `FakeAiChatbotBaseInfoClient`: 변경된 Dto 반영