### PR TITLE
refactor: 단체 챌린지 목록 조회 API category 파라미터 enum 방식으로 변경

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeSearchReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeSearchReadService.java
@@ -4,9 +4,6 @@ import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.enums.GroupChallengeCategoryName;
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.*;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.*;
-import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
-import ktb.leafresh.backend.global.exception.CustomException;
-import ktb.leafresh.backend.global.exception.GlobalErrorCode;
 import ktb.leafresh.backend.global.util.pagination.CursorPaginationHelper;
 import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
 import lombok.RequiredArgsConstructor;
@@ -25,13 +22,9 @@ public class GroupChallengeSearchReadService {
     private final GroupChallengeSearchQueryRepository searchRepository;
 
     public CursorPaginationResult<GroupChallengeSummaryDto> getGroupChallenges(
-            String input, String category, Long cursorId, String cursorTimestamp, int size) {
+            String input, GroupChallengeCategoryName category, Long cursorId, String cursorTimestamp, int size) {
 
-        if (category == null || category.trim().isEmpty()) {
-            throw new CustomException(GlobalErrorCode.INVALID_REQUEST);
-        }
-
-        String internalCategoryName = resolveCategoryNameOrThrow(category);
+        String internalCategoryName = (category != null) ? category.name() : null;
 
         List<GroupChallenge> challenges = searchRepository
                 .findByFilter(input, internalCategoryName, cursorId, cursorTimestamp, size + 1);
@@ -43,13 +36,5 @@ public class GroupChallengeSearchReadService {
                 GroupChallengeSummaryDto::id,
                 GroupChallengeSummaryDto::createdAt
         );
-    }
-
-    private String resolveCategoryNameOrThrow(String label) {
-        String name = GroupChallengeCategoryName.toEnglish(label);
-        if (name == null) {
-            throw new CustomException(ChallengeErrorCode.CHALLENGE_CATEGORY_NOT_FOUND);
-        }
-        return name;
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/enums/GroupChallengeCategoryName.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/enums/GroupChallengeCategoryName.java
@@ -1,7 +1,5 @@
 package ktb.leafresh.backend.domain.challenge.group.domain.entity.enums;
 
-import java.util.Arrays;
-
 public enum GroupChallengeCategoryName {
 
     ZERO_WASTE("제로웨이스트"),
@@ -22,14 +20,6 @@ public enum GroupChallengeCategoryName {
 
     public String getLabel() {
         return label;
-    }
-
-    public static String toEnglish(String koreanInput) {
-        return Arrays.stream(values())
-                .filter(v -> v.label.equals(koreanInput))
-                .map(Enum::name)
-                .findFirst()
-                .orElse(null);
     }
 
     public static String getImageUrl(String name) {

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeManageController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeManageController.java
@@ -2,6 +2,7 @@ package ktb.leafresh.backend.domain.challenge.group.presentation.controller;
 
 import jakarta.validation.Valid;
 import ktb.leafresh.backend.domain.challenge.group.application.service.*;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.enums.GroupChallengeCategoryName;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.*;
@@ -32,7 +33,7 @@ public class GroupChallengeManageController {
     @GetMapping
     public ResponseEntity<ApiResponse<CursorPaginationResult<GroupChallengeSummaryDto>>> getGroupChallenges(
             @RequestParam(required = false) String input,
-            @RequestParam(required = false) String category,
+            @RequestParam(required = false) GroupChallengeCategoryName category,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(required = false) String cursorTimestamp,
             @RequestParam(defaultValue = "12") int size


### PR DESCRIPTION
## 변경 내용
- 단체 챌린지 목록 조회 시 `category` 파라미터를 더 이상 한글 label로 받지 않고, `GroupChallengeCategoryName` enum 값으로 직접 바인딩하도록 변경
- 이에 따라 기존의 `toEnglish()` 메서드 제거 및 서비스 계층 변환 로직도 함께 삭제
- Controller, Service에 모두 enum 기반 구조 반영

## 참고 사항
- 프론트에서도 category를 `"기타"` → `"ETC"` 형식으로 요청해야 하며, 잘못된 enum 값 전달 시 자동으로 400 Bad Request 처리됩니다.
