### PR TITLE
chore: application.yml 내 GCP 설정 제거 (bigbang.yml에 포함됨)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,10 +60,3 @@ cookie:
 
 ai-server:
   base-url: ${ai_server_base_url}
-
-gcp:
-  project-id: your-gcp-project-id
-  credentials:
-    location: classpath:your-service-account-key.json
-  storage:
-    bucket: your-bucket-name


### PR DESCRIPTION
## 변경 내용
- `application.yml` 내 GCP 설정 블록 제거
  - `gcp.project-id`
  - `gcp.credentials.location`
  - `gcp.storage.bucket`

## 사유
- 동일한 설정이 `application-bigbang.yml`에 포함되어 있어 중복 제거
- 공통 설정 파일에 불필요한 정보가 존재하지 않도록 정리하여 유지보수성 향상