### PR TITLE
refactor: 커서 기반 페이지네이션 응답 도메인별 네이밍 적용 및 DTO 구조 개선

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCreatedReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCreatedReadService.java
@@ -20,7 +20,7 @@ public class GroupChallengeCreatedReadService {
 
     private final GroupChallengeCreatedQueryRepository createdRepository;
 
-    public CursorPaginationResult<GroupChallengeSummaryDto> getCreatedChallengesByMember(
+    public CursorPaginationResult<CreatedGroupChallengeSummaryResponseDto> getCreatedChallengesByMember(
             Long memberId, Long cursorId, String cursorTimestamp, int size
     ) {
         List<GroupChallenge> entities =
@@ -29,9 +29,9 @@ public class GroupChallengeCreatedReadService {
         return CursorPaginationHelper.paginateWithTimestamp(
                 entities,
                 size,
-                GroupChallengeSummaryDto::from,
-                GroupChallengeSummaryDto::id,
-                GroupChallengeSummaryDto::createdAt
+                CreatedGroupChallengeSummaryResponseDto::from,
+                CreatedGroupChallengeSummaryResponseDto::id,
+                CreatedGroupChallengeSummaryResponseDto::createdAt
         );
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeSearchReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeSearchReadService.java
@@ -21,7 +21,7 @@ public class GroupChallengeSearchReadService {
 
     private final GroupChallengeSearchQueryRepository searchRepository;
 
-    public CursorPaginationResult<GroupChallengeSummaryDto> getGroupChallenges(
+    public CursorPaginationResult<GroupChallengeSummaryResponseDto> getGroupChallenges(
             String input, GroupChallengeCategoryName category, Long cursorId, String cursorTimestamp, int size) {
 
         String internalCategoryName = (category != null) ? category.name() : null;
@@ -32,9 +32,9 @@ public class GroupChallengeSearchReadService {
         return CursorPaginationHelper.paginateWithTimestamp(
                 challenges,
                 size,
-                GroupChallengeSummaryDto::from,
-                GroupChallengeSummaryDto::id,
-                GroupChallengeSummaryDto::createdAt
+                GroupChallengeSummaryResponseDto::from,
+                GroupChallengeSummaryResponseDto::id,
+                GroupChallengeSummaryResponseDto::createdAt
         );
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeVerificationReadController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeVerificationReadController.java
@@ -5,9 +5,11 @@ import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.*;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.GlobalErrorCode;
 import ktb.leafresh.backend.global.response.ApiResponse;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
 import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -36,8 +38,13 @@ public class GroupChallengeVerificationReadController {
 
     @GetMapping("/rules")
     public ResponseEntity<ApiResponse<GroupChallengeRuleResponseDto>> getGroupChallengeRules(
-            @PathVariable Long challengeId
+            @PathVariable Long challengeId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        if (userDetails == null) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
         GroupChallengeRuleResponseDto response = groupChallengeVerificationReadService.getChallengeRules(challengeId);
         return ResponseEntity.ok(ApiResponse.success("단체 챌린지 인증 규약 정보를 성공적으로 조회했습니다.", response));
     }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/CreatedGroupChallengeListResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/CreatedGroupChallengeListResponseDto.java
@@ -7,13 +7,13 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
-public record GroupChallengeListResponseDto(
-        List<GroupChallengeSummaryResponseDto> groupChallenges,
+public record CreatedGroupChallengeListResponseDto(
+        List<CreatedGroupChallengeSummaryResponseDto> groupChallenges,
         boolean hasNext,
         CursorInfo cursorInfo
 ) {
-    public static GroupChallengeListResponseDto from(CursorPaginationResult<GroupChallengeSummaryResponseDto> result) {
-        return new GroupChallengeListResponseDto(
+    public static CreatedGroupChallengeListResponseDto from(CursorPaginationResult<CreatedGroupChallengeSummaryResponseDto> result) {
+        return new CreatedGroupChallengeListResponseDto(
                 result.items(),
                 result.hasNext(),
                 result.cursorInfo()

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/CreatedGroupChallengeSummaryResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/CreatedGroupChallengeSummaryResponseDto.java
@@ -1,0 +1,42 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record CreatedGroupChallengeSummaryResponseDto(
+        Long id,
+        String name,
+        String description,
+        String startDate,
+        String endDate,
+        String imageUrl,
+        int currentParticipantCount,
+        @JsonIgnore
+        LocalDateTime createdAt
+) {
+    public static CreatedGroupChallengeSummaryResponseDto from(GroupChallenge entity) {
+        return CreatedGroupChallengeSummaryResponseDto.builder()
+                .id(entity.getId())
+                .name(entity.getTitle())
+                .description(entity.getDescription())
+                .startDate(entity.getStartDate().toLocalDate().toString())
+                .endDate(entity.getEndDate().toLocalDate().toString())
+                .imageUrl(entity.getImageUrl())
+                .currentParticipantCount(entity.getCurrentParticipantCount())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+
+    public static List<CreatedGroupChallengeSummaryResponseDto> fromEntities(List<GroupChallenge> entities) {
+        return entities.stream().map(CreatedGroupChallengeSummaryResponseDto::from).toList();
+    }
+
+    public LocalDateTime createdAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeSummaryResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeSummaryResponseDto.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
-public record GroupChallengeSummaryDto(
+public record GroupChallengeSummaryResponseDto(
         Long id,
         String title,
         String thumbnailUrl,
@@ -19,10 +19,10 @@ public record GroupChallengeSummaryDto(
         int currentParticipantCount,
         LocalDateTime createdAt
 ) {
-    public static GroupChallengeSummaryDto from(GroupChallenge entity) {
+    public static GroupChallengeSummaryResponseDto from(GroupChallenge entity) {
         int remainingDay = GroupChallengeRemainingDayCalculator.calculate(entity.getStartDate().toLocalDate());
 
-        return GroupChallengeSummaryDto.builder()
+        return GroupChallengeSummaryResponseDto.builder()
                 .id(entity.getId())
                 .title(entity.getTitle())
                 .thumbnailUrl(entity.getImageUrl())
@@ -35,8 +35,8 @@ public record GroupChallengeSummaryDto(
                 .build();
     }
 
-    public static List<GroupChallengeSummaryDto> fromEntities(List<GroupChallenge> entities) {
-        return entities.stream().map(GroupChallengeSummaryDto::from).toList();
+    public static List<GroupChallengeSummaryResponseDto> fromEntities(List<GroupChallenge> entities) {
+        return entities.stream().map(GroupChallengeSummaryResponseDto::from).toList();
     }
 
     public LocalDateTime createdAt() {

--- a/src/main/java/ktb/leafresh/backend/domain/notification/application/service/NotificationReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/application/service/NotificationReadService.java
@@ -3,7 +3,7 @@ package ktb.leafresh.backend.domain.notification.application.service;
 import ktb.leafresh.backend.domain.notification.domain.entity.Notification;
 import ktb.leafresh.backend.domain.notification.infrastructure.repository.NotificationReadQueryRepository;
 import ktb.leafresh.backend.domain.notification.infrastructure.repository.NotificationRepository;
-import ktb.leafresh.backend.domain.notification.presentation.dto.response.NotificationDto;
+import ktb.leafresh.backend.domain.notification.presentation.dto.response.NotificationSummaryResponse;
 import ktb.leafresh.backend.global.util.pagination.CursorConditionUtils;
 import ktb.leafresh.backend.global.util.pagination.CursorPaginationHelper;
 import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
@@ -24,7 +24,7 @@ public class NotificationReadService {
     private final NotificationRepository notificationRepository;
 
     @Transactional(readOnly = true)
-    public CursorPaginationResult<NotificationDto> getNotifications(Long memberId, Long cursorId, String cursorTimestamp, int size) {
+    public CursorPaginationResult<NotificationSummaryResponse> getNotifications(Long memberId, Long cursorId, String cursorTimestamp, int size) {
         LocalDateTime parsedTimestamp = CursorConditionUtils.parseTimestamp(cursorTimestamp);
 
         List<Notification> notifications = notificationReadQueryRepository
@@ -33,9 +33,9 @@ public class NotificationReadService {
         return CursorPaginationHelper.paginateWithTimestamp(
                 notifications,
                 size,
-                NotificationDto::from,
-                NotificationDto::id,
-                NotificationDto::createdAt
+                NotificationSummaryResponse::from,
+                NotificationSummaryResponse::id,
+                NotificationSummaryResponse::createdAt
         );
     }
 

--- a/src/main/java/ktb/leafresh/backend/domain/notification/presentation/dto/response/NotificationListResponse.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/presentation/dto/response/NotificationListResponse.java
@@ -1,0 +1,22 @@
+package ktb.leafresh.backend.domain.notification.presentation.dto.response;
+
+import ktb.leafresh.backend.global.util.pagination.CursorInfo;
+import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record NotificationListResponse(
+        List<NotificationSummaryResponse> notifications,
+        boolean hasNext,
+        CursorInfo cursorInfo
+) {
+    public static NotificationListResponse from(CursorPaginationResult<NotificationSummaryResponse> result) {
+        return NotificationListResponse.builder()
+                .notifications(result.items())
+                .hasNext(result.hasNext())
+                .cursorInfo(result.cursorInfo())
+                .build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/notification/presentation/dto/response/NotificationSummaryResponse.java
+++ b/src/main/java/ktb/leafresh/backend/domain/notification/presentation/dto/response/NotificationSummaryResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import java.time.LocalDateTime;
 
 @Builder
-public record NotificationDto(
+public record NotificationSummaryResponse(
         Long id,
         String title,
         String content,
@@ -17,8 +17,8 @@ public record NotificationDto(
         String imageUrl,
         Long challengeId
 ) {
-    public static NotificationDto from(Notification entity) {
-        return NotificationDto.builder()
+    public static NotificationSummaryResponse from(Notification entity) {
+        return NotificationSummaryResponse.builder()
                 .id(entity.getId())
                 .title(entity.getTitle())
                 .content(entity.getContent())


### PR DESCRIPTION
- 커서 기반 페이지네이션 공통 구조의 items 키를 도메인별 명확한 네이밍으로 변경:
  - 단체 챌린지 목록: `groupChallenges`
  - 생성한 단체 챌린지 목록: `groupChallenges`
  - 알림 목록: `notifications`

- 도메인별 응답 DTO 클래스 분리 및 적용

- Controller 및 Service 코드에서 새로운 DTO 구조에 맞게 전체 적용
- 응답 일관성 향상 및 프론트엔드 연동 편의성 개선