### PR TITLE
feat: 최근 획득한 뱃지 조회 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/RecentBadgeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/RecentBadgeReadService.java
@@ -1,0 +1,63 @@
+package ktb.leafresh.backend.domain.member.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.MemberBadge;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.RecentBadgeListResponseDto;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.BadgeSummaryDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecentBadgeReadService {
+
+    private final MemberRepository memberRepository;
+    private final MemberBadgeRepository memberBadgeRepository;
+
+    public RecentBadgeListResponseDto getRecentBadges(Long memberId, int count) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> {
+                    log.warn("[최근 뱃지 조회] 존재하지 않는 사용자 - memberId: {}", memberId);
+                    throw new CustomException(MemberErrorCode.MEMBER_NOT_FOUND);
+                });
+
+        try {
+            List<MemberBadge> recentBadges = memberBadgeRepository.findRecentBadgesByMemberId(memberId, count);
+
+            if (recentBadges == null || recentBadges.isEmpty()) {
+                log.warn("[최근 뱃지 조회] 획득한 뱃지가 없습니다 - memberId: {}", memberId);
+                throw new CustomException(MemberErrorCode.BADGE_NOT_FOUND);
+            }
+
+            log.info("[최근 뱃지 조회] 조회 성공 - memberId: {}, count: {}", memberId, recentBadges.size());
+
+            List<BadgeSummaryDto> badgeDtos = recentBadges.stream()
+                    .map(b -> BadgeSummaryDto.builder()
+                            .id(b.getBadge().getId())
+                            .name(b.getBadge().getName())
+                            .condition(b.getBadge().getCondition())
+                            .imageUrl(b.getBadge().getImageUrl())
+                            .build())
+                    .toList();
+
+            return RecentBadgeListResponseDto.builder()
+                    .badges(badgeDtos)
+                    .build();
+
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[최근 뱃지 조회] 서버 내부 오류 발생 - memberId: {}", memberId, e);
+            throw new CustomException(MemberErrorCode.BADGE_QUERY_FAILED);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/MemberBadge.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/MemberBadge.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import ktb.leafresh.backend.global.common.entity.BaseEntity;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "member_badges")
 @Getter
@@ -23,4 +25,7 @@ public class MemberBadge extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "badge_id", nullable = false)
     private Badge badge;
+
+    @Column(name = "acquired_at", nullable = false)
+    private LocalDateTime acquiredAt;
 }

--- a/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/enums/BadgeType.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/enums/BadgeType.java
@@ -3,7 +3,7 @@ package ktb.leafresh.backend.domain.member.domain.entity.enums;
 public enum BadgeType {
     GROUP, // 카테고리별 뱃지 (단체 챌린지 중심)
     PERSONAL, // 개인 챌린지 연속 달성 뱃지
-    TOTAL, // 누적 챌린지 참여 수 뱃지 (단체+개인 통합)
+    TOTAL, // 누적 챌린지 인증 수 뱃지 (단체+개인 통합)
     SPECIAL, // 스페셜 뱃지 (이벤트성 or 테마 완주형)
     EVENT // 이벤트 챌린지별 뱃지 설계 (인증 3회 이상 시 자동 지급)
 }

