### PR TITLE
chore: 단체 챌린지 카테고리 라벨 수정 및 ETC 카테고리 제외

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCategoryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCategoryService.java
@@ -21,6 +21,7 @@ public class GroupChallengeCategoryService {
             List<GroupChallengeCategoryResponseDto> categories = categoryRepository
                     .findAllByActivatedIsTrueOrderBySequenceNumberAsc()
                     .stream()
+                    .filter(category -> !category.getName().equalsIgnoreCase("ETC"))
                     .map(category -> GroupChallengeCategoryResponseDto.builder()
                             .category(category.getName())
                             .label(getLabelFromCategoryName(category.getName()))
@@ -46,8 +47,8 @@ public class GroupChallengeCategoryService {
             case "PLOGGING" -> "플로깅";
             case "CARBON_FOOTPRINT" -> "탄소 발자국";
             case "ENERGY_SAVING" -> "에너지 절약";
-            case "UPCYCLING" -> "중고거래/업사이클";
-            case "MEDIA" -> "서적, 영화";
+            case "UPCYCLING" -> "업사이클";
+            case "MEDIA" -> "문화 공유";
             case "DIGITAL_CARBON" -> "디지털 탄소";
             case "VEGAN" -> "비건";
             case "ETC" -> "기타";

--- a/src/main/java/ktb/leafresh/backend/global/initializer/TreeLevelInitializer.java
+++ b/src/main/java/ktb/leafresh/backend/global/initializer/TreeLevelInitializer.java
@@ -8,14 +8,6 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Leafresh 서비스의 기본 TreeLevel 5단계를 DB에 등록하는 초기화 클래스입니다.
- * - SPROUT, YOUNG, SMALL_TREE, TREE, BIG_TREE
- * - 애플리케이션 시작 시 존재하지 않을 경우 자동 생성됩니다.
- *
- * 위치: global.init (전역 초기화 책임)
- */
-
 @Component
 @RequiredArgsConstructor
 public class TreeLevelInitializer implements CommandLineRunner {
@@ -30,7 +22,7 @@ public class TreeLevelInitializer implements CommandLineRunner {
                         TreeLevel.builder()
                                 .name(levelName)
                                 .minLeafPoint(getMinLeafPoint(levelName))
-                                .imageUrl("default_" + levelName.name().toLowerCase() + ".png")
+                                .imageUrl(getImageUrl(levelName))
                                 .description(getDescription(levelName))
                                 .build()
                 );
@@ -40,21 +32,25 @@ public class TreeLevelInitializer implements CommandLineRunner {
 
     private int getMinLeafPoint(TreeLevelName name) {
         return switch (name) {
-            case SPROUT -> 0;
-            case YOUNG -> 2000;
-            case SMALL_TREE -> 4000;
-            case TREE -> 6000;
-            case BIG_TREE -> 8000;
+            case SPROUT -> 0;           // 새싹
+            case YOUNG -> 2501;         // 묘목
+            case SMALL_TREE -> 5001;    // 작은 나무
+            case TREE -> 7501;          // 중간 나무
+            case BIG_TREE -> 10001;     // 큰 나무
         };
+    }
+
+    private String getImageUrl(TreeLevelName name) {
+        return "https://storage.googleapis.com/leafresh-images/init/treelevel/" + name.name() + ".png";
     }
 
     private String getDescription(TreeLevelName name) {
         return switch (name) {
-            case SPROUT -> "씨앗 단계입니다.";
+            case SPROUT -> "새싹 단계입니다.";
             case YOUNG -> "묘목 단계입니다.";
             case SMALL_TREE -> "작은 나무 단계입니다.";
-            case TREE -> "성장한 나무 단계입니다.";
-            case BIG_TREE -> "울창한 나무 단계입니다.";
+            case TREE -> "중간 나무 단계입니다.";
+            case BIG_TREE -> "큰 나무 단계입니다.";
         };
     }
 }


### PR DESCRIPTION
- 'UPCYCLING' 라벨을 '업사이클링'으로 수정
- 'MEDIA' 라벨을 '문화 공유'로 수정
- 그룹 챌린지 카테고리 조회 시 ETC 카테고리는 제외하도록 필터링 추가
