### PR TITLE
test: 로컬 환경용 Fake AI 이미지 검증 클라이언트 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/FakeAiVerificationClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/FakeAiVerificationClient.java
@@ -1,0 +1,17 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.client;
+
+import ktb.leafresh.backend.domain.verification.infrastructure.dto.request.AiVerificationRequestDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("local")
+public class FakeAiVerificationClient implements AiVerificationClient {
+
+    @Override
+    public void verifyImage(AiVerificationRequestDto requestDto) {
+        log.info("[FAKE AI 클라이언트] 로컬 환경에서 AI 이미지 검증 요청 무시됨. 요청 DTO: {}", requestDto);
+    }
+}


### PR DESCRIPTION
- `@Profile("local")` 조건에 따라 활성화되는 FakeAiVerificationClient 구현
- 실제 AI 서버와 통신하지 않고 로그 출력으로 검증 요청을 대체
- 개발 및 테스트 시 AI 의존성 제거로 속도 및 안정성 향상
- `AiVerificationClient` 인터페이스를 구현하여 실제 구현체 대체 가능
