### PR TITLE
Feat/improve ai response logging and error handling

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/EventChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/EventChallengeReadService.java
@@ -3,6 +3,8 @@ package ktb.leafresh.backend.domain.challenge.group.application.service;
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.EventChallengeResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,10 +22,14 @@ public class EventChallengeReadService {
     private final GroupChallengeRepository groupChallengeRepository;
 
     public List<EventChallengeResponseDto> getEventChallenges() {
-        LocalDateTime now = LocalDateTime.now();
-        List<GroupChallenge> challenges = groupChallengeRepository.findOngoingEventChallenges(now);
-        return challenges.stream()
-                .map(EventChallengeResponseDto::from)
-                .collect(toList());
+        try {
+            LocalDateTime now = LocalDateTime.now();
+            List<GroupChallenge> challenges = groupChallengeRepository.findOngoingEventChallenges(now);
+            return challenges.stream()
+                    .map(EventChallengeResponseDto::from)
+                    .collect(toList());
+        } catch (Exception e) {
+            throw new CustomException(ChallengeErrorCode.EVENT_CHALLENGE_READ_FAILED);
+        }
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeParticipationRecordQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeParticipationRecordQueryRepositoryImpl.java
@@ -3,6 +3,7 @@ package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
@@ -91,9 +92,13 @@ public class GroupChallengeParticipationRecordQueryRepositoryImpl implements Gro
                                 "success"
                         ),
                         ExpressionUtils.as(
-                                JPAExpressions.select(verification.count())
-                                        .from(verification)
-                                        .where(verification.participantRecord.eq(record)),
+                                JPAExpressions.select(
+                                        Expressions.numberTemplate(Long.class,
+                                                "DATEDIFF({0}, {1}) + 1",
+                                                challenge.endDate,
+                                                record.createdAt
+                                        )
+                                ),
                                 "total"
                         ),
                         challenge.createdAt
@@ -116,7 +121,7 @@ public class GroupChallengeParticipationRecordQueryRepositoryImpl implements Gro
         return switch (status.toLowerCase()) {
             case "not_started" -> challenge.startDate.gt(now);
             case "ongoing" -> challenge.startDate.loe(now).and(challenge.endDate.goe(now));
-            case "ended" -> challenge.endDate.lt(now).or(record.status.eq(FINISHED));
+            case "completed" -> challenge.endDate.lt(now).or(record.status.eq(FINISHED));
             default -> throw new CustomException(GlobalErrorCode.INVALID_REQUEST);
         };
     }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeReadService.java
