### PR TITLE
feat: 챌린지 인증 요청 SSE 스트림 처리 기능 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/stream/AiVerificationStreamDispatcher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/stream/AiVerificationStreamDispatcher.java
@@ -5,13 +5,17 @@ import ktb.leafresh.backend.domain.verification.application.service.Verification
 import ktb.leafresh.backend.domain.verification.infrastructure.client.AiVerificationSseClient;
 import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
 import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationSsePayload;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationSseResponseDto;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
 import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
+import ktb.leafresh.backend.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -23,32 +27,64 @@ public class AiVerificationStreamDispatcher {
 
     private final VerificationResultProcessor verificationResultProcessor;
     private final AiVerificationSseClient sseClient;
-    private final Map<String, Sinks.Many<VerificationSsePayload>> userSinkMap = new ConcurrentHashMap<>();
+
+    private final Map<String, Sinks.Many<ApiResponse<VerificationSseResponseDto>>> sseSinkMap = new ConcurrentHashMap<>();
 
     @PostConstruct
     public void init() {
         sseClient.getFlux().subscribe(event -> {
-            // 저장 로직: 상태 업데이트, 리워드 지급, 알림 생성
-            processVerificationResult(event);
+            log.info("[1단계] SSE 이벤트 수신: verificationId={}, memberId={}, challengeId={}, type={}, result={}",
+                    event.verificationId(), event.memberId(), event.challengeId(), event.challengeType(), event.result());
 
-            // FE에게 결과 push
+            // 2단계: 인증 결과 저장 및 리워드 처리
+            log.info("[2단계] 인증 결과 처리 시작");
+            processVerificationResult(event);
+            log.info("[2단계] 인증 결과 처리 완료");
+
+            // 3단계: Sink 조회 및 응답 전송
             String key = key(event.memberId(), event.challengeId());
-            Sinks.Many<VerificationSsePayload> sink = userSinkMap.get(key);
+            Sinks.Many<ApiResponse<VerificationSseResponseDto>> sink = sseSinkMap.get(key);
+
             if (sink != null) {
-                sink.tryEmitNext(event);
+                VerificationSseResponseDto dto = VerificationSseResponseDto.fromBoolean(event.result());
+                var response = ApiResponse.success(dto.message(), dto);
+                sink.tryEmitNext(response);
+                log.info("[3단계] SSE 응답 전송 완료 - key={}, status={}, message={}", key, dto.status(), dto.message());
+            } else {
+                log.warn("[3단계] SSE Sink 미존재로 전송 생략 - key={}", key);
             }
         });
     }
 
-    public Flux<VerificationSsePayload> subscribe(Long memberId, Long challengeId) {
+    public Flux<ApiResponse<VerificationSseResponseDto>> subscribe(Long memberId, Long challengeId, ChallengeType type) {
         String key = key(memberId, challengeId);
-        Sinks.Many<VerificationSsePayload> sink = Sinks.many().unicast().onBackpressureBuffer();
-        userSinkMap.put(key, sink);
-        return sink.asFlux();
-    }
+        Sinks.Many<ApiResponse<VerificationSseResponseDto>> sink = Sinks.many().unicast().onBackpressureBuffer();
+        sseSinkMap.put(key, sink);
 
-    private String key(Long memberId, Long challengeId) {
-        return memberId + "_" + challengeId;
+        // 1단계: 초기 상태 조회
+        log.info("[초기 상태 조회] SSE 구독 요청 수신 - memberId={}, challengeId={}, type={}", memberId, challengeId, type);
+        ChallengeStatus status = verificationResultProcessor.getCurrentStatus(memberId, challengeId, type);
+        VerificationSseResponseDto dto = VerificationSseResponseDto.fromStatus(status);
+        var initialResponse = ApiResponse.success(dto.message(), dto);
+
+        // 2단계: 초기 응답 전송
+        sink.tryEmitNext(initialResponse);
+        log.info("[초기 응답 전송 완료] key={}, status={}, message={}", key, dto.status(), dto.message());
+
+        // 3단계: ping 이벤트 스트림
+        Flux<ApiResponse<VerificationSseResponseDto>> pingFlux = Flux
+                .interval(Duration.ofSeconds(30))
+                .map(i -> {
+                    log.debug("[PING 전송] key={}", key);
+                    return ApiResponse.success("ping", new VerificationSseResponseDto("PING", "ping"));
+                });
+
+        // 4단계: merge & 연결 종료 처리
+        return Flux.merge(sink.asFlux(), pingFlux)
+                .doFinally(signal -> {
+                    log.info("[SSE 연결 종료] key={}, 종료 signal={}", key, signal);
+                    sseSinkMap.remove(key);
+                });
     }
 
     private void processVerificationResult(VerificationSsePayload event) {
@@ -61,5 +97,9 @@ public class AiVerificationStreamDispatcher {
                 .build();
 
         verificationResultProcessor.process(event.verificationId(), dto);
+    }
+
+    private String key(Long memberId, Long challengeId) {
+        return memberId + "_" + challengeId;
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupChallengeVerificationSubmitSseController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupChallengeVerificationSubmitSseController.java
@@ -2,8 +2,11 @@ package ktb.leafresh.backend.domain.verification.presentation.controller;
 
 import ktb.leafresh.backend.domain.verification.infrastructure.stream.AiVerificationStreamDispatcher;
 import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationSsePayload;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationSseResponseDto;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +24,7 @@ public class GroupChallengeVerificationSubmitSseController {
     private final AiVerificationStreamDispatcher dispatcher;
 
     @GetMapping("/{challengeId}/verification/result/stream")
-    public Flux<ServerSentEvent<VerificationSsePayload>> streamGroupVerificationResult(
+    public Flux<ServerSentEvent<ApiResponse<VerificationSseResponseDto>>> streamGroupVerificationResult(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long challengeId
     ) {
@@ -33,7 +36,9 @@ public class GroupChallengeVerificationSubmitSseController {
         Long memberId = userDetails.getMemberId();
         log.info("[단체 인증 SSE 구독 요청] challengeId={}, memberId={}", challengeId, memberId);
 
-        return dispatcher.subscribe(memberId, challengeId)
-                .map(data -> ServerSentEvent.<VerificationSsePayload>builder().data(data).build());
+        return dispatcher.subscribe(memberId, challengeId, ChallengeType.GROUP)
+                .map(response -> ServerSentEvent.<ApiResponse<VerificationSseResponseDto>>builder()
+                        .data(response)
+                        .build());
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/PersonalChallengeVerificationSubmitSseController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/PersonalChallengeVerificationSubmitSseController.java
@@ -2,8 +2,11 @@ package ktb.leafresh.backend.domain.verification.presentation.controller;
 
 import ktb.leafresh.backend.domain.verification.infrastructure.stream.AiVerificationStreamDispatcher;
 import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationSsePayload;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationSseResponseDto;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +24,7 @@ public class PersonalChallengeVerificationSubmitSseController {
     private final AiVerificationStreamDispatcher dispatcher;
 
     @GetMapping("/{challengeId}/verification/result/stream")
-    public Flux<ServerSentEvent<VerificationSsePayload>> streamPersonalVerificationResult(
+    public Flux<ServerSentEvent<ApiResponse<VerificationSseResponseDto>>> streamPersonalVerificationResult(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long challengeId
     ) {
@@ -33,7 +36,9 @@ public class PersonalChallengeVerificationSubmitSseController {
         Long memberId = userDetails.getMemberId();
         log.info("[개인 인증 SSE 구독 요청] challengeId={}, memberId={}", challengeId, memberId);
 
-        return dispatcher.subscribe(memberId, challengeId)
-                .map(data -> ServerSentEvent.<VerificationSsePayload>builder().data(data).build());
+        return dispatcher.subscribe(memberId, challengeId, ChallengeType.PERSONAL)
+                .map(response -> ServerSentEvent.<ApiResponse<VerificationSseResponseDto>>builder()
+                        .data(response)
+                        .build());
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/dto/response/VerificationSseResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/dto/response/VerificationSseResponseDto.java
@@ -1,0 +1,23 @@
+package ktb.leafresh.backend.domain.verification.presentation.dto.response;
+
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+
+public record VerificationSseResponseDto(String status, String message) {
+
+    public static VerificationSseResponseDto fromStatus(ChallengeStatus status) {
+        return new VerificationSseResponseDto(status.name(), resolveMessage(status));
+    }
+
+    public static VerificationSseResponseDto fromBoolean(boolean result) {
+        return fromStatus(result ? ChallengeStatus.SUCCESS : ChallengeStatus.FAILURE);
+    }
+
+    public static String resolveMessage(ChallengeStatus status) {
+        return switch (status) {
+            case SUCCESS -> "인증에 성공했습니다.";
+            case FAILURE -> "인증에 실패했습니다.";
+            case PENDING_APPROVAL -> "아직 인증 결과가 도착하지 않았습니다.";
+            case NOT_SUBMITTED -> "아직 인증을 제출하지 않았습니다.";
+        };
+    }
+}


### PR DESCRIPTION
## 챌린지 인증 요청 SSE 기능 구현

- 인증 결과 SSE 전송을 위한 Dto 및 처리기 추가
- 개인/단체 챌린지 인증 결과 스트림 컨트롤러 구현
- AI 서버와의 통신을 위한 Dispatcher 및 Processor 분리