### PR TITLE
chore: 단체 챌린지 카테고리 이미지 URL을 GCS 경로로 변경

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/enums/GroupChallengeCategoryName.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/enums/GroupChallengeCategoryName.java
@@ -24,16 +24,16 @@ public enum GroupChallengeCategoryName {
 
     public static String getImageUrl(String name) {
         return switch (name) {
-            case "ZERO_WASTE" -> "imageUrl1";
-            case "PLOGGING" -> "imageUrl2";
-            case "CARBON_FOOTPRINT" -> "imageUrl3";
-            case "ENERGY_SAVING" -> "imageUrl4";
-            case "UPCYCLING" -> "imageUrl5";
-            case "MEDIA" -> "imageUrl6";
-            case "DIGITAL_CARBON" -> "imageUrl7";
-            case "VEGAN" -> "imageUrl8";
-            case "ETC" -> "imageUrl9";
-            default -> "defaultImageUrl";
+            case "ZERO_WASTE" -> "https://storage.googleapis.com/leafresh-images/init/zero_waste.png";
+            case "PLOGGING" -> "https://storage.googleapis.com/leafresh-images/init/plogging.png";
+            case "CARBON_FOOTPRINT" -> "https://storage.googleapis.com/leafresh-images/init/carbon_footprint.png";
+            case "ENERGY_SAVING" -> "https://storage.googleapis.com/leafresh-images/init/energy_saving.png";
+            case "UPCYCLING" -> "https://storage.googleapis.com/leafresh-images/init/upcycling.png";
+            case "MEDIA" -> "https://storage.googleapis.com/leafresh-images/init/media.png";
+            case "DIGITAL_CARBON" -> "https://storage.googleapis.com/leafresh-images/init/digital_carbon.png";
+            case "VEGAN" -> "https://storage.googleapis.com/leafresh-images/init/vegan.png";
+            case "ETC" -> "https://storage.googleapis.com/leafresh-images/init/etc.png";
+            default -> "default_image_url";
         };
     }
 


### PR DESCRIPTION
- GroupChallengeCategoryName 내 imageUrl 값을 GCS에 업로드된 이미지 경로로 변경
- 정적 자산을 외부 저장소(GCS) 기반으로 관리하여 유지보수 및 배포 효율성 향상