### PR TITLE
fix: 회원정보 수정 시 본인 외 사용자와 닉네임 중복되지 않도록 검사 로직 보완

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/MemberUpdateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/MemberUpdateService.java
@@ -27,7 +27,7 @@ public class MemberUpdateService {
             if (newNickname != null && !newNickname.equals(member.getNickname())) {
                 validateNicknameFormat(newNickname);
 
-                if (memberRepository.existsByNickname(newNickname)) {
+                if (memberRepository.existsByNicknameAndIdNot(newNickname, member.getId())) {
                     throw new CustomException(MemberErrorCode.ALREADY_EXISTS);
                 }
 
@@ -43,7 +43,7 @@ public class MemberUpdateService {
             }
 
             if (!updated) {
-                throw new CustomException(GlobalErrorCode.NO_CONTENT);
+                throw new CustomException(MemberErrorCode.NO_CHANGES);
             }
 
         } catch (CustomException e) {

--- a/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<Member> findByEmail(String email);
+
+    boolean existsByNicknameAndIdNot(String nickname, Long id);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/MemberController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/MemberController.java
@@ -57,7 +57,8 @@ public class MemberController {
 
             return ResponseEntity.status(HttpStatus.NO_CONTENT)
                     .body(ApiResponse.success("회원 정보가 성공적으로 수정되었습니다."));
-
+        } catch (CustomException e) {
+            throw e;
         } catch (Exception e) {
             log.error("[회원 정보 수정] 처리 중 서버 내부 오류 발생", e);
             throw new CustomException(MemberErrorCode.NICKNAME_UPDATE_FAILED);

--- a/src/main/java/ktb/leafresh/backend/global/exception/MemberErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/MemberErrorCode.java
@@ -21,6 +21,7 @@ public enum MemberErrorCode implements BaseErrorCode {
     LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 로그아웃에 실패했습니다."),
     KAKAO_LOGOUT_FAILED(HttpStatus.BAD_GATEWAY, "카카오 로그아웃 처리 중 오류가 발생했습니다."),
     NICKNAME_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "닉네임 수정 권한이 없습니다."),
+    NO_CHANGES(HttpStatus.BAD_REQUEST, "변경된 정보가 없습니다."),
     NICKNAME_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 닉네임 변경에 실패했습니다."),
     MEMBER_INFO_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 회원 정보를 조회하지 못했습니다.");
 


### PR DESCRIPTION
- 본인 닉네임은 허용하되, 다른 사용자의 닉네임으로 변경을 시도할 경우 중복 예외가 발생하도록 로직 수정
- `existsByNicknameAndIdNot()` 사용으로 중복 조건을 명확하게 처리
- 변경사항 없는 경우 400 에러 반환되도록 예외 정의 (`NO_CHANGES`)
- 관련 예외 메시지 및 상태 코드 (`409`, `400`) 명확하게 설정