### PR TITLE
fix: exampleImages.new 매핑 오류 수정

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/request/GroupChallengeUpdateRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/request/GroupChallengeUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package ktb.leafresh.backend.domain.challenge.group.presentation.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -51,6 +52,7 @@ public record GroupChallengeUpdateRequestDto(
             @JsonSetter(nulls = Nulls.AS_EMPTY)
             @Schema(description = "기존 유지할 이미지 ID와 순서 목록") List<KeepImage> keep,
 
+            @JsonProperty("new")
             @JsonSetter(nulls = Nulls.AS_EMPTY)
             @Schema(description = "신규 추가할 이미지 목록") List<NewImage> newImages,
 


### PR DESCRIPTION
## 수정 내용
- JSON에서 `"new"` 키로 전달되던 인증 예시 이미지 리스트가 DTO의 `newImages` 필드에 매핑되지 않는 문제를 해결했습니다.
- `@JsonProperty("new")` 어노테이션을 적용하여 Jackson 매핑 오류를 제거했습니다.

## 영향 범위
- 단체 챌린지 수정 API (PATCH /api/challenges/group/{id})
- 기존 트랜잭션 처리 및 도메인 로직은 변경 없이 그대로 유지됩니다.

## 확인 사항
- 프론트에서 `"new"` 키로 전송된 이미지들이 정상적으로 매핑되는지 확인 완료
