### PR TITLE
feat: 단체 챌린지 수정 시 예시 이미지 필드에 @JsonSetter(nulls = AS_EMPTY) 적용

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/request/GroupChallengeUpdateRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/request/GroupChallengeUpdateRequestDto.java
@@ -1,5 +1,7 @@
 package ktb.leafresh.backend.domain.challenge.group.presentation.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
@@ -46,10 +48,13 @@ public record GroupChallengeUpdateRequestDto(
 ) {
     public record ExampleImages(
             @Size(max = 5)
+            @JsonSetter(nulls = Nulls.AS_EMPTY)
             @Schema(description = "기존 유지할 이미지 ID와 순서 목록") List<KeepImage> keep,
 
+            @JsonSetter(nulls = Nulls.AS_EMPTY)
             @Schema(description = "신규 추가할 이미지 목록") List<NewImage> newImages,
 
+            @JsonSetter(nulls = Nulls.AS_EMPTY)
             @Schema(description = "삭제할 이미지 ID 목록") List<Long> deleted
     ) {
         public record KeepImage(


### PR DESCRIPTION
- GroupChallengeUpdateRequestDto.ExampleImages 내부 필드인 keep, newImages, deleted에
  @JsonSetter(nulls = Nulls.AS_EMPTY) 적용
- 프론트엔드에서 null로 전송한 경우에도 빈 리스트로 처리되도록 하여 NPE 방지
- validation 및 stream 연산 안정성 확보
