### PR TITLE
feat: 개인/단체 챌린지 인증 보상 및 기간 완료 보너스 지급 로직 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/GroupChallenge.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/GroupChallenge.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -123,5 +124,9 @@ public class GroupChallenge extends BaseEntity {
 
     public boolean isFull() {
         return this.currentParticipantCount >= this.maxParticipantCount;
+    }
+
+    public int getDurationInDays() {
+        return (int) ChronoUnit.DAYS.between(this.startDate, this.endDate) + 1;
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/GroupChallengeParticipantRecord.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/GroupChallengeParticipantRecord.java
@@ -5,6 +5,7 @@ import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVeri
 import jakarta.persistence.*;
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.global.common.entity.BaseEntity;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
 import ktb.leafresh.backend.global.common.entity.enums.ParticipantStatus;
 import lombok.*;
 
@@ -40,6 +41,14 @@ public class GroupChallengeParticipantRecord extends BaseEntity {
     @Column(nullable = false, length = 20)
     private ParticipantStatus status;
 
+    @Column(name = "bonus_rewarded", nullable = false)
+    private boolean bonusRewarded;
+
+    @PrePersist
+    public void prePersist() {
+        this.bonusRewarded = false;
+    }
+
     public void changeStatus(ParticipantStatus newStatus) {
         this.status = newStatus;
     }
@@ -54,5 +63,18 @@ public class GroupChallengeParticipantRecord extends BaseEntity {
 
     public boolean isActive() {
         return this.status == ParticipantStatus.ACTIVE;
+    }
+
+    public boolean isAllSuccess() {
+        return this.getVerifications().stream()
+                .allMatch(v -> v.getStatus() == ChallengeStatus.SUCCESS);
+    }
+
+    public boolean hasReceivedParticipationBonus() {
+        return bonusRewarded;
+    }
+
+    public void markParticipationBonusRewarded() {
+        this.bonusRewarded = true;
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/RewardGrantService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/RewardGrantService.java
@@ -1,0 +1,51 @@
+package ktb.leafresh.backend.domain.member.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class RewardGrantService {
+
+    private static final int SIGNUP_REWARD = 1500;
+    private static final int DAILY_LOGIN_REWARD = 10;
+
+    public void grantLeafPoints(Member member, int points) {
+        member.addLeafPoints(points);
+        log.info("[나뭇잎 지급] memberId={}, 지급량={}, 현재={}, 누적={}",
+                member.getId(), points, member.getCurrentLeafPoints(), member.getTotalLeafPoints());
+    }
+
+    public void grantParticipationBonus(Member member, GroupChallengeParticipantRecord record) {
+        int days = record.getGroupChallenge().getDurationInDays();
+        int bonus = calculateBonus(days);
+        grantLeafPoints(member, bonus);
+        log.info("[전체 인증 성공 보너스 지급] memberId={}, days={}, bonus={}", member.getId(), days, bonus);
+    }
+
+    public void grantSignupReward(Member member) {
+        grantLeafPoints(member, SIGNUP_REWARD);
+        log.info("[회원가입 보상 지급] memberId={}, 보상={}", member.getId(), SIGNUP_REWARD);
+    }
+
+    public void grantDailyLoginReward(Member member) {
+        if (member.hasReceivedLoginRewardToday()) {
+            log.info("[일일 로그인 보상 스킵] 오늘 이미 보상받은 사용자입니다. memberId={}", member.getId());
+            return;
+        }
+
+        grantLeafPoints(member, DAILY_LOGIN_REWARD);
+        member.updateLastLoginRewardedAt();
+        log.info("[일일 로그인 보상 지급] memberId={}, 보상={}, 현재={}, 누적={}",
+                member.getId(), DAILY_LOGIN_REWARD, member.getCurrentLeafPoints(), member.getTotalLeafPoints());
+    }
+
+    private int calculateBonus(int days) {
+        if (days <= 5) return 50;
+        else if (days <= 10) return 100;
+        else if (days <= 15) return 150;
+        else return 200;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/Member.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/Member.java
@@ -21,6 +21,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -105,10 +107,27 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private Integer currentLeafPoints;
 
+    @Column(name = "last_login_rewarded_at")
+    private LocalDateTime lastLoginRewardedAt;
+
     @PrePersist
     public void prePersist() {
         if (activated == null) activated = true;
         if (totalLeafPoints == null) totalLeafPoints = 0;
         if (currentLeafPoints == null) currentLeafPoints = 0;
+    }
+
+    public void addLeafPoints(int amount) {
+        this.currentLeafPoints += amount;
+        this.totalLeafPoints += amount;
+    }
+
+    public boolean hasReceivedLoginRewardToday() {
+        return lastLoginRewardedAt != null &&
+                lastLoginRewardedAt.toLocalDate().isEqual(LocalDate.now());
+    }
+
+    public void updateLastLoginRewardedAt() {
+        this.lastLoginRewardedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultSaveService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultSaveService.java
@@ -1,5 +1,8 @@
 package ktb.leafresh.backend.domain.verification.application.service;
 
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.member.application.service.RewardGrantService;
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.notification.application.service.NotificationCreateService;
 import ktb.leafresh.backend.domain.notification.domain.entity.enums.NotificationType;
@@ -21,6 +24,7 @@ public class GroupChallengeVerificationResultSaveService {
 
     private final GroupChallengeVerificationRepository groupVerificationRepository;
     private final NotificationCreateService notificationCreateService;
+    private final RewardGrantService rewardGrantService;
 
     @Transactional
     public void saveResult(Long verificationId, VerificationResultRequestDto dto) {
@@ -28,30 +32,45 @@ public class GroupChallengeVerificationResultSaveService {
 
         GroupChallengeVerification verification = groupVerificationRepository.findById(verificationId)
                 .orElseThrow(() -> {
-                    log.error("[단체 인증 결과 저장 실패] verificationId={}에 해당하는 인증이 존재하지 않음", verificationId);
-                    return new CustomException(VerificationErrorCode.VERIFICATION_NOT_FOUND);
+                    log.error("[단체 인증 결과 저장 실패] verificationId={} 존재하지 않음", verificationId);
+                    throw new CustomException(VerificationErrorCode.VERIFICATION_NOT_FOUND);
                 });
 
         ChallengeStatus newStatus = dto.result() ? ChallengeStatus.SUCCESS : ChallengeStatus.FAILURE;
         verification.markVerified(newStatus);
-
-        log.info("[단체 인증 결과 저장 완료] verificationId={}, status={}", verificationId, newStatus);
-        log.info("[단체 인증 상태 업데이트 완료] verificationId={}, newStatus={}", verificationId, newStatus);
+        log.info("[상태 업데이트 완료] verificationId={}, newStatus={}", verificationId, newStatus);
 
         Member member = verification.getParticipantRecord().getMember();
-        String challengeTitle = verification.getParticipantRecord().getGroupChallenge().getTitle();
-
-        log.info("[알림 생성 시작] memberId={}, challengeTitle={}", member.getId(), challengeTitle);
+        GroupChallengeParticipantRecord record = verification.getParticipantRecord();
+        GroupChallenge challenge = record.getGroupChallenge();
 
         notificationCreateService.createChallengeVerificationResultNotification(
                 member,
-                challengeTitle,
+                challenge.getTitle(),
                 dto.result(),
                 NotificationType.GROUP,
                 verification.getImageUrl(),
-                verification.getParticipantRecord().getGroupChallenge().getId()
+                challenge.getId()
         );
+        log.info("[알림 생성 완료] memberId={}, challengeTitle={}", member.getId(), challenge.getTitle());
 
-        log.info("[알림 생성 완료]");
+        // 1차 보상: 인증 성공 + 미보상 시 지급
+        if (dto.result() && !verification.isRewarded()) {
+            int reward = challenge.getLeafReward();
+            rewardGrantService.grantLeafPoints(member, reward);
+            verification.markRewarded();
+            log.info("[1차 보상 지급 완료] memberId={}, reward={}", member.getId(), reward);
+        }
+
+        // 2차 보상: 전체 성공 + 기간 일수만큼 인증 존재 + 미지급 시 지급
+        if (record.isAllSuccess()
+                && record.getVerifications().size() == challenge.getDurationInDays()
+                && !record.hasReceivedParticipationBonus()) {
+            rewardGrantService.grantParticipationBonus(member, record);
+            record.markParticipationBonusRewarded();
+            log.info("[2차 보너스 지급 완료] memberId={}, bonusGranted=true", member.getId());
+        }
+
+        log.info("[단체 인증 결과 저장 로직 완료] verificationId={}", verificationId);
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/domain/entity/GroupChallengeVerification.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/domain/entity/GroupChallengeVerification.java
@@ -37,12 +37,24 @@ public class GroupChallengeVerification extends BaseEntity {
     @Column(name = "verified_at")
     private LocalDateTime verifiedAt;
 
+    @Column(nullable = false)
+    private boolean rewarded;
+
+    @PrePersist
+    public void prePersist() {
+        this.rewarded = false;
+    }
+
     public void markVerified(ChallengeStatus status) {
         this.status = status;
         this.verifiedAt = LocalDateTime.now();
     }
 
-    public boolean isFinalized() {
-        return this.status != ChallengeStatus.PENDING_APPROVAL;
+    public boolean isRewarded() {
+        return this.rewarded;
+    }
+
+    public void markRewarded() {
+        this.rewarded = true;
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/domain/entity/PersonalChallengeVerification.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/domain/entity/PersonalChallengeVerification.java
@@ -48,12 +48,24 @@ public class PersonalChallengeVerification extends BaseEntity {
     @Column(name = "verified_at")
     private LocalDateTime verifiedAt;
 
+    @Column(nullable = false)
+    private boolean rewarded;
+
+    @PrePersist
+    public void prePersist() {
+        this.rewarded = false;
+    }
+
     public void markVerified(ChallengeStatus status) {
         this.status = status;
         this.verifiedAt = LocalDateTime.now();
     }
 
-    public boolean isFinalized() {
-        return this.status != ChallengeStatus.PENDING_APPROVAL;
+    public boolean isRewarded() {
+        return this.rewarded;
+    }
+
+    public void markRewarded() {
+        this.rewarded = true;
     }
 }


### PR DESCRIPTION
- 개인 챌린지 및 단체 챌린지 인증 성공 시 나뭇잎 포인트 지급 로직 추가
  - 인증 단건 성공 시 기본 보상 지급
  - 챌린지 기간 내 전체 인증 완료 시 추가 보너스 지급

- 관련 엔티티 필드 및 메서드 수정:
  - 인증 기록(Verification) 및 참가 기록(ParticipantRecord)에 보상 상태 업데이트
  - 인증 성공/보상 지급 여부 판단을 위한 메서드 추가

- Member 엔티티에 리워드 지급 연동