### PR TITLE
config: application-local.yml 환경변수 기반 쿠키 설정 및 GCP 설정 추가

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,4 +12,11 @@ spring:
 
 cookie:
   secure: false
-  samesite: Lax
+  samesite: ${cookie_samesite:none}
+
+gcp:
+  project-id: ${gcp_project_id}
+  credentials:
+    location: classpath:${gcp_credentials_location}
+  storage:
+    bucket: ${gcp_storage_bucket}


### PR DESCRIPTION
- samesite 값을 하드코딩된 'Lax'에서 환경변수 `${cookie_samesite}` 기반으로 변경 (유연한 설정 대응 목적)
- GCP 관련 설정 추가:
  - project-id, credentials 경로, storage bucket 정보
- 향후 로컬에서도 GCS 연동 및 Presigned URL 기능 활용 가능하도록 구성
