### PR TITLE
feat: AI → BE → FE 인증 결과 SSE 스트리밍 구조 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/client/HttpFeedbackAiClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/client/HttpFeedbackAiClient.java
@@ -2,7 +2,7 @@ package ktb.leafresh.backend.domain.feedback.infrastructure.client;
 
 import ktb.leafresh.backend.domain.feedback.domain.model.WeeklyFeedbackPayload;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -12,18 +12,18 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Slf4j
 public class HttpFeedbackAiClient implements FeedbackAiClient {
 
-    private final WebClient webClient;
+    private final WebClient aiServerWebClient;
 
-    public HttpFeedbackAiClient(@Value("${ai-server.base-url}") String baseUrl) {
-        this.webClient = WebClient.builder()
-                .baseUrl(baseUrl)
-                .build();
+    public HttpFeedbackAiClient(
+            @Qualifier("aiServerWebClient") WebClient aiServerWebClient
+    ) {
+        this.aiServerWebClient = aiServerWebClient;
     }
 
     @Override
     public String requestWeeklyFeedback(WeeklyFeedbackPayload payload) {
         try {
-            return webClient.post()
+            return aiServerWebClient.post()
                     .uri("/feedback")
                     .bodyValue(payload)
                     .retrieve()

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultSaveService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultSaveService.java
@@ -1,17 +1,6 @@
 package ktb.leafresh.backend.domain.verification.application.service;
 
-import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
-import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
-import ktb.leafresh.backend.domain.member.application.service.RewardGrantService;
-import ktb.leafresh.backend.domain.member.domain.entity.Member;
-import ktb.leafresh.backend.domain.notification.application.service.NotificationCreateService;
-import ktb.leafresh.backend.domain.notification.domain.entity.enums.NotificationType;
-import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
-import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
 import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
-import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
-import ktb.leafresh.backend.global.exception.CustomException;
-import ktb.leafresh.backend.global.exception.VerificationErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,55 +11,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GroupChallengeVerificationResultSaveService {
 
-    private final GroupChallengeVerificationRepository groupVerificationRepository;
-    private final NotificationCreateService notificationCreateService;
-    private final RewardGrantService rewardGrantService;
+    private final VerificationResultProcessor verificationResultProcessor;
 
     @Transactional
     public void saveResult(Long verificationId, VerificationResultRequestDto dto) {
-        log.info("[단체 인증 결과 수신] verificationId={}, result={}", verificationId, dto.result());
-
-        GroupChallengeVerification verification = groupVerificationRepository.findById(verificationId)
-                .orElseThrow(() -> {
-                    log.error("[단체 인증 결과 저장 실패] verificationId={} 존재하지 않음", verificationId);
-                    throw new CustomException(VerificationErrorCode.VERIFICATION_NOT_FOUND);
-                });
-
-        ChallengeStatus newStatus = dto.result() ? ChallengeStatus.SUCCESS : ChallengeStatus.FAILURE;
-        verification.markVerified(newStatus);
-        log.info("[상태 업데이트 완료] verificationId={}, newStatus={}", verificationId, newStatus);
-
-        Member member = verification.getParticipantRecord().getMember();
-        GroupChallengeParticipantRecord record = verification.getParticipantRecord();
-        GroupChallenge challenge = record.getGroupChallenge();
-
-        notificationCreateService.createChallengeVerificationResultNotification(
-                member,
-                challenge.getTitle(),
-                dto.result(),
-                NotificationType.GROUP,
-                verification.getImageUrl(),
-                challenge.getId()
-        );
-        log.info("[알림 생성 완료] memberId={}, challengeTitle={}", member.getId(), challenge.getTitle());
-
-        // 1차 보상: 인증 성공 + 미보상 시 지급
-        if (dto.result() && !verification.isRewarded()) {
-            int reward = challenge.getLeafReward();
-            rewardGrantService.grantLeafPoints(member, reward);
-            verification.markRewarded();
-            log.info("[1차 보상 지급 완료] memberId={}, reward={}", member.getId(), reward);
-        }
-
-        // 2차 보상: 전체 성공 + 기간 일수만큼 인증 존재 + 미지급 시 지급
-        if (record.isAllSuccess()
-                && record.getVerifications().size() == challenge.getDurationInDays()
-                && !record.hasReceivedParticipationBonus()) {
-            rewardGrantService.grantParticipationBonus(member, record);
-            record.markParticipationBonusRewarded();
-            log.info("[2차 보너스 지급 완료] memberId={}, bonusGranted=true", member.getId());
-        }
-
-        log.info("[단체 인증 결과 저장 로직 완료] verificationId={}", verificationId);
+        log.info("[단체 인증 결과 위임 시작] verificationId={}, result={}", verificationId, dto.result());
+        verificationResultProcessor.process(verificationId, dto);
+        log.info("[단체 인증 결과 위임 완료] verificationId={}", verificationId);
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultSaveService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultSaveService.java
@@ -1,15 +1,6 @@
 package ktb.leafresh.backend.domain.verification.application.service;
 
-import ktb.leafresh.backend.domain.member.application.service.RewardGrantService;
-import ktb.leafresh.backend.domain.member.domain.entity.Member;
-import ktb.leafresh.backend.domain.notification.application.service.NotificationCreateService;
-import ktb.leafresh.backend.domain.notification.domain.entity.enums.NotificationType;
-import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
-import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
 import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
-import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
-import ktb.leafresh.backend.global.exception.CustomException;
-import ktb.leafresh.backend.global.exception.VerificationErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,52 +11,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PersonalChallengeVerificationResultSaveService {
 
-    private final PersonalChallengeVerificationRepository verificationRepository;
-    private final NotificationCreateService notificationCreateService;
-    private final RewardGrantService rewardGrantService;
+    private final VerificationResultProcessor verificationResultProcessor;
 
     @Transactional
     public void saveResult(Long verificationId, VerificationResultRequestDto dto) {
-        log.info("[개인 인증 결과 수신] verificationId={}, type={}, result={}", verificationId, dto.type(), dto.result());
-
-        PersonalChallengeVerification verification = verificationRepository.findById(verificationId)
-                .orElseThrow(() -> {
-                    log.error("[인증 결과 저장 실패] verificationId={}에 해당하는 인증이 존재하지 않음", verificationId);
-                    return new CustomException(VerificationErrorCode.VERIFICATION_NOT_FOUND);
-                });
-
-        ChallengeStatus newStatus = dto.result() ? ChallengeStatus.SUCCESS : ChallengeStatus.FAILURE;
-        verification.markVerified(newStatus);
-        log.info("[인증 상태 업데이트 완료] verificationId={}, newStatus={}", verificationId, newStatus);
-
-        Member member = verification.getMember();
-        String challengeTitle = verification.getPersonalChallenge().getTitle();
-
-        log.info("[알림 생성 시작] memberId={}, challengeTitle={}", member.getId(), challengeTitle);
-        notificationCreateService.createChallengeVerificationResultNotification(
-                member,
-                challengeTitle,
-                dto.result(),
-                NotificationType.PERSONAL,
-                verification.getImageUrl(),
-                verification.getPersonalChallenge().getId()
-        );
-        log.info("[알림 생성 완료]");
-
-        // 1차 보상: 성공 + 미보상 상태에서만 지급
-        if (dto.result()) {
-            if (verification.isRewarded()) {
-                log.warn("[보상 스킵] 이미 보상된 인증입니다. verificationId={}, memberId={}", verificationId, member.getId());
-            } else {
-                int reward = verification.getPersonalChallenge().getLeafReward();
-                log.info("[보상 지급 시작] reward={}, memberId={}", reward, member.getId());
-
-                rewardGrantService.grantLeafPoints(member, reward);
-                verification.markRewarded();  // 보상 완료 처리
-                log.info("[보상 지급 완료 및 상태 플래그 업데이트] verificationId={}, memberId={}", verificationId, member.getId());
-            }
-        }
-
-        log.info("[개인 인증 결과 저장 및 보상 로직 완료]");
+        log.info("[개인 인증 결과 위임 시작] verificationId={}, result={}", verificationId, dto.result());
+        verificationResultProcessor.process(verificationId, dto);
+        log.info("[개인 인증 결과 위임 완료] verificationId={}", verificationId);
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/VerificationResultProcessor.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/VerificationResultProcessor.java
@@ -1,0 +1,130 @@
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.member.application.service.RewardGrantService;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.notification.application.service.NotificationCreateService;
+import ktb.leafresh.backend.domain.notification.domain.entity.enums.NotificationType;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VerificationResultProcessor {
+
+    private final GroupChallengeVerificationRepository groupChallengeVerificationRepository;
+    private final PersonalChallengeVerificationRepository personalChallengeVerificationRepository;
+    private final NotificationCreateService notificationCreateService;
+    private final RewardGrantService rewardGrantService;
+
+    public void process(Long verificationId, VerificationResultRequestDto dto) {
+        if (dto.type() == ChallengeType.GROUP) {
+            processGroup(verificationId, dto);
+        } else {
+            processPersonal(verificationId, dto);
+        }
+    }
+
+    private void processGroup(Long verificationId, VerificationResultRequestDto dto) {
+        log.info("[Processor 단체 인증 결과 수신] verificationId={}, result={}", verificationId, dto.result());
+
+        GroupChallengeVerification verification = groupChallengeVerificationRepository.findById(verificationId)
+                .orElseThrow(() -> {
+                    log.error("[Processor 단체 인증 결과 저장 실패] verificationId={} 존재하지 않음", verificationId);
+                    throw new CustomException(VerificationErrorCode.VERIFICATION_NOT_FOUND);
+                });
+
+        ChallengeStatus newStatus = dto.result() ? ChallengeStatus.SUCCESS : ChallengeStatus.FAILURE;
+        verification.markVerified(newStatus);
+        log.info("[Processor 상태 업데이트 완료] verificationId={}, newStatus={}", verificationId, newStatus);
+
+        Member member = verification.getParticipantRecord().getMember();
+        GroupChallengeParticipantRecord record = verification.getParticipantRecord();
+        GroupChallenge challenge = record.getGroupChallenge();
+
+        notificationCreateService.createChallengeVerificationResultNotification(
+                member,
+                challenge.getTitle(),
+                dto.result(),
+                NotificationType.GROUP,
+                verification.getImageUrl(),
+                challenge.getId()
+        );
+        log.info("[Processor 알림 생성 완료] memberId={}, challengeTitle={}", member.getId(), challenge.getTitle());
+
+        // 1차 보상: 인증 성공 + 미보상 시 지급
+        if (dto.result() && !verification.isRewarded()) {
+            int reward = challenge.getLeafReward();
+            rewardGrantService.grantLeafPoints(member, reward);
+            verification.markRewarded();
+            log.info("[Processor 1차 보상 지급 완료] memberId={}, reward={}", member.getId(), reward);
+        }
+
+        // 2차 보상: 전체 성공 + 기간 일수만큼 인증 존재 + 미지급 시 지급
+        if (record.isAllSuccess()
+                && record.getVerifications().size() == challenge.getDurationInDays()
+                && !record.hasReceivedParticipationBonus()) {
+            rewardGrantService.grantParticipationBonus(member, record);
+            record.markParticipationBonusRewarded();
+            log.info("[Processor 2차 보너스 지급 완료] memberId={}, bonusGranted=true", member.getId());
+        }
+
+        log.info("[Processor 단체 인증 결과 저장 로직 완료] verificationId={}", verificationId);
+    }
+
+    private void processPersonal(Long verificationId, VerificationResultRequestDto dto) {
+        log.info("[Processor 개인 인증 결과 수신] verificationId={}, type={}, result={}", verificationId, dto.type(), dto.result());
+
+        PersonalChallengeVerification verification = personalChallengeVerificationRepository.findById(verificationId)
+                .orElseThrow(() -> {
+                    log.error("[Processor 인증 결과 저장 실패] verificationId={}에 해당하는 인증이 존재하지 않음", verificationId);
+                    return new CustomException(VerificationErrorCode.VERIFICATION_NOT_FOUND);
+                });
+
+        ChallengeStatus newStatus = dto.result() ? ChallengeStatus.SUCCESS : ChallengeStatus.FAILURE;
+        verification.markVerified(newStatus);
+        log.info("[Processor 인증 상태 업데이트 완료] verificationId={}, newStatus={}", verificationId, newStatus);
+
+        Member member = verification.getMember();
+        String challengeTitle = verification.getPersonalChallenge().getTitle();
+
+        log.info("[Processor 알림 생성 시작] memberId={}, challengeTitle={}", member.getId(), challengeTitle);
+        notificationCreateService.createChallengeVerificationResultNotification(
+                member,
+                challengeTitle,
+                dto.result(),
+                NotificationType.PERSONAL,
+                verification.getImageUrl(),
+                verification.getPersonalChallenge().getId()
+        );
+        log.info("[Processor 알림 생성 완료]");
+
+        // 1차 보상: 성공 + 미보상 상태에서만 지급
+        if (dto.result()) {
+            if (verification.isRewarded()) {
+                log.warn("[Processor 보상 스킵] 이미 보상된 인증입니다. verificationId={}, memberId={}", verificationId, member.getId());
+            } else {
+                int reward = verification.getPersonalChallenge().getLeafReward();
+                log.info("[Processor 보상 지급 시작] reward={}, memberId={}", reward, member.getId());
+
+                rewardGrantService.grantLeafPoints(member, reward);
+                verification.markRewarded();  // 보상 완료 처리
+                log.info("[Processor 보상 지급 완료 및 상태 플래그 업데이트] verificationId={}, memberId={}", verificationId, member.getId());
+            }
+        }
+
+        log.info("[Processor 개인 인증 결과 저장 및 보상 로직 완료]");
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/AiVerificationSseClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/AiVerificationSseClient.java
@@ -1,0 +1,8 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.client;
+
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationSsePayload;
+import reactor.core.publisher.Flux;
+
+public interface AiVerificationSseClient {
+    Flux<VerificationSsePayload> getFlux();
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/FakeAiVerificationSseClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/FakeAiVerificationSseClient.java
@@ -1,0 +1,19 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.client;
+
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationSsePayload;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+@Slf4j
+@Component
+@Profile("local")
+public class FakeAiVerificationSseClient implements AiVerificationSseClient {
+
+    @Override
+    public Flux<VerificationSsePayload> getFlux() {
+        log.warn("[Fake SSE 클라이언트] 로컬 환경에서는 SSE 스트리밍을 사용하지 않습니다.");
+        return Flux.never();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/HttpAiVerificationSseClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/HttpAiVerificationSseClient.java
@@ -1,0 +1,42 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.client;
+
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationSsePayload;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+
+@Slf4j
+@Component
+@Profile("!local")
+public class HttpAiVerificationSseClient implements AiVerificationSseClient {
+
+    private final WebClient aiServerWebClient;
+    private final Sinks.Many<VerificationSsePayload> sink = Sinks.many().multicast().onBackpressureBuffer();
+
+    public HttpAiVerificationSseClient(@Qualifier("aiServerWebClient") WebClient aiServerWebClient) {
+        this.aiServerWebClient = aiServerWebClient;
+        subscribeFromAi();
+    }
+
+    private void subscribeFromAi() {
+        aiServerWebClient.get()
+                .uri("/api/verifications/result/stream") // /api/verifications/{verificationId}/result/stream
+                .retrieve()
+                .bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<VerificationSsePayload>>() {})
+                .map(ServerSentEvent::data)
+                .doOnNext(sink::tryEmitNext)
+                .doOnError(e -> log.error("[SSE 연결 실패] {}", e.getMessage(), e))
+                .subscribe();
+    }
+
+    @Override
+    public Flux<VerificationSsePayload> getFlux() {
+        return sink.asFlux();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/stream/AiVerificationStreamDispatcher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/stream/AiVerificationStreamDispatcher.java
@@ -1,0 +1,65 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.stream;
+
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.verification.application.service.VerificationResultProcessor;
+import ktb.leafresh.backend.domain.verification.infrastructure.client.AiVerificationSseClient;
+import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationSsePayload;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiVerificationStreamDispatcher {
+
+    private final VerificationResultProcessor verificationResultProcessor;
+    private final AiVerificationSseClient sseClient;
+    private final Map<String, Sinks.Many<VerificationSsePayload>> userSinkMap = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    public void init() {
+        sseClient.getFlux().subscribe(event -> {
+            // 저장 로직: 상태 업데이트, 리워드 지급, 알림 생성
+            processVerificationResult(event);
+
+            // FE에게 결과 push
+            String key = key(event.memberId(), event.challengeId());
+            Sinks.Many<VerificationSsePayload> sink = userSinkMap.get(key);
+            if (sink != null) {
+                sink.tryEmitNext(event);
+            }
+        });
+    }
+
+    public Flux<VerificationSsePayload> subscribe(Long memberId, Long challengeId) {
+        String key = key(memberId, challengeId);
+        Sinks.Many<VerificationSsePayload> sink = Sinks.many().unicast().onBackpressureBuffer();
+        userSinkMap.put(key, sink);
+        return sink.asFlux();
+    }
+
+    private String key(Long memberId, Long challengeId) {
+        return memberId + "_" + challengeId;
+    }
+
+    private void processVerificationResult(VerificationSsePayload event) {
+        VerificationResultRequestDto dto = VerificationResultRequestDto.builder()
+                .type(ChallengeType.valueOf(event.challengeType()))
+                .memberId(event.memberId())
+                .challengeId(event.challengeId())
+                .date(LocalDateTime.now().toString())
+                .result(event.result())
+                .build();
+
+        verificationResultProcessor.process(event.verificationId(), dto);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupChallengeVerificationSubmitSseController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupChallengeVerificationSubmitSseController.java
@@ -1,0 +1,39 @@
+package ktb.leafresh.backend.domain.verification.presentation.controller;
+
+import ktb.leafresh.backend.domain.verification.infrastructure.stream.AiVerificationStreamDispatcher;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationSsePayload;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/challenges/group")
+@RequiredArgsConstructor
+public class GroupChallengeVerificationSubmitSseController {
+
+    private final AiVerificationStreamDispatcher dispatcher;
+
+    @GetMapping("/{challengeId}/verification/result/stream")
+    public Flux<ServerSentEvent<VerificationSsePayload>> streamGroupVerificationResult(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long challengeId
+    ) {
+        if (userDetails == null) {
+            log.warn("[단체 인증 SSE 수신 실패] 인증 정보가 없습니다.");
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        Long memberId = userDetails.getMemberId();
+        log.info("[단체 인증 SSE 구독 요청] challengeId={}, memberId={}", challengeId, memberId);
+
+        return dispatcher.subscribe(memberId, challengeId)
+                .map(data -> ServerSentEvent.<VerificationSsePayload>builder().data(data).build());
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/PersonalChallengeVerificationSubmitSseController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/PersonalChallengeVerificationSubmitSseController.java
@@ -1,0 +1,39 @@
+package ktb.leafresh.backend.domain.verification.presentation.controller;
+
+import ktb.leafresh.backend.domain.verification.infrastructure.stream.AiVerificationStreamDispatcher;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationSsePayload;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/challenges/personal")
+@RequiredArgsConstructor
+public class PersonalChallengeVerificationSubmitSseController {
+
+    private final AiVerificationStreamDispatcher dispatcher;
+
+    @GetMapping("/{challengeId}/verification/result/stream")
+    public Flux<ServerSentEvent<VerificationSsePayload>> streamPersonalVerificationResult(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long challengeId
+    ) {
+        if (userDetails == null) {
+            log.warn("[개인 인증 SSE 수신 실패] 인증 정보가 없습니다.");
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        Long memberId = userDetails.getMemberId();
+        log.info("[개인 인증 SSE 구독 요청] challengeId={}, memberId={}", challengeId, memberId);
+
+        return dispatcher.subscribe(memberId, challengeId)
+                .map(data -> ServerSentEvent.<VerificationSsePayload>builder().data(data).build());
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/VerificationResultSseController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/VerificationResultSseController.java
@@ -1,0 +1,38 @@
+package ktb.leafresh.backend.domain.verification.presentation.controller;
+
+import ktb.leafresh.backend.domain.verification.application.service.GroupChallengeVerificationResultSaveService;
+import ktb.leafresh.backend.domain.verification.application.service.PersonalChallengeVerificationResultSaveService;
+import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/verifications")
+@RequiredArgsConstructor
+public class VerificationResultSseController {
+
+    private final PersonalChallengeVerificationResultSaveService personalChallengeVerificationResultSaveService;
+    private final GroupChallengeVerificationResultSaveService groupChallengeVerificationResultSaveService;
+
+    @PostMapping("/{verificationId}/result/stream")
+    public ResponseEntity<ApiResponse<Void>> receiveResultStream(
+            @PathVariable Long verificationId,
+            @RequestBody @Validated VerificationResultRequestDto dto
+    ) {
+        log.info("[SSE 인증 결과 수신 API 호출] verificationId={}, result={}", verificationId, dto.result());
+
+        if (dto.type() == ChallengeType.GROUP) {
+            groupChallengeVerificationResultSaveService.saveResult(verificationId, dto);
+        } else {
+            personalChallengeVerificationResultSaveService.saveResult(verificationId, dto);
+        }
+
+        return ResponseEntity.ok(ApiResponse.success("SSE 인증 결과 수신 완료"));
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/dto/response/VerificationSsePayload.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/dto/response/VerificationSsePayload.java
@@ -1,0 +1,9 @@
+package ktb.leafresh.backend.domain.verification.presentation.dto.response;
+
+public record VerificationSsePayload(
+        Long verificationId,
+        Long memberId,
+        Long challengeId,
+        String challengeType, // "PERSONAL", "GROUP"
+        boolean result
+) {}

--- a/src/main/java/ktb/leafresh/backend/global/exception/GlobalErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/GlobalErrorCode.java
@@ -18,7 +18,8 @@ public enum GlobalErrorCode implements BaseErrorCode {
     INVALID_CURSOR(HttpStatus.BAD_REQUEST, "cursorId와 cursorTimestamp는 반드시 함께 전달되어야 합니다."),
     UNSUPPORTED_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 Content-Type입니다."),
     INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 이미지 URL입니다."),
-    NO_CONTENT(HttpStatus.BAD_REQUEST, "변경된 정보가 없습니다.");
+    VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 기록이 존재하지 않습니다."),
+    SSE_STREAM_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "SSE 스트림이 중단되었습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/ktb/leafresh/backend/global/util/stream/SseStreamExecutor.java
+++ b/src/main/java/ktb/leafresh/backend/global/util/stream/SseStreamExecutor.java
@@ -1,0 +1,21 @@
+package ktb.leafresh.backend.global.util.stream;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SseStreamExecutor {
+
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+
+    public void execute(SseEmitter emitter, Runnable task) {
+        executor.execute(task);
+    }
+}


### PR DESCRIPTION
## 요약

이 PR은 AI 서버로부터 인증 결과를 SSE 기반으로 스트리밍하여 BE → FE로 전송하는 기능을 도입합니다 (AI → BE → FE)

## 주요 변경 사항

- AI → BE
    - `AiVerificationSseClient` 인터페이스를 정의하고, `Fake` / `Http` 구현체를 추가하였습니다.
    - WebClient를 통해 AI 서버의 인증 SSE 스트림에 구독하도록 구성했습니다.
- BE 내부
    - `AiVerificationStreamDispatcher`가 AI 서버에서 수신한 이벤트를 처리하고, 사용자별 sink로 결과를 전송합니다.
    - `VerificationResultProcessor`를 통해 인증 상태 갱신 및 리워드 지급을 수행합니다.
- BE → FE
    - 프론트엔드가 `/verification/result/stream` 경로를 통해 인증 결과를 구독할 수 있도록 SSE 전용 엔드포인트를 추가했습니다.

## 참고 사항

- `verificationId`는 URI가 아닌 SSE 이벤트의 본문(payload)에 포함되어 전송됩니다.
- 로컬 환경에서는 `FakeAiVerificationSseClient`를 사용하여 실제 SSE 연결을 방지합니다.