### PR TITLE
feat: 나뭇잎 보유량 조회 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/MemberLeafPointReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/MemberLeafPointReadService.java
@@ -1,0 +1,31 @@
+package ktb.leafresh.backend.domain.member.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.MemberLeafPointResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberLeafPointReadService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberLeafPointResponseDto getCurrentLeafPoints(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> {
+                    log.warn("[나뭇잎 보유량 조회] 존재하지 않는 사용자 - memberId: {}", memberId);
+                    return new CustomException(MemberErrorCode.MEMBER_NOT_FOUND);
+                });
+
+        Integer leafPoints = member.getCurrentLeafPoints();
+        log.info("[나뭇잎 보유량 조회] 조회 성공 - memberId: {}, leafPoints: {}", memberId, leafPoints);
+
+        return new MemberLeafPointResponseDto(leafPoints);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/MemberLeafPointController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/MemberLeafPointController.java
@@ -1,0 +1,41 @@
+package ktb.leafresh.backend.domain.member.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import ktb.leafresh.backend.domain.member.application.service.MemberLeafPointReadService;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.MemberLeafPointResponseDto;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import ktb.leafresh.backend.global.response.ApiResponseConstants;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberLeafPointController {
+
+    private final MemberLeafPointReadService memberLeafPointReadService;
+
+    @GetMapping("/leaves")
+    @Operation(summary = "나뭇잎 보유량 조회", description = "현재 로그인한 사용자의 보유 나뭇잎 수를 반환합니다.")
+    @ApiResponseConstants.ClientErrorResponses
+    @ApiResponseConstants.ServerErrorResponses
+    public ResponseEntity<ApiResponse<MemberLeafPointResponseDto>> getLeafPoints(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long memberId = userDetails.getMemberId();
+        log.debug("[나뭇잎 보유량 조회] 요청 시작 - memberId: {}", memberId);
+
+        MemberLeafPointResponseDto responseDto = memberLeafPointReadService.getCurrentLeafPoints(memberId);
+
+        log.debug("[나뭇잎 보유량 조회] 응답 완료 - memberId: {}, currentLeafPoints: {}", memberId, responseDto.getCurrentLeafPoints());
+        return ResponseEntity.ok(ApiResponse.success("보유 나뭇잎 수를 조회했습니다.", responseDto));
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/MemberLeafPointResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/MemberLeafPointResponseDto.java
@@ -1,0 +1,10 @@
+package ktb.leafresh.backend.domain.member.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberLeafPointResponseDto {
+    private Integer currentLeafPoints;
+}


### PR DESCRIPTION
- 로그인한 사용자의 currentLeafPoints를 반환하는 조회 API 구현
- MemberLeafPointController, Service, ResponseDto 생성
- 인증 필요 (401), 회원 없음 (404), 서버 오류 (500) 처리 포함
- 스웨거 명세 및 로그 포함
