### PR TITLE
fix: AI 인증 요청 응답 처리 개선 및 예외 대응

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/listener/VerificationEventListener.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/listener/VerificationEventListener.java
@@ -19,7 +19,13 @@ public class VerificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(VerificationCreatedEvent event) {
-        log.info("[이벤트 리스너] 인증 정보 저장 커밋 완료. AI 서버로 전송 시작");
-        aiClient.verifyImage(event.requestDto());
+        try {
+            log.info("[이벤트 리스너] 인증 정보 저장 커밋 완료. AI 서버로 전송 시작");
+            aiClient.verifyImage(event.requestDto());
+            log.info("[이벤트 리스너] AI 요청 완료");
+        } catch (Exception e) {
+            log.error("[이벤트 리스너] AI 요청 중 예외 발생: {}", e.getMessage(), e);
+            // → retry 메커니즘이 있다면 여기에 큐 또는 재시도 등록 로직 삽입
+        }
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/HttpAiVerificationClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/HttpAiVerificationClient.java
@@ -44,7 +44,17 @@ public class HttpAiVerificationClient implements AiVerificationClient {
             AiVerificationApiResponseDto parsed =
                     new ObjectMapper().readValue(rawJson, AiVerificationApiResponseDto.class);
 
+            if (parsed.status() == 202) {
+                log.info("[AI 응답] 인증 요청 정상 접수됨. 콜백을 기다립니다.");
+                return;
+            }
+
             AiVerificationResponseDto result = parsed.data();
+            if (result == null) {
+                log.warn("[AI 응답] data 필드가 null입니다. 콜백 방식이므로 무시합니다. verificationId={}", requestDto.verificationId());
+                return;
+            }
+
             log.debug("[AI 응답 파싱 완료] result={}", result.result());
 
             if (!result.result()) {
@@ -52,7 +62,7 @@ public class HttpAiVerificationClient implements AiVerificationClient {
                 throw new CustomException(VerificationErrorCode.AI_VERIFICATION_FAILED);
             }
 
-            log.info("[검열 통과] AI 응답 result=true (이미지 적합)");
+            log.info("[검열 통과] AI 응답 result=true");
 
         } catch (CustomException e) {
             throw e;


### PR DESCRIPTION
## 주요 변경 사항
- AI 서버에서 202 Accepted 응답 시 result 파싱을 생략하고 콜백을 기다리도록 처리
- result 필드가 null인 경우 로그만 출력하고 예외는 발생시키지 않음
- VerificationEventListener 내에서 예외 발생 시 catch로 처리해 전체 비동기 흐름이 중단되지 않도록 방지

## 수정 이유
- 일부 요청에서 AI 응답을 잘 받았음에도 인증 상태가 계속 PENDING_APPROVAL에 머무는 이슈 발생
- 비동기 이벤트 흐름에서 예외 전파로 인해 예상치 못한 중단이 생기는 것을 방지

## 기타
- 향후 AI 서버 콜백이 제대로 오지 않을 경우 재시도 메커니즘도 고려할 예정입니다.