### PR TITLE
feat: 프로필 카드 조회 API 구현 및 예외 응답 구조 정리

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/ProfileCardReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/ProfileCardReadService.java
@@ -1,0 +1,136 @@
+package ktb.leafresh.backend.domain.member.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.TreeLevel;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.TreeLevelRepository;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.ProfileCardResponseDto;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.ProfileCardResponseDto.RecentBadgeDto;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProfileCardReadService {
+
+    private final MemberRepository memberRepository;
+    private final MemberBadgeRepository memberBadgeRepository;
+    private final TreeLevelRepository treeLevelRepository;
+
+    public ProfileCardResponseDto getProfileCard(Long memberId) {
+        try {
+            log.info("[1] 프로필 카드 조회 시작 - memberId: {}", memberId);
+            Member member = findMember(memberId);
+            TreeLevel current = member.getTreeLevel();
+            TreeLevel next = findNextTreeLevel(current);
+
+            int totalSuccess = countTotalSuccess(member);
+            int completedGroupCount = countCompletedGroupChallenges(member);
+            List<RecentBadgeDto> badges = fetchRecentBadges(memberId);
+
+            int leafPointsToNextLevel = (next != null)
+                    ? next.getMinLeafPoint() - member.getTotalLeafPoints()
+                    : 0;
+
+            log.info("[6] 프로필 카드 응답 생성 완료 - memberId: {}", memberId);
+            return buildResponse(member, current, next, totalSuccess, completedGroupCount, badges, leafPointsToNextLevel);
+
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[X] 예기치 못한 오류 발생 - memberId: {}, message: {}", memberId, e.getMessage(), e);
+            throw new CustomException(MemberErrorCode.PROFILE_CARD_QUERY_FAILED);
+        }
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> {
+                    log.warn("[1-1] 회원을 찾을 수 없습니다 - memberId: {}", memberId);
+                    return new CustomException(MemberErrorCode.PROFILE_CARD_NOT_FOUND);
+                });
+    }
+
+    private TreeLevel findNextTreeLevel(TreeLevel current) {
+        TreeLevel next = treeLevelRepository
+                .findFirstByMinLeafPointGreaterThanOrderByMinLeafPointAsc(current.getMinLeafPoint())
+                .orElse(null);
+
+        if (next != null) {
+            log.debug("[2-2] 다음 트리 레벨: {} (minPoint: {})", next.getName(), next.getMinLeafPoint());
+        } else {
+            log.debug("[2-2] 다음 트리 레벨 없음 (최종 단계)");
+        }
+        return next;
+    }
+
+    private int countTotalSuccess(Member member) {
+        int group = (int) member.getGroupChallengeParticipantRecords().stream()
+                .flatMap(r -> r.getVerifications().stream())
+                .filter(v -> v.getStatus() == ChallengeStatus.SUCCESS)
+                .count();
+
+        int personal = (int) member.getPersonalChallengeVerifications().stream()
+                .filter(v -> v.getStatus() == ChallengeStatus.SUCCESS)
+                .count();
+
+        log.debug("[3] 총 인증 성공 횟수 - 개인: {}, 단체: {}, 합계: {}", personal, group, group + personal);
+        return group + personal;
+    }
+
+    private int countCompletedGroupChallenges(Member member) {
+        int count = (int) member.getGroupChallengeParticipantRecords().stream()
+                .filter(GroupChallengeParticipantRecord::isAllSuccess)
+                .count();
+        log.debug("[4] 단체 챌린지 완주 횟수: {}", count);
+        return count;
+    }
+
+    private List<RecentBadgeDto> fetchRecentBadges(Long memberId) {
+        List<RecentBadgeDto> result = memberBadgeRepository.findRecentBadgesByMemberId(memberId, 3)
+                .stream()
+                .map(b -> new RecentBadgeDto(
+                        b.getBadge().getId(),
+                        b.getBadge().getName(),
+                        b.getBadge().getImageUrl()))
+                .toList();
+        log.debug("[5] 최근 획득 뱃지 개수: {}", result.size());
+        return result;
+    }
+
+    private ProfileCardResponseDto buildResponse(
+            Member member,
+            TreeLevel current,
+            TreeLevel next,
+            int totalSuccess,
+            int completedGroupCount,
+            List<RecentBadgeDto> badges,
+            int leafPointsToNextLevel
+    ) {
+        return ProfileCardResponseDto.builder()
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getImageUrl())
+                .treeLevelId(current.getId())
+                .treeLevelName(current.getName().name())
+                .treeImageUrl(current.getImageUrl())
+                .nextTreeLevelName(next != null ? next.getName().name() : null)
+                .nextTreeImageUrl(next != null ? next.getImageUrl() : null)
+                .totalLeafPoints(member.getTotalLeafPoints())
+                .leafPointsToNextLevel(leafPointsToNextLevel)
+                .totalSuccessfulVerifications(totalSuccess)
+                .completedGroupChallengesCount(completedGroupCount)
+                .badges(badges)
+                .build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/TreeLevelRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/TreeLevelRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface TreeLevelRepository extends JpaRepository<TreeLevel, Long> {
 
     Optional<TreeLevel> findByName(TreeLevelName name);
+
+    Optional<TreeLevel> findFirstByMinLeafPointGreaterThanOrderByMinLeafPointAsc(int minLeafPoint);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/ProfileCardController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/ProfileCardController.java
@@ -1,0 +1,36 @@
+package ktb.leafresh.backend.domain.member.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import ktb.leafresh.backend.domain.member.application.service.ProfileCardReadService;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.ProfileCardResponseDto;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class ProfileCardController {
+
+    private final ProfileCardReadService profileCardReadService;
+
+    @GetMapping("/profilecard")
+    @Operation(summary = "프로필 카드 조회", description = "사용자의 닉네임, 트리 레벨, 누적 포인트, 최근 획득 뱃지 등을 포함한 프로필 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<ProfileCardResponseDto>> getProfileCard(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long memberId = userDetails.getMemberId();
+        log.debug("[프로필 카드 조회] 요청 - memberId: {}", memberId);
+
+        ProfileCardResponseDto response = profileCardReadService.getProfileCard(memberId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success("프로필 카드 조회에 성공하였습니다.", response)
+        );
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/ProfileCardResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/ProfileCardResponseDto.java
@@ -1,0 +1,24 @@
+package ktb.leafresh.backend.domain.member.presentation.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProfileCardResponseDto(
+        String nickname,
+        String profileImageUrl,
+        Long treeLevelId,
+        String treeLevelName,
+        String treeImageUrl,
+        String nextTreeLevelName,
+        String nextTreeImageUrl,
+        int totalLeafPoints,
+        int leafPointsToNextLevel,
+        int totalSuccessfulVerifications,
+        int completedGroupChallengesCount,
+        List<RecentBadgeDto> badges
+) {
+    @Builder
+    public record RecentBadgeDto(Long id, String name, String imageUrl) {}
+}

--- a/src/main/java/ktb/leafresh/backend/global/exception/MemberErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/MemberErrorCode.java
@@ -26,7 +26,10 @@ public enum MemberErrorCode implements BaseErrorCode {
     MEMBER_INFO_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 회원 정보를 조회하지 못했습니다."),
     BADGE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "뱃지 조회 권한이 없습니다."),
     BADGE_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 획득 뱃지를 찾을 수 없습니다."),
-    BADGE_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 인해 획득 뱃지 목록을 불러오지 못했습니다.");
+    BADGE_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 인해 획득 뱃지 목록을 불러오지 못했습니다."),
+    PROFILE_CARD_ACCESS_DENIED(HttpStatus.FORBIDDEN, "프로필 카드 조회 권한이 없습니다."),
+    PROFILE_CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자의 프로필 정보를 찾을 수 없습니다."),
+    PROFILE_CARD_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 인해 프로필 카드를 조회하지 못했습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 주요 변경사항

- `/api/members/profilecard` GET API 구현
- 트리 레벨/인증 횟수/뱃지 목록 포함된 프로필 카드 응답 반환
- 다음 레벨 정보가 없을 경우 null 처리
- 최근 획득 뱃지 3개 조회 기능 연동
- 인증 실패, 권한 없음, 사용자 정보 없음, 서버 오류 케이스에 대한 에러 메시지 상수화 및 통일