### PR TITLE
feat: 회원 정보 조회 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/MemberInfoQueryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/MemberInfoQueryService.java
@@ -1,0 +1,43 @@
+package ktb.leafresh.backend.domain.member.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.TreeLevel;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.MemberInfoResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberInfoQueryService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public MemberInfoResponseDto getMemberInfo(Long memberId) {
+        log.debug("[회원 정보 조회] 요청 시작 - memberId: {}", memberId);
+
+        try {
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+            TreeLevel treeLevel = member.getTreeLevel();
+            if (treeLevel == null) {
+                log.error("[회원 정보 조회] 트리 레벨 정보 없음 - memberId: {}", memberId);
+                throw new CustomException(MemberErrorCode.TREE_LEVEL_NOT_FOUND);
+            }
+
+            return MemberInfoResponseDto.of(member, treeLevel);
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[회원 정보 조회] 서비스 내부 오류", e);
+            throw new CustomException(MemberErrorCode.MEMBER_INFO_QUERY_FAILED);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/MemberInfoResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/MemberInfoResponseDto.java
@@ -1,0 +1,29 @@
+package ktb.leafresh.backend.domain.member.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.TreeLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MemberInfoResponseDto {
+
+    private String nickname;
+    private String profileImageUrl;
+    private Long treeLevelId;
+    private String treeLevelName;
+    private String treeImageUrl;
+
+    public static MemberInfoResponseDto of(Member member, TreeLevel treeLevel) {
+        return MemberInfoResponseDto.builder()
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getImageUrl())
+                .treeLevelId(treeLevel.getId())
+                .treeLevelName(treeLevel.getName().name())
+                .treeImageUrl(treeLevel.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/exception/MemberErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/MemberErrorCode.java
@@ -21,7 +21,8 @@ public enum MemberErrorCode implements BaseErrorCode {
     LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 로그아웃에 실패했습니다."),
     KAKAO_LOGOUT_FAILED(HttpStatus.BAD_GATEWAY, "카카오 로그아웃 처리 중 오류가 발생했습니다."),
     NICKNAME_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "닉네임 수정 권한이 없습니다."),
-    NICKNAME_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 닉네임 변경에 실패했습니다.");
+    NICKNAME_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 닉네임 변경에 실패했습니다."),
+    MEMBER_INFO_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 회원 정보를 조회하지 못했습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 작업 내용
- `/api/members` GET API 구현
- 인증된 사용자의 닉네임, 트리 레벨 정보 반환
- 에러 응답 (401/403/404/500 등) 및 예외 핸들러 연동
- Controller/Service 로그 중복 제거 및 정리