### PR TITLE
feat: 알림 조회 및 생성 기능 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/notification/application/service/NotificationCreateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/application/service/NotificationCreateService.java
@@ -1,0 +1,39 @@
+package ktb.leafresh.backend.domain.notification.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.notification.domain.entity.Notification;
+import ktb.leafresh.backend.domain.notification.domain.entity.enums.NotificationType;
+import ktb.leafresh.backend.domain.notification.infrastructure.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationCreateService {
+
+    private final NotificationRepository notificationRepository;
+
+    public void createChallengeVerificationResultNotification(
+            Member member,
+            String challengeName,
+            boolean isSuccess,
+            NotificationType type,
+            Long challengeId
+    ) {
+        String titlePrefix = (type == NotificationType.PERSONAL) ? "[개인]" : "[단체]";
+        String title = titlePrefix + " " + challengeName + " 인증 심사 결과가 도착했습니다.";
+        String content = isSuccess ? "인증이 승인되었습니다." : "반려되었습니다.";
+
+        Notification notification = Notification.builder()
+                .member(member)
+                .title(title)
+                .content(content)
+                .type(type)
+                .challengeId(challengeId)
+                .build();
+
+        notificationRepository.save(notification);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/notification/application/service/NotificationReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/application/service/NotificationReadService.java
@@ -1,0 +1,57 @@
+package ktb.leafresh.backend.domain.notification.application.service;
+
+import ktb.leafresh.backend.domain.notification.domain.entity.Notification;
+import ktb.leafresh.backend.domain.notification.infrastructure.repository.NotificationReadQueryRepository;
+import ktb.leafresh.backend.domain.notification.infrastructure.repository.NotificationRepository;
+import ktb.leafresh.backend.domain.notification.presentation.dto.response.NotificationDto;
+import ktb.leafresh.backend.global.util.pagination.CursorConditionUtils;
+import ktb.leafresh.backend.global.util.pagination.CursorPaginationHelper;
+import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationReadService {
+
+    private final NotificationReadQueryRepository notificationReadQueryRepository;
+    private final NotificationRepository notificationRepository;
+
+    @Transactional(readOnly = true)
+    public CursorPaginationResult<NotificationDto> getNotifications(Long memberId, Long cursorId, String cursorTimestamp, int size) {
+        LocalDateTime parsedTimestamp = CursorConditionUtils.parseTimestamp(cursorTimestamp);
+
+        List<Notification> notifications = notificationReadQueryRepository
+                .findAllWithCursorAndMemberId(parsedTimestamp, cursorId, size + 1, memberId);
+
+        return CursorPaginationHelper.paginateWithTimestamp(
+                notifications,
+                size,
+                NotificationDto::from,
+                NotificationDto::id,
+                NotificationDto::createdAt
+        );
+    }
+
+    @Transactional
+    public void markAllAsRead(Long memberId) {
+        List<Notification> unreadNotifications = notificationRepository.findByMemberIdAndStatusFalse(memberId);
+
+        if (unreadNotifications.isEmpty()) {
+            log.info("[알림 읽음 처리] memberId={} - 읽지 않은 알림 없음", memberId);
+            return;
+        }
+
+        log.info("[알림 읽음 처리 시작] memberId={}, 읽지 않은 알림 수={}", memberId, unreadNotifications.size());
+
+        unreadNotifications.forEach(Notification::markAsRead);
+
+        log.info("[알림 읽음 처리 완료] memberId={}", memberId);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/notification/domain/entity/Notification.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/domain/entity/Notification.java
@@ -22,13 +22,24 @@ public class Notification extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private NotificationType type;
+
+    @Column(name = "challenge_id", nullable = false)
+    private Long challengeId;
+
     @Column(nullable = false, length = 100)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    private NotificationType type;
+    @Column(name = "status", nullable = false)
+    @Builder.Default
+    private boolean status = false;
+
+    public void markAsRead() {
+        this.status = true;
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/notification/infrastructure/repository/NotificationReadQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/infrastructure/repository/NotificationReadQueryRepository.java
@@ -1,0 +1,10 @@
+package ktb.leafresh.backend.domain.notification.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.notification.domain.entity.Notification;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface NotificationReadQueryRepository {
+    List<Notification> findAllWithCursorAndMemberId(LocalDateTime cursorTimestamp, Long cursorId, int size, Long memberId);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/notification/infrastructure/repository/NotificationReadQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/infrastructure/repository/NotificationReadQueryRepositoryImpl.java
@@ -1,0 +1,32 @@
+package ktb.leafresh.backend.domain.notification.infrastructure.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import ktb.leafresh.backend.domain.notification.domain.entity.Notification;
+import ktb.leafresh.backend.domain.notification.domain.entity.QNotification;
+import ktb.leafresh.backend.global.util.pagination.CursorConditionUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationReadQueryRepositoryImpl implements NotificationReadQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QNotification n = QNotification.notification;
+
+    @Override
+    public List<Notification> findAllWithCursorAndMemberId(LocalDateTime cursorTimestamp, Long cursorId, int size, Long memberId) {
+        return queryFactory.selectFrom(n)
+                .where(
+                        n.deletedAt.isNull(),
+                        n.member.id.eq(memberId),
+                        CursorConditionUtils.ltCursorWithTimestamp(n.createdAt, n.id, cursorTimestamp, cursorId)
+                )
+                .orderBy(n.createdAt.desc(), n.id.desc())
+                .limit(size)
+                .fetch();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/notification/infrastructure/repository/NotificationRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/infrastructure/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package ktb.leafresh.backend.domain.notification.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.notification.domain.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByMemberIdAndStatusFalse(Long memberId);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/notification/presentation/controller/NotificationController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/presentation/controller/NotificationController.java
@@ -1,0 +1,58 @@
+package ktb.leafresh.backend.domain.notification.presentation.controller;
+
+import ktb.leafresh.backend.domain.notification.application.service.NotificationReadService;
+import ktb.leafresh.backend.domain.notification.presentation.dto.response.NotificationDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
+import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members/notifications")
+public class NotificationController {
+
+    private final NotificationReadService notificationReadService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<CursorPaginationResult<NotificationDto>>> getNotifications(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false) String cursorTimestamp,
+            @RequestParam(defaultValue = "12") int size
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        if ((cursorId == null) != (cursorTimestamp == null)) {
+            throw new CustomException(GlobalErrorCode.INVALID_CURSOR);
+        }
+
+        Long memberId = userDetails.getMemberId();
+
+        CursorPaginationResult<NotificationDto> result =
+                notificationReadService.getNotifications(memberId, cursorId, cursorTimestamp, size);
+
+        return ResponseEntity.ok(ApiResponse.success("알림 조회에 성공했습니다.", result));
+    }
+
+    @PatchMapping
+    public ResponseEntity<Void> markAllNotificationsAsRead(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        Long memberId = userDetails.getMemberId();
+        notificationReadService.markAllAsRead(memberId);
+
+        return ResponseEntity.noContent().build(); // 204
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/notification/presentation/dto/response/NotificationDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/presentation/dto/response/NotificationDto.java
@@ -1,0 +1,38 @@
+package ktb.leafresh.backend.domain.notification.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.notification.domain.entity.Notification;
+import ktb.leafresh.backend.domain.notification.domain.entity.enums.NotificationType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record NotificationDto(
+        Long id,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        boolean isRead,
+        NotificationType type,
+        Long challengeId
+) {
+    public static NotificationDto from(Notification entity) {
+        return NotificationDto.builder()
+                .id(entity.getId())
+                .title(entity.getTitle())
+                .content(entity.getContent())
+                .createdAt(entity.getCreatedAt())
+                .isRead(entity.isStatus())
+                .type(entity.getType())
+                .challengeId(entity.getChallengeId())
+                .build();
+    }
+
+    public LocalDateTime createdAt() {
+        return this.createdAt;
+    }
+
+    public Long id() {
+        return this.id;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultSaveService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultSaveService.java
@@ -1,5 +1,8 @@
 package ktb.leafresh.backend.domain.verification.application.service;
 
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.notification.application.service.NotificationCreateService;
+import ktb.leafresh.backend.domain.notification.domain.entity.enums.NotificationType;
 import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
 import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
 import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
@@ -17,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PersonalChallengeVerificationResultSaveService {
 
     private final PersonalChallengeVerificationRepository verificationRepository;
+    private final NotificationCreateService notificationCreateService;
 
     @Transactional
     public void saveResult(Long verificationId, VerificationResultRequestDto dto) {
@@ -32,5 +36,20 @@ public class PersonalChallengeVerificationResultSaveService {
         verification.markVerified(newStatus);
 
         log.info("[인증 결과 저장 완료] verificationId={}, status={}", verificationId, newStatus);
+
+        Member member = verification.getMember();
+        String challengeTitle = verification.getPersonalChallenge().getTitle();
+
+        log.info("[알림 생성 시작] memberId={}, challengeTitle={}", member.getId(), challengeTitle);
+
+        notificationCreateService.createChallengeVerificationResultNotification(
+                member,
+                challengeTitle,
+                dto.result(),
+                NotificationType.PERSONAL,
+                verification.getPersonalChallenge().getId()
+        );
+
+        log.info("[알림 생성 완료]");
     }
 }


### PR DESCRIPTION
## 주요 변경사항
- 알림 도메인 관련 기능 추가
  - 로그인된 유저의 알림 목록 조회 (커서 기반 페이징)
  - 인증 결과 수신 시 알림 생성 기능
  - 전체 알림 읽음 처리 API

- 알림 테이블 필드 확장
  - challengeId, status 컬럼 추가

## 추가 참고사항
- SSE 미도입 상태 기준 전체 읽음 처리 방식
- 향후 SSE 도입 시 부분 업데이트 고려 필요
