### PR TITLE
.env.bigbang 파일 환경별(local/prod)로 분리 및 .gitignore 업데이트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,8 @@ out/
 
 ### .env ###
 .env.local
-.env.bigbang
+.env.bigbang-local
+.env.bigbang-prod
 .env.docker-local
 .env.docker-prod
 .env.eks-local


### PR DESCRIPTION
## 변경 사항
- `.env.bigbang` 단일 파일을 `.env.bigbang-local`, `.env.bigbang-prod`로 환경별 분리
- 각 환경에 맞는 세팅을 명확히 분리하여 혼동 방지 및 협업 효율 향상
- `.gitignore`에 두 파일을 명시적으로 추가하여 git 추적 방지

## 작업 배경
- 여러 환경에서 동일 파일을 공유하면서 충돌/덮어쓰기 문제 발생
- 배포 스크립트에서 명확한 환경 구분을 위해 사전 정비