### PR TITLE
feat: 인증 제출 시 내용 필수 입력값 검증 Validator 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/domain/support/validator/VerificationSubmitValidator.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/domain/support/validator/VerificationSubmitValidator.java
@@ -1,0 +1,18 @@
+package ktb.leafresh.backend.domain.verification.domain.support.validator;
+
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@RequiredArgsConstructor
+@Component
+public class VerificationSubmitValidator {
+
+    public void validate(String content) {
+        if (!StringUtils.hasText(content)) {
+            throw new CustomException(VerificationErrorCode.CONTENT_REQUIRED);
+        }
+    }
+}


### PR DESCRIPTION
- VerificationSubmitValidator 클래스 생성
  - content 값이 비어있거나 공백만 있는 경우 예외 발생 (`CONTENT_REQUIRED`)
  - StringUtils.hasText() 기반의 텍스트 존재 여부 검증

- 도메인 유효성 검증 책임을 Validator 클래스로 분리하여 재사용성 및 테스트 용이성 향상
- `@Component` 등록을 통해 서비스 계층에서 주입 및 사용 가능