--- a/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberBadgeQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberBadgeQueryRepository.java
@@ -1,0 +1,9 @@
+package ktb.leafresh.backend.domain.member.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.member.domain.entity.MemberBadge;
+
+import java.util.List;
+
+public interface MemberBadgeQueryRepository {
+    List<MemberBadge> findRecentBadgesByMemberId(Long memberId, int count);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberBadgeQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberBadgeQueryRepositoryImpl.java
@@ -1,0 +1,28 @@
+package ktb.leafresh.backend.domain.member.infrastructure.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import ktb.leafresh.backend.domain.member.domain.entity.MemberBadge;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static ktb.leafresh.backend.domain.member.domain.entity.QMemberBadge.memberBadge;
+import static ktb.leafresh.backend.domain.member.domain.entity.QBadge.badge;
+
+@RequiredArgsConstructor
+public class MemberBadgeQueryRepositoryImpl implements MemberBadgeQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MemberBadge> findRecentBadgesByMemberId(Long memberId, int count) {
+        return queryFactory
+                .selectFrom(memberBadge)
+                .join(memberBadge.badge, badge).fetchJoin()
+                .where(memberBadge.member.id.eq(memberId))
+                .orderBy(memberBadge.acquiredAt.desc())
+                .limit(count)
+                .fetch();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberBadgeRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberBadgeRepository.java
@@ -1,0 +1,8 @@
+package ktb.leafresh.backend.domain.member.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.member.domain.entity.MemberBadge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberBadgeRepository extends JpaRepository<MemberBadge, Long>, MemberBadgeQueryRepository {
+    // QueryDSL용 custom interface 분리
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/MemberBadgeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/MemberBadgeController.java
@@ -1,0 +1,37 @@
+package ktb.leafresh.backend.domain.member.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import ktb.leafresh.backend.domain.member.application.service.RecentBadgeReadService;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.RecentBadgeListResponseDto;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members/badges")
+public class MemberBadgeController {
+
+    private final RecentBadgeReadService recentBadgeReadService;
+
+    @GetMapping("/recent")
+    @Operation(summary = "최근 획득한 뱃지 조회", description = "회원이 최근에 획득한 뱃지를 최신순으로 조회합니다.")
+    public ResponseEntity<ApiResponse<RecentBadgeListResponseDto>> getRecentBadges(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "8") int count
+    ) {
+        Long memberId = userDetails.getMemberId();
+        log.debug("[최근 뱃지 조회] API 요청 시작 - memberId: {}, count: {}", memberId, count);
+
+        RecentBadgeListResponseDto badges = recentBadgeReadService.getRecentBadges(memberId, count);
+
+        return ResponseEntity.ok(ApiResponse.success("최근 획득한 뱃지 조회에 성공하였습니다.", badges));
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/BadgeSummaryDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/BadgeSummaryDto.java
@@ -1,0 +1,12 @@
+package ktb.leafresh.backend.domain.member.presentation.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record BadgeSummaryDto(
+        Long id,
+        String name,
+        String condition,
+        String imageUrl
+) {
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/RecentBadgeListResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/RecentBadgeListResponseDto.java
@@ -1,0 +1,10 @@
+package ktb.leafresh.backend.domain.member.presentation.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RecentBadgeListResponseDto(
+        List<BadgeSummaryDto> badges
+) {}

--- a/src/main/java/ktb/leafresh/backend/global/exception/MemberErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/MemberErrorCode.java
@@ -23,7 +23,10 @@ public enum MemberErrorCode implements BaseErrorCode {
     NICKNAME_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "닉네임 수정 권한이 없습니다."),
     NO_CHANGES(HttpStatus.BAD_REQUEST, "변경된 정보가 없습니다."),
     NICKNAME_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 닉네임 변경에 실패했습니다."),
-    MEMBER_INFO_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 회원 정보를 조회하지 못했습니다.");
+    MEMBER_INFO_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 회원 정보를 조회하지 못했습니다."),
+    BADGE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "뱃지 조회 권한이 없습니다."),
+    BADGE_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 획득 뱃지를 찾을 수 없습니다."),
+    BADGE_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 인해 획득 뱃지 목록을 불러오지 못했습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 작업 개요
- 마이페이지에서 사용자의 최근 획득 뱃지를 최신순으로 조회하는 API 구현
- 기본 8개, count 파라미터로 개수 조절 가능

## 주요 변경 사항
- MemberBadge 엔티티에 acquiredAt 필드 추가
- MemberBadgeQueryRepository + QueryDSL 구현
- BadgeSummaryDto → 공통 요약 응답으로 네이밍 변경
- ApiResponse 데이터 구조를 { badges: [] } 형태로 감쌈

## 관련 이슈
- close #207 (마이페이지 - 최근 획득 뱃지 조회)