### PR TITLE
feat: 누적 나뭇잎 수 조회 API + Redis 캐시 및 초기화 로직 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/LeafPointReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/LeafPointReadService.java
@@ -1,0 +1,42 @@
+package ktb.leafresh.backend.domain.member.application.service;
+
+import ktb.leafresh.backend.global.exception.LeafPointErrorCode;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberLeafPointQueryRepository;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.TotalLeafPointResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LeafPointReadService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final MemberLeafPointQueryRepository memberLeafPointQueryRepository;
+
+    private static final String TOTAL_LEAF_SUM_KEY = "leafresh:totalLeafPoints:sum";
+
+    public TotalLeafPointResponseDto getTotalLeafPoints() {
+        try {
+            String cached = redisTemplate.opsForValue().get(TOTAL_LEAF_SUM_KEY);
+            if (cached != null) {
+                log.debug("[LeafPointReadService] Redis cache hit: {}", cached);
+                return new TotalLeafPointResponseDto(Integer.parseInt(cached));
+            }
+            log.debug("[LeafPointReadService] Redis cache miss. Querying DB...");
+
+            int sum = memberLeafPointQueryRepository.getTotalLeafPointSum();
+            redisTemplate.opsForValue().set(TOTAL_LEAF_SUM_KEY, String.valueOf(sum));
+            return new TotalLeafPointResponseDto(sum);
+        } catch (NumberFormatException e) {
+            log.error("[LeafPointReadService] Redis 캐싱 값 변환 실패", e);
+            throw new CustomException(LeafPointErrorCode.REDIS_FAILURE);
+        } catch (Exception e) {
+            log.error("[LeafPointReadService] 누적 나뭇잎 DB 조회 실패", e);
+            throw new CustomException(LeafPointErrorCode.DB_QUERY_FAILED);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/MemberLeafPointRewardService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/MemberLeafPointRewardService.java
@@ -1,0 +1,36 @@
+package ktb.leafresh.backend.domain.member.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberLeafPointRewardService {
+
+    private final MemberRepository memberRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String TOTAL_LEAF_SUM_KEY = "leafresh:totalLeafPoints:sum";
+
+    /**
+     * 트랜잭션 내에서만 Redis 증가 → DB 커밋 성공 시 Redis도 반영
+     */
+    @Transactional
+    public void rewardLeafPoints(Member member, int amount) {
+        member.addLeafPoints(amount);
+        memberRepository.save(member); // flush 포함됨
+
+        try {
+            redisTemplate.opsForValue().increment(TOTAL_LEAF_SUM_KEY, amount);
+            log.debug("[MemberService] Redis 누적 나뭇잎 증가 +{} 반영 완료", amount);
+        } catch (Exception e) {
+            log.warn("[MemberService] Redis 증가 실패 - 추후 초기화 필요: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberLeafPointQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberLeafPointQueryRepository.java
@@ -1,0 +1,5 @@
+package ktb.leafresh.backend.domain.member.infrastructure.repository;
+
+public interface MemberLeafPointQueryRepository {
+    int getTotalLeafPointSum();
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberLeafPointQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberLeafPointQueryRepositoryImpl.java
@@ -1,0 +1,28 @@
+package ktb.leafresh.backend.domain.member.infrastructure.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import ktb.leafresh.backend.domain.member.domain.entity.QMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberLeafPointQueryRepositoryImpl implements MemberLeafPointQueryRepository {
+
+    private final EntityManager em;
+
+    @Override
+    public int getTotalLeafPointSum() {
+        JPAQueryFactory query = new JPAQueryFactory(em);
+        QMember member = QMember.member;
+
+        Integer sum = query
+                .select(member.totalLeafPoints.sum())
+                .from(member)
+                .where(member.deletedAt.isNull())
+                .fetchOne();
+
+        return sum != null ? sum : 0;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/LeafPointController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/LeafPointController.java
@@ -1,0 +1,21 @@
+package ktb.leafresh.backend.domain.member.presentation.controller;
+
+import ktb.leafresh.backend.domain.member.application.service.LeafPointReadService;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.TotalLeafPointResponseDto;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/leaves")
+@RequiredArgsConstructor
+public class LeafPointController {
+
+    private final LeafPointReadService leafPointReadService;
+
+    @GetMapping("/count")
+    public ApiResponse<TotalLeafPointResponseDto> getTotalLeafPoints() {
+        TotalLeafPointResponseDto result = leafPointReadService.getTotalLeafPoints();
+        return ApiResponse.success("누적 나뭇잎 수 조회에 성공했습니다.", result);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/TotalLeafPointResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/TotalLeafPointResponseDto.java
@@ -1,0 +1,3 @@
+package ktb.leafresh.backend.domain.member.presentation.dto.response;
+
+public record TotalLeafPointResponseDto(int count) {}

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -62,6 +62,10 @@ public class SecurityConfig {
                         // images
                         .requestMatchers("/s3/images/presigned-url").permitAll()
 
+                        // 메인 페이지
+                        .requestMatchers("/api/leaves/count").permitAll()
+                        .requestMatchers("/api/challenges/verifications/count").permitAll()
+
                         // 테스트 컨트롤러용 허용 경로 추가
                         .requestMatchers("/spring/**").permitAll()
 

--- a/src/main/java/ktb/leafresh/backend/global/exception/LeafPointErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/LeafPointErrorCode.java
@@ -1,0 +1,19 @@
+package ktb.leafresh.backend.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum LeafPointErrorCode implements BaseErrorCode {
+    REDIS_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 조회에 실패했습니다."),
+    DB_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "DB에서 누적 나뭇잎 수 조회에 실패했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    LeafPointErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public HttpStatus getStatus() { return status; }
+    public String getMessage() { return message; }
+}

--- a/src/main/java/ktb/leafresh/backend/global/initializer/LeafPointInitializer.java
+++ b/src/main/java/ktb/leafresh/backend/global/initializer/LeafPointInitializer.java
@@ -1,0 +1,30 @@
+package ktb.leafresh.backend.global.initializer;
+
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberLeafPointQueryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LeafPointInitializer {
+
+    private final MemberLeafPointQueryRepository memberLeafPointQueryRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String TOTAL_LEAF_SUM_KEY = "leafresh:totalLeafPoints:sum";
+
+    @PostConstruct
+    public void initializeLeafPointCache() {
+        try {
+            int sum = memberLeafPointQueryRepository.getTotalLeafPointSum();
+            redisTemplate.opsForValue().set(TOTAL_LEAF_SUM_KEY, String.valueOf(sum));
+            log.info("[LeafPointInitializer] Redis 누적 나뭇잎 합계 초기화 완료: {}", sum);
+        } catch (Exception e) {
+            log.error("[LeafPointInitializer] Redis 초기화 실패", e);
+        }
+    }
+}


### PR DESCRIPTION
## 구현 내용
- `/api/leaves/count` 엔드포인트를 통한 누적 나뭇잎 수 조회 기능 구현
- Redis 캐시(`leafresh:totalLeafPoints:sum`) 기반 조회 + DB fallback 적용
- 애플리케이션 시작 시 Redis 초기화 로직 (`@PostConstruct`)
- MemberLeafPointRewardService를 통한 addLeafPoints() → Redis 동기화 반영

## 고려 사항
- TTL 없이 캐시 유지 (누적값은 영구 유지 목적)
- Redis 장애 시 DB fallback 및 로그 처리
- 모든 포인트 지급은 addLeafPoints() 기반으로 일관성 확보됨