### PR TITLE
feat: 뱃지 엔티티 클래스 및 타입 정의 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/Badge.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/Badge.java
@@ -1,6 +1,7 @@
 package ktb.leafresh.backend.domain.member.domain.entity;
 
 import jakarta.persistence.*;
+import ktb.leafresh.backend.domain.member.domain.entity.enums.BadgeType;
 import lombok.*;
 
 import java.util.ArrayList;
@@ -21,11 +22,15 @@ public class Badge {
     @OneToMany(mappedBy = "badge", cascade = CascadeType.ALL)
     private List<MemberBadge> memberBadges = new ArrayList<>();
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private BadgeType type;
+
     @Column(nullable = false, length = 30)
     private String name;
 
-    @Column(nullable = false, length = 100)
-    private String description;
+    @Column(name = "acquisition_condition", nullable = false, columnDefinition = "TEXT")
+    private String condition;
 
     @Column(nullable = false, length = 512)
     private String imageUrl;

--- a/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/enums/BadgeType.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/enums/BadgeType.java
@@ -1,0 +1,9 @@
+package ktb.leafresh.backend.domain.member.domain.entity.enums;
+
+public enum BadgeType {
+    GROUP,
+    PERSONAL,
+    TOTAL,
+    SPECIAL,
+    EVENT
+}


### PR DESCRIPTION
Badge 엔티티 및 BadgeType Enum을 추가

- Badge 엔티티 클래스 정의
  - id, type, name, condition, imageUrl 필드 포함
  - DB 컬럼명 매핑 처리 (`condition` → `acquisition_condition`)
- BadgeType Enum 추가 (GROUP, PERSONAL, TOTAL, SPECIAL, EVENT)