@@ -28,26 +28,34 @@ public class PersonalChallengeReadService {
     private final PersonalChallengeVerificationRepository verificationRepository;
 
     public PersonalChallengeListResponseDto getByDayOfWeek(DayOfWeek dayOfWeek) {
-        List<PersonalChallenge> challenges = repository.findAllByDayOfWeek(dayOfWeek);
+        try {
+            List<PersonalChallenge> challenges = repository.findAllByDayOfWeek(dayOfWeek);
 
-        if (challenges.isEmpty()) {
-            throw new CustomException(ChallengeErrorCode.PERSONAL_CHALLENGE_EMPTY);
+            if (challenges.isEmpty()) {
+                throw new CustomException(ChallengeErrorCode.PERSONAL_CHALLENGE_EMPTY);
+            }
+
+            return new PersonalChallengeListResponseDto(PersonalChallengeSummaryDto.fromEntities(challenges));
+        } catch (Exception e) {
+            throw new CustomException(ChallengeErrorCode.PERSONAL_CHALLENGE_READ_FAILED);
         }
-
-        return new PersonalChallengeListResponseDto(PersonalChallengeSummaryDto.fromEntities(challenges));
     }
 
     public PersonalChallengeDetailResponseDto getChallengeDetail(Long memberIdOrNull, Long challengeId) {
-        PersonalChallenge challenge = repository.findById(challengeId)
-                .orElseThrow(() -> new CustomException(ChallengeErrorCode.PERSONAL_CHALLENGE_NOT_FOUND));
+        try {
+            PersonalChallenge challenge = repository.findById(challengeId)
+                    .orElseThrow(() -> new CustomException(ChallengeErrorCode.PERSONAL_CHALLENGE_NOT_FOUND));
 
-        List<PersonalChallengeExampleImageDto> exampleImages = challenge.getExampleImages().stream()
-                .map(PersonalChallengeExampleImageDto::from)
-                .toList();
+            List<PersonalChallengeExampleImageDto> exampleImages = challenge.getExampleImages().stream()
+                    .map(PersonalChallengeExampleImageDto::from)
+                    .toList();
 
-        ChallengeStatus status = resolveChallengeStatus(memberIdOrNull, challengeId);
+            ChallengeStatus status = resolveChallengeStatus(memberIdOrNull, challengeId);
 
-        return PersonalChallengeDetailResponseDto.of(challenge, exampleImages, status);
+            return PersonalChallengeDetailResponseDto.of(challenge, exampleImages, status);
+        } catch (Exception e) {
+            throw new CustomException(ChallengeErrorCode.PERSONAL_CHALLENGE_DETAIL_READ_FAILED);
+        }
     }
 
     private ChallengeStatus resolveChallengeStatus(Long memberIdOrNull, Long challengeId) {

--- a/src/main/java/ktb/leafresh/backend/global/exception/ChallengeErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/ChallengeErrorCode.java
@@ -10,6 +10,7 @@ public enum ChallengeErrorCode implements BaseErrorCode {
     CHALLENGE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "챌린지 삭제 권한이 없습니다."),
 
     // 단체
+    EVENT_CHALLENGE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 이벤트 챌린지 목록 조회에 실패했습니다."),
     CHALLENGE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 챌린지 카테고리입니다."),
     GROUP_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "단체 챌린지를 찾을 수 없습니다."),
     GROUP_CHALLENGE_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "참여 기록이 존재하지 않습니다."),
@@ -24,9 +25,15 @@ public enum ChallengeErrorCode implements BaseErrorCode {
     CHALLENGE_ALREADY_DROPPED(HttpStatus.BAD_REQUEST, "이미 취소된 참여 이력입니다."),
 
     // 개인
+    PERSONAL_CHALLENGE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 개인 챌린지 목록 조회에 실패했습니다."),
     EXCEEDS_DAILY_PERSONAL_CHALLENGE_LIMIT(HttpStatus.BAD_REQUEST, "요일별 챌린지는 최대 3개까지만 등록할 수 있습니다."),
-    PERSONAL_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "개인 챌린지를 찾을 수 없습니다."),
-    PERSONAL_CHALLENGE_EMPTY(HttpStatus.NOT_FOUND, "현재 등록된 개인 챌린지가 없습니다.");
+    PERSONAL_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 개인 챌린지를 찾을 수 없습니다."),
+    PERSONAL_CHALLENGE_EMPTY(HttpStatus.NOT_FOUND, "현재 등록된 개인 챌린지가 없습니다."),
+    PERSONAL_CHALLENGE_DETAIL_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 개인 챌린지 상세 조회에 실패했습니다."),
+    PERSONAL_CHALLENGE_DETAIL_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "현재 개인 챌린지 상세 정보를 불러올 수 없습니다. 잠시 후 다시 시도해주세요."),
+    PERSONAL_CHALLENGE_RULE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 인증 규약을 조회하지 못했습니다."),
+    PERSONAL_CHALLENGE_RULE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 챌린지에 참여 중인 사용자가 아닙니다."),
+    PERSONAL_CHALLENGE_RULE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 챌린지입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/ktb/leafresh/backend/global/exception/GlobalErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/GlobalErrorCode.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum GlobalErrorCode implements BaseErrorCode {
 
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 요청을 처리할 수 없습니다."),
     INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 JSON 형식입니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
@@ -12,7 +13,9 @@ public enum GlobalErrorCode implements BaseErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "저장된 리프레시 토큰이 없습니다."),
-    INVALID_CURSOR(HttpStatus.BAD_REQUEST, "cursorId와 cursorTimestamp는 반드시 함께 전달되어야 합니다.");
+    INVALID_CURSOR(HttpStatus.BAD_REQUEST, "cursorId와 cursorTimestamp는 반드시 함께 전달되어야 합니다."),
+    UNSUPPORTED_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 Content-Type입니다."),
+    INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 이미지 URL입니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 주요 변경 사항
- 챌린지 예외 처리 개선
  - `PersonalChallengeReadService`, `EventChallengeReadService`에 try-catch 및 커스텀 예외 적용
  - `ChallengeErrorCode`, `GlobalErrorCode`에 관련 항목 추가

- 단체 챌린지 참여 기간 계산 쿼리 개선
  - QueryDSL을 사용한 날짜 차이 계산으로 변경 (DATE_DIFF)

## 목적
- 챌린지 조회 도중 발생하는 NPE/빈 리스트 등 예외 상황에 대한 사용자 응답 명확화
- QueryDSL 로직 개선을 통한 기간 계산 정확도 및 유지보수성 향상
