### PR TITLE
refactor: 회원가입 시 카카오 프로필 이미지 대신 디폴트 이미지 설정

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/auth/infrastructure/client/OAuthKakaoService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/infrastructure/client/OAuthKakaoService.java
@@ -1,6 +1,8 @@
 package ktb.leafresh.backend.domain.auth.infrastructure.client;
 
 import ktb.leafresh.backend.domain.auth.application.dto.OAuthUserInfoDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +14,20 @@ public class OAuthKakaoService {
     private final KakaoProfileClient kakaoProfileClient;
 
     public OAuthUserInfoDto getUserInfo(String authorizationCode) {
-        String accessToken = kakaoTokenClient.getAccessToken(authorizationCode);
-        return kakaoProfileClient.getUserProfile(accessToken);
+        try {
+            String accessToken = kakaoTokenClient.getAccessToken(authorizationCode);
+            OAuthUserInfoDto kakaoUser = kakaoProfileClient.getUserProfile(accessToken);
+
+            // 디폴트 이미지 적용
+            return new OAuthUserInfoDto(
+                    kakaoUser.getProvider(),
+                    kakaoUser.getProviderId(),
+                    kakaoUser.getEmail(),
+                    "https://storage.googleapis.com/leafresh-images/init/user_icon.png",
+                    kakaoUser.getNickname()
+            );
+        } catch (Exception e) {
+            throw new CustomException(MemberErrorCode.KAKAO_TOKEN_ISSUE_FAILED, e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
- 기존: 소셜 로그인 시 카카오로부터 프로필 이미지 URL 수신 후 저장
- 변경: 카카오 이미지 사용 대신 서비스 자체 디폴트 이미지 URL로 고정 설정
  - 디폴트 이미지 URL: https://storage.googleapis.com/leafresh-images/init/user_icon.png

- 신규 가입자에 대해 일관된 초기 프로필 이미지 제공