### PR TITLE
feat: 회원 정보 수정 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/MemberUpdateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/MemberUpdateService.java
@@ -1,0 +1,62 @@
+package ktb.leafresh.backend.domain.member.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberUpdateService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void updateMemberInfo(Member member, String newNickname, String newImageUrl) {
+        boolean updated = false;
+
+        log.debug("[회원 정보 수정] 시작 - memberId: {}", member.getId());
+
+        try {
+            if (newNickname != null && !newNickname.equals(member.getNickname())) {
+                validateNicknameFormat(newNickname);
+
+                if (memberRepository.existsByNickname(newNickname)) {
+                    throw new CustomException(MemberErrorCode.ALREADY_EXISTS);
+                }
+
+                member.updateNickname(newNickname);
+                updated = true;
+                log.info("[회원 정보 수정] 닉네임 변경: {}", newNickname);
+            }
+
+            if (newImageUrl != null && !newImageUrl.equals(member.getImageUrl())) {
+                member.updateImageUrl(newImageUrl);
+                updated = true;
+                log.info("[회원 정보 수정] 이미지 URL 변경");
+            }
+
+            if (!updated) {
+                throw new CustomException(GlobalErrorCode.NO_CONTENT);
+            }
+
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[회원 정보 수정] 서버 오류 발생", e);
+            throw new CustomException(MemberErrorCode.NICKNAME_UPDATE_FAILED);
+        }
+    }
+
+    private void validateNicknameFormat(String nickname) {
+        if (!nickname.matches("^[a-zA-Z0-9가-힣]{1,20}$")) {
+            throw new CustomException(MemberErrorCode.NICKNAME_INVALID_FORMAT);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/Member.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/Member.java
@@ -130,4 +130,12 @@ public class Member extends BaseEntity {
     public void updateLastLoginRewardedAt() {
         this.lastLoginRewardedAt = LocalDateTime.now();
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/MemberController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/MemberController.java
@@ -1,0 +1,49 @@
+package ktb.leafresh.backend.domain.member.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import ktb.leafresh.backend.domain.member.application.service.MemberUpdateService;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.member.presentation.dto.request.MemberUpdateRequestDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import ktb.leafresh.backend.global.response.ApiResponseConstants;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+
+@Tag(name = "회원 정보 수정", description = "회원 닉네임 및 프로필 이미지 수정 API")
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+@Validated
+public class MemberController {
+
+    private final MemberRepository memberRepository;
+    private final MemberUpdateService memberUpdateService;
+
+    @PatchMapping
+    @Operation(summary = "회원 정보 수정", description = "닉네임, 이미지 URL을 수정합니다.")
+    @ApiResponseConstants.ClientErrorResponses
+    @ApiResponseConstants.ServerErrorResponses
+    public ResponseEntity<ApiResponse<Void>> updateMemberInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody MemberUpdateRequestDto requestDto) {
+
+        Member member = memberRepository.findById(userDetails.getMemberId())
+                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        memberUpdateService.updateMemberInfo(member, requestDto.getNickname(), requestDto.getImageUrl());
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .body(ApiResponse.success("회원 정보가 성공적으로 수정되었습니다."));
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/request/MemberUpdateRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/request/MemberUpdateRequestDto.java
@@ -1,0 +1,22 @@
+package ktb.leafresh.backend.domain.member.presentation.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import ktb.leafresh.backend.global.validator.ValidGcsImageUrl;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberUpdateRequestDto {
+
+        @Size(min = 1, max = 20, message = "닉네임은 1자 이상 20자 이하로 입력해주세요.")
+        @Pattern(
+                regexp = "^[a-zA-Z0-9가-힣]{1,20}$",
+                message = "닉네임은 특수문자 없이 1~20자의 영문, 숫자, 한글만 사용할 수 있습니다."
+        )
+        private String nickname;
+
+        @ValidGcsImageUrl
+        private String imageUrl;
+}

--- a/src/main/java/ktb/leafresh/backend/global/exception/GlobalErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/GlobalErrorCode.java
@@ -17,7 +17,9 @@ public enum GlobalErrorCode implements BaseErrorCode {
     TOKEN_REISSUE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 토큰 재발급에 실패했습니다."),
     INVALID_CURSOR(HttpStatus.BAD_REQUEST, "cursorId와 cursorTimestamp는 반드시 함께 전달되어야 합니다."),
     UNSUPPORTED_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 Content-Type입니다."),
-    INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 이미지 URL입니다.");
+    INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 이미지 URL입니다."),
+    NO_CONTENT(HttpStatus.BAD_REQUEST, "변경된 정보가 없습니다.");
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/ktb/leafresh/backend/global/exception/MemberErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/MemberErrorCode.java
@@ -19,7 +19,9 @@ public enum MemberErrorCode implements BaseErrorCode {
     SIGNUP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 회원가입에 실패했습니다."),
     INVALID_LOGOUT_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 요청입니다. accessToken이 존재하지 않습니다."),
     LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 로그아웃에 실패했습니다."),
-    KAKAO_LOGOUT_FAILED(HttpStatus.BAD_GATEWAY, "카카오 로그아웃 처리 중 오류가 발생했습니다.");
+    KAKAO_LOGOUT_FAILED(HttpStatus.BAD_GATEWAY, "카카오 로그아웃 처리 중 오류가 발생했습니다."),
+    NICKNAME_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "닉네임 수정 권한이 없습니다."),
+    NICKNAME_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 닉네임 변경에 실패했습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 주요 개발 내용
- 회원 닉네임 및 프로필 이미지 URL을 수정하는 API(PATCH /api/members) 구현
- 닉네임은 1~20자, 특수문자 제외 형식 검증 및 중복 확인 포함
- 이미지 URL은 GCS에서 발급된 주소만 허용
- Member 엔티티에 updateNickname, updateImageUrl 메서드 추가
- 변경 사항이 없을 경우 400 예외 처리 (NO_CONTENT)
- 예외 상황에 맞는 커스텀 예외 코드 추가

## 응답 예시
| 상황 | 응답 코드 | 메시지 |
|------|-----------|--------|
| 수정 성공 | 204 No Content | 회원 정보가 성공적으로 수정되었습니다. |
| 변경사항 없음 | 400 Bad Request | 변경된 정보가 없습니다. |
| 닉네임 중복 | 409 Conflict | 이미 사용 중인 닉네임입니다. |

## 테스트 시나리오
- [x] 닉네임/이미지 단독 또는 함께 수정
- [x] 닉네임 형식 오류 시 예외 발생
- [x] 닉네임 중복 시 예외 발생
- [x] imageUrl이 GCS URL이 아닌 경우 예외 발생
- [x] 변경사항 없을 경우 예외 발생
