### PR TITLE
feat: 알림에 인증 이미지(imageUrl) 포함 기능 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/notification/application/service/NotificationCreateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/application/service/NotificationCreateService.java
@@ -20,6 +20,7 @@ public class NotificationCreateService {
             String challengeName,
             boolean isSuccess,
             NotificationType type,
+            String imageUrl,
             Long challengeId
     ) {
         String titlePrefix = (type == NotificationType.PERSONAL) ? "[개인]" : "[단체]";
@@ -31,6 +32,7 @@ public class NotificationCreateService {
                 .title(title)
                 .content(content)
                 .type(type)
+                .imageUrl(imageUrl)
                 .challengeId(challengeId)
                 .build();
 

--- a/src/main/java/ktb/leafresh/backend/domain/notification/domain/entity/Notification.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/domain/entity/Notification.java
@@ -39,6 +39,9 @@ public class Notification extends BaseEntity {
     @Builder.Default
     private boolean status = false;
 
+    @Column(nullable = false, length = 512)
+    private String imageUrl;
+
     public void markAsRead() {
         this.status = true;
     }

--- a/src/main/java/ktb/leafresh/backend/domain/notification/presentation/dto/response/NotificationDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/presentation/dto/response/NotificationDto.java
@@ -14,6 +14,7 @@ public record NotificationDto(
         LocalDateTime createdAt,
         boolean isRead,
         NotificationType type,
+        String imageUrl,
         Long challengeId
 ) {
     public static NotificationDto from(Notification entity) {
@@ -24,6 +25,7 @@ public record NotificationDto(
                 .createdAt(entity.getCreatedAt())
                 .isRead(entity.isStatus())
                 .type(entity.getType())
+                .imageUrl(entity.getImageUrl())
                 .challengeId(entity.getChallengeId())
                 .build();
     }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultSaveService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultSaveService.java
@@ -48,6 +48,7 @@ public class GroupChallengeVerificationResultSaveService {
                 challengeTitle,
                 dto.result(),
                 NotificationType.GROUP,
+                verification.getImageUrl(),
                 verification.getParticipantRecord().getGroupChallenge().getId()
         );
 

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultSaveService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultSaveService.java
@@ -47,6 +47,7 @@ public class PersonalChallengeVerificationResultSaveService {
                 challengeTitle,
                 dto.result(),
                 NotificationType.PERSONAL,
+                verification.getImageUrl(),
                 verification.getPersonalChallenge().getId()
         );
 


### PR DESCRIPTION
- 인증 결과 알림에 인증 사진 URL(imageUrl)을 포함할 수 있도록 전체 구조를 수정했습니다.
- Notification 엔티티에 imageUrl 컬럼을 추가하고, Dto 및 ReadService에 반영했습니다.
- Personal/GroupChallengeVerificationResultSaveService에서 imageUrl을 전달하도록 수정했습니다.
- NotificationCreateService는 새로운 imageUrl 파라미터를 받아 저장 시 포함되도록 개선했습니다.
