### PR TITLE
feat: 이벤트 챌린지 조회 시 현재부터 2주 후까지로 필터링 적용

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/EventChallengeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/EventChallengeReadService.java
@@ -11,8 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static java.util.stream.Collectors.toList;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,10 +23,11 @@ public class EventChallengeReadService {
     public List<EventChallengeResponseDto> getEventChallenges() {
         try {
             LocalDateTime now = LocalDateTime.now();
-            List<GroupChallenge> challenges = groupChallengeRepository.findOngoingEventChallenges(now);
+            LocalDateTime twoWeeksLater = now.plusWeeks(2);
+            List<GroupChallenge> challenges = groupChallengeRepository.findEventChallengesWithinRange(now, twoWeeksLater);
             return challenges.stream()
                     .map(EventChallengeResponseDto::from)
-                    .collect(toList());
+                    .collect(Collectors.toList());
         } catch (Exception e) {
             throw new CustomException(ChallengeErrorCode.EVENT_CHALLENGE_READ_FAILED);
         }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeRepository.java
@@ -19,6 +19,12 @@ public interface GroupChallengeRepository extends JpaRepository<GroupChallenge, 
     @Query("SELECT gc FROM GroupChallenge gc " +
             "WHERE gc.eventFlag = true " +
             "AND gc.deletedAt IS NULL " +
+            "AND gc.startDate <= :endInclusive " +
             "AND gc.endDate >= :now")
-    List<GroupChallenge> findOngoingEventChallenges(@Param("now") LocalDateTime now);
+    List<GroupChallenge> findEventChallengesWithinRange(
+            @Param("now") LocalDateTime now,
+            @Param("endInclusive") LocalDateTime endInclusive
+    );
+
+    boolean existsByTitleAndEventFlagTrue(String title);
 }


### PR DESCRIPTION
- 이벤트 챌린지 조회 시점 기준으로 현재 ~ 2주 후까지 시작하는 챌린지만 조회되도록 필터링 로직 추가
- EventChallengeReadService 내부 비즈니스 로직 수정
