### PR TITLE
refactor: 쿠키 설정 외부화 및 인증 응답 쿠키 생성 로직 개선

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/auth/presentation/controller/OAuthSignupController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/presentation/controller/OAuthSignupController.java
@@ -19,8 +19,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.Duration;
-
 @Slf4j
 @Tag(name = "OAuth 회원가입", description = "OAuth 인증 이후 회원가입 API")
 @RestController
@@ -49,7 +47,6 @@ public class OAuthSignupController {
             @RequestBody OAuthSignupRequestDto request,
             HttpServletResponse response
     ) {
-        log.info("회원가입 컨트롤러 진입");
         log.info("회원가입 요청 수신 - email={}, provider={}, providerId={}, nickname={}",
                 request.email(), request.provider(), request.provider().id(), request.nickname());
 

--- a/src/main/java/ktb/leafresh/backend/global/config/JwtSecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/JwtSecurityConfig.java
@@ -1,5 +1,6 @@
 package ktb.leafresh.backend.global.config;
 
+import ktb.leafresh.backend.global.security.AuthCookieProvider;
 import ktb.leafresh.backend.global.security.JwtFilter;
 import ktb.leafresh.backend.global.security.TokenBlacklistService;
 import ktb.leafresh.backend.global.security.TokenProvider;
@@ -15,11 +16,12 @@ public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurity
 
     private final TokenProvider tokenProvider;
     private final TokenBlacklistService tokenBlacklistService;
+    private final AuthCookieProvider authCookieProvider;
 
     // TokenProvider 를 주입받아서 JwtFilter 를 통해 Security 로직에 필터를 등록
     @Override
     public void configure(HttpSecurity http) {
-        JwtFilter customFilter = new JwtFilter(tokenProvider, tokenBlacklistService);
+        JwtFilter customFilter = new JwtFilter(tokenProvider, tokenBlacklistService, authCookieProvider);
         http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
     }
 }

--- a/src/main/java/ktb/leafresh/backend/global/security/AuthCookieProvider.java
+++ b/src/main/java/ktb/leafresh/backend/global/security/AuthCookieProvider.java
@@ -1,11 +1,14 @@
 package ktb.leafresh.backend.global.security;
 
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 
+@Slf4j
 @Component
 public class AuthCookieProvider {
 
@@ -14,6 +17,11 @@ public class AuthCookieProvider {
 
     @Value("${cookie.samesite:Strict}") // 기본은 Strict
     private String sameSite;
+
+    @PostConstruct
+    public void init() {
+        log.info("[쿠키설정] secure={}, sameSite={}", secure, sameSite);
+    }
 
     public ResponseCookie createCookie(String name, String value, Duration maxAge) {
         ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)


### PR DESCRIPTION
- AuthCookieProvider 개선
  - 쿠키 secure, sameSite 속성을 @Value를 통해 환경변수로 외부화
  - @PostConstruct에서 설정 값 로그로 출력 (디버깅 용이)
  - ResponseCookie 빌더 메서드로 쿠키 생성 통일

- JwtSecurityConfig 수정
  - AuthCookieProvider 주입 추가 → 추후 JWT 관련 쿠키 설정에 활용 가능성 열어둠
 
- OAuthSignupController 수정
  - 회원가입 시 AuthCookieProvider 주입 기반 쿠키 설정 가능하도록 필드 추가
  - (이 PR에서는 직접 사용되진 않지만, 구조 반영됨)