### PR TITLE
feat: AI 서버 타임아웃 및 연결 실패 예외 처리 로직 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/HttpAiVerificationClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/HttpAiVerificationClient.java
@@ -11,6 +11,10 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+
+import java.net.SocketTimeoutException;
+import java.time.Duration;
 
 @Slf4j
 @Component
@@ -18,6 +22,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class HttpAiVerificationClient implements AiVerificationClient {
 
     private final WebClient aiServerWebClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public HttpAiVerificationClient(
             @Qualifier("aiServerWebClient") WebClient aiServerWebClient
@@ -36,13 +41,25 @@ public class HttpAiVerificationClient implements AiVerificationClient {
                     .bodyValue(requestDto)
                     .retrieve()
                     .bodyToMono(String.class)
-                    .block();
+                    .block(Duration.ofSeconds(5));
+//                    .block();
 
             log.info("[AI 응답 수신 완료]");
             log.debug("[AI 응답 원문 JSON] {}", rawJson);
 
-            AiVerificationApiResponseDto parsed =
-                    new ObjectMapper().readValue(rawJson, AiVerificationApiResponseDto.class);
+            if (rawJson == null || rawJson.isBlank()) {
+                log.error("[AI 응답 에러] 응답이 null 혹은 빈 문자열입니다. verificationId={}", requestDto.verificationId());
+                throw new CustomException(VerificationErrorCode.AI_SERVER_ERROR);
+            }
+
+            AiVerificationApiResponseDto parsed;
+            try {
+                parsed = objectMapper.readValue(rawJson, AiVerificationApiResponseDto.class);
+            } catch (Exception parseEx) {
+                log.error("[AI 응답 파싱 실패] JSON 파싱 중 예외 발생: {}", parseEx.getMessage(), parseEx);
+                log.error("[AI 응답 원문(JSON)] {}", rawJson); // 파싱 실패한 원본도 같이 출력
+                throw new CustomException(VerificationErrorCode.AI_SERVER_ERROR);
+            }
 
             if (parsed.status() == 202) {
                 log.info("[AI 응답] 인증 요청 정상 접수됨. 콜백을 기다립니다.");
@@ -62,12 +79,21 @@ public class HttpAiVerificationClient implements AiVerificationClient {
                 throw new CustomException(VerificationErrorCode.AI_VERIFICATION_FAILED);
             }
 
-            log.info("[검열 통과] AI 응답 result=true");
+            log.info("[검열 통과] AI 응답 result=true. verificationId={}", requestDto.verificationId());
 
         } catch (CustomException e) {
             throw e;
+        } catch (WebClientRequestException ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof SocketTimeoutException) {
+                log.error("[AI 서버 타임아웃] 응답 대기 중 시간 초과. verificationId={}", requestDto.verificationId(), ex);
+                throw new CustomException(VerificationErrorCode.AI_REQUEST_TIMEOUT);
+            }
+            log.error("[AI 서버 연결 실패] WebClient 요청 중 예외 발생. verificationId={}", requestDto.verificationId(), ex);
+            throw new CustomException(VerificationErrorCode.AI_CONNECTION_FAILED);
+
         } catch (Exception e) {
-            log.error("[AI 이미지 검열 중 예외 발생] {}", e.getMessage(), e);
+            log.error("[AI 이미지 검열 중 알 수 없는 예외 발생] {}", e.getMessage(), e);
             throw new CustomException(VerificationErrorCode.AI_SERVER_ERROR);
         }
     }

--- a/src/main/java/ktb/leafresh/backend/global/exception/VerificationErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/VerificationErrorCode.java
@@ -27,7 +27,11 @@ public enum VerificationErrorCode implements BaseErrorCode {
     RESULT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 인증 결과 저장 실패. 잠시 후 다시 시도해주세요."),
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 챌린지입니다."),
     CHALLENGE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 챌린지에 접근할 수 없습니다."),
-    RESULT_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 인증 결과를 조회하지 못했습니다.");
+    RESULT_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 인증 결과를 조회하지 못했습니다."),
+    AI_RESPONSE_FAILED(HttpStatus.BAD_REQUEST, "AI 응답 결과가 검열 실패로 판단되었습니다."),
+    AI_RESPONSE_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 응답 파싱에 실패했습니다."),
+    AI_REQUEST_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "AI 서버 응답이 시간 초과되었습니다."),
+    AI_CONNECTION_FAILED(HttpStatus.BAD_GATEWAY, "AI 서버에 연결할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 주요 변경 사항
- WebClientRequestException 내부 cause 확인하여 SocketTimeoutException 구분
- 타임아웃: AI_REQUEST_TIMEOUT 반환
- 연결 실패: AI_CONNECTION_FAILED 반환
- VerificationErrorCode 항목 확장