### PR TITLE
feat: 단체 챌린지 생성/수정 시 성공 예시 이미지 1개 이상 필수 조건 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/request/GroupChallengeCreateRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/request/GroupChallengeCreateRequestDto.java
@@ -41,6 +41,7 @@ public record GroupChallengeCreateRequestDto(
         @Schema(description = "인증 종료 시간") LocalTime verificationEndTime,
 
         @Valid
+        @NotNull(message = "챌린지에는 최소 한 개 이상의 성공 예시 이미지가 필요합니다.")
         @Size(max = 5)
         @Schema(description = "인증 예시 이미지 목록") List<ExampleImageRequestDto> exampleImages
 ) {

--- a/src/main/java/ktb/leafresh/backend/global/exception/ChallengeErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/ChallengeErrorCode.java
@@ -17,6 +17,7 @@ public enum ChallengeErrorCode implements BaseErrorCode {
     GROUP_CHALLENGE_PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "단체 챌린지 참여 정보를 찾을 수 없습니다."),
     CHALLENGE_DURATION_TOO_SHORT(HttpStatus.BAD_REQUEST, "챌린지 기간은 최소 1일 이상이어야 합니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작일은 종료일보다 이전이어야 합니다."),
+    GROUP_CHALLENGE_REQUIRES_SUCCESS_IMAGE(HttpStatus.BAD_REQUEST, "챌린지에는 최소 한 개 이상의 성공 예시 이미지가 필요합니다."),
     CHALLENGE_CREATION_REJECTED_BY_AI(HttpStatus.UNPROCESSABLE_ENTITY, "AI 판단 결과 챌린지 생성이 거부되었습니다."),
     CHALLENGE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 단체 챌린지입니다."),
     CHALLENGE_HAS_PARTICIPANTS_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "해당 챌린지에 참여자가 있어 삭제할 수 없습니다."),


### PR DESCRIPTION
## 주요 변경 사항
- GroupChallengeCreateRequestDto에 `@NotNull` 메시지 커스터마이징
- ChallengeErrorCode에 `GROUP_CHALLENGE_REQUIRES_SUCCESS_IMAGE` 추가
- DomainValidator에서 성공 이미지만 필수로 검증하도록 로직 변경
- 수정 시 기존 성공 이미지 유지 여부 + 신규 이미지 조합 기준으로 판단

## 테스트
- 실패 이미지만 있는 경우 → 400 에러
- 성공 이미지가 1개 이상 포함된 경우 → 정상 생성
- exampleImages가 null인 경우 → `@NotNull` 유효성 검증 에러 발생