### PR TITLE
feat: 뱃지 지급 정책 도입 및 테스트 코드 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/BadgeGrantManager.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/BadgeGrantManager.java
@@ -1,0 +1,40 @@
+package ktb.leafresh.backend.domain.member.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.MemberBadge;
+import ktb.leafresh.backend.domain.member.domain.service.policy.BadgeGrantPolicy;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BadgeGrantManager {
+
+    private final List<BadgeGrantPolicy> policies;
+    private final MemberBadgeRepository memberBadgeRepository;
+
+    @Transactional
+    public void evaluateAllAndGrant(Member member) {
+        for (BadgeGrantPolicy policy : policies) {
+            List<Badge> newBadges = policy.evaluateAndGetNewBadges(member);
+            boolean grantedAny = false;
+            for (Badge badge : newBadges) {
+                if (!memberBadgeRepository.existsByMemberAndBadge(member, badge)) {
+                    memberBadgeRepository.save(MemberBadge.of(member, badge));
+                    log.info("[뱃지 지급] memberId={}, badgeName={}, policy={}", member.getId(), badge.getName(), policy.getClass().getSimpleName());
+                    grantedAny = true;
+                }
+            }
+            if (!grantedAny) {
+                log.debug("[뱃지 없음] memberId={}, policy={}", member.getId(), policy.getClass().getSimpleName());
+            }
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/policy/EventChallengeBadgePolicy.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/policy/EventChallengeBadgePolicy.java
@@ -1,0 +1,74 @@
+package ktb.leafresh.backend.domain.member.application.service.policy;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.service.policy.BadgeGrantPolicy;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventChallengeBadgePolicy implements BadgeGrantPolicy {
+
+    private final GroupChallengeVerificationRepository groupVerificationRepository;
+    private final BadgeRepository badgeRepository;
+    private final MemberBadgeRepository memberBadgeRepository;
+
+    // 이벤트명 → 뱃지명 매핑
+    private static final Map<String, String> eventToBadgeName = Map.ofEntries(
+            Map.entry("세계 습지의 날", "습지 전도사"),
+            Map.entry("고래의 날", "바다 지킴이"),
+            Map.entry("세계 물의 날", "물수호대"),
+            Map.entry("식목일", "나무 한 그루의 기적"),
+            Map.entry("지구의 날", "지구에게 쓴 편지"),
+            Map.entry("세계 퇴비 주간", "퇴비 마스터"),
+            Map.entry("공정무역의 날", "착한 소비러"),
+            Map.entry("바다의 날", "파도 위 발자국"),
+            Map.entry("환경의 날", "환경 루틴러"),
+            Map.entry("사막화와 가뭄 방지의 날", "양치컵 히어로"),
+            Map.entry("세계 호랑이의 날", "호랑이 친구"),
+            Map.entry("에너지의 날", "OFF 마스터"),
+            Map.entry("자원순환의 날", "자원순환 챔피언"),
+            Map.entry("세계 차 없는 날", "무탄소 여행자"),
+            Map.entry("세계 자연재해 감소의 날", "기후 기록자"),
+            Map.entry("세계 식량의 날", "비건 한 끼 도전자"),
+            Map.entry("농민의 날", "도시 농부")
+    );
+
+    @Override
+    public List<Badge> evaluateAndGetNewBadges(Member member) {
+        List<Badge> newBadges = new ArrayList<>();
+
+        List<String> eventTitles = groupVerificationRepository.findDistinctEventTitlesWithEventFlagTrue();
+        for (String eventTitle : eventTitles) {
+            long count = groupVerificationRepository.countByMemberIdAndEventTitleAndStatus(
+                    member.getId(), eventTitle, ChallengeStatus.SUCCESS);
+
+            if (count >= 3) {
+                String badgeName = eventToBadgeName.get(eventTitle);
+                if (badgeName != null) {
+                    badgeRepository.findByName(badgeName).ifPresent(badge -> {
+                        if (!memberBadgeRepository.existsByMemberAndBadge(member, badge)) {
+                            newBadges.add(badge);
+                        }
+                    });
+                } else {
+                    // 알 수 없는 이벤트명 대응 (로그만)
+                    log.warn("[이벤트 뱃지] 매핑되지 않은 이벤트명: {}", eventTitle);
+                }
+            }
+        }
+
+        return newBadges;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/policy/GroupChallengeCategoryBadgePolicy.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/policy/GroupChallengeCategoryBadgePolicy.java
@@ -1,0 +1,70 @@
+package ktb.leafresh.backend.domain.member.application.service.policy;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.service.policy.BadgeGrantPolicy;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Component
+@RequiredArgsConstructor
+public class GroupChallengeCategoryBadgePolicy implements BadgeGrantPolicy {
+
+    private final GroupChallengeVerificationRepository groupVerificationRepository;
+    private final BadgeRepository badgeRepository;
+    private final MemberBadgeRepository memberBadgeRepository;
+    private final GroupChallengeCategoryRepository groupChallengeCategoryRepository;
+
+    // 단체 챌린지 카테고리명 → 뱃지명 매핑
+    private static final Map<String, String> categoryToBadge = Map.of(
+            "제로웨이스트", "제로 히어로",
+            "플로깅", "플로깅 파이터",
+            "탄소 발자국", "발자국 줄이기 고수",
+            "에너지 절약", "절전 마스터",
+            "업사이클", "새활용 장인",
+            "문화 공유", "녹색 지식인",
+            "디지털 탄소", "디지털 디톡서",
+            "비건", "비건 챌린저"
+    );
+
+    @Override
+    public List<Badge> evaluateAndGetNewBadges(Member member) {
+        List<Badge> newBadges = new ArrayList<>();
+
+        for (Map.Entry<String, String> entry : categoryToBadge.entrySet()) {
+            String categoryName = entry.getKey();
+            String badgeName = entry.getValue();
+
+            // 문자열 → GroupChallengeCategory entity 조회
+            Optional<GroupChallengeCategory> optionalCategory =
+                    groupChallengeCategoryRepository.findByName(categoryName);
+
+            if (optionalCategory.isEmpty()) {
+                continue; // DB에 없는 카테고리는 스킵
+            }
+
+            GroupChallengeCategory category = optionalCategory.get();
+
+            long distinctSuccesses = groupVerificationRepository.countDistinctChallengesByMemberIdAndCategoryAndStatus(
+                    member.getId(), category, ChallengeStatus.SUCCESS);
+
+            if (distinctSuccesses >= 3) {
+                badgeRepository.findByName(badgeName).ifPresent(badge -> {
+                    if (!memberBadgeRepository.existsByMemberAndBadge(member, badge)) {
+                        newBadges.add(badge);
+                    }
+                });
+            }
+        }
+
+        return newBadges;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/policy/PersonalChallengeStreakBadgePolicy.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/policy/PersonalChallengeStreakBadgePolicy.java
@@ -1,0 +1,50 @@
+package ktb.leafresh.backend.domain.member.application.service.policy;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.service.policy.BadgeGrantPolicy;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class PersonalChallengeStreakBadgePolicy implements BadgeGrantPolicy {
+
+    private final PersonalChallengeVerificationRepository personalVerificationRepository;
+    private final BadgeRepository badgeRepository;
+    private final MemberBadgeRepository memberBadgeRepository;
+
+    // 연속 인증 기준 → 뱃지명
+    private static final Map<Integer, String> streakToBadgeName = Map.of(
+            3, "새싹 실천러",
+            7, "일주일의 습관",
+            14, "반달 에코러",
+            30, "한 달 챌린지 완주자"
+    );
+
+    @Override
+    public List<Badge> evaluateAndGetNewBadges(Member member) {
+        List<Badge> newBadges = new ArrayList<>();
+
+        int streakDays = personalVerificationRepository.countConsecutiveSuccessDays(member.getId());
+
+        for (Map.Entry<Integer, String> entry : streakToBadgeName.entrySet()) {
+            if (streakDays >= entry.getKey()) {
+                badgeRepository.findByName(entry.getValue()).ifPresent(badge -> {
+                    if (!memberBadgeRepository.existsByMemberAndBadge(member, badge)) {
+                        newBadges.add(badge);
+                    }
+                });
+            }
+        }
+
+        return newBadges;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/policy/SpecialBadgePolicy.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/policy/SpecialBadgePolicy.java
@@ -1,0 +1,99 @@
+package ktb.leafresh.backend.domain.member.application.service.policy;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.enums.GroupChallengeCategoryName;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.service.policy.BadgeGrantPolicy;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Component
+@RequiredArgsConstructor
+public class SpecialBadgePolicy implements BadgeGrantPolicy {
+
+    private final GroupChallengeVerificationRepository groupVerificationRepository;
+    private final PersonalChallengeVerificationRepository personalVerificationRepository;
+    private final BadgeRepository badgeRepository;
+    private final MemberBadgeRepository memberBadgeRepository;
+    private final GroupChallengeCategoryRepository groupChallengeCategoryRepository;
+
+    private static final Map<String, String> categoryToBadge = Map.of(
+            "제로웨이스트", "제로웨이스트",
+            "플로깅", "플로깅",
+            "탄소 발자국", "탄소 발자국",
+            "에너지 절약", "에너지 절약",
+            "업사이클", "업사이클",
+            "문화 공유", "문화 공유",
+            "디지털 탄소", "디지털 탄소",
+            "비건", "비건"
+    );
+
+    @Override
+    public List<Badge> evaluateAndGetNewBadges(Member member) {
+        List<Badge> newBadges = new ArrayList<>();
+
+        // 1. 모든 단체 카테고리 1회 이상 인증 성공 → 지속가능 전도사
+        List<GroupChallengeCategoryName> requiredCategories = Arrays.stream(GroupChallengeCategoryName.values())
+                .filter(category -> category != GroupChallengeCategoryName.ETC)
+                .toList();
+
+        boolean allGroupCategoriesCleared = requiredCategories.stream().allMatch(enumName ->
+                groupChallengeCategoryRepository.findByName(enumName.name())
+                        .map(categoryEntity ->
+                                groupVerificationRepository.existsByMemberIdAndCategoryAndStatus(
+                                        member.getId(), categoryEntity, ChallengeStatus.SUCCESS)
+                        ).orElse(false)
+        );
+        if (allGroupCategoriesCleared) {
+            addIfNotExists(member, "지속가능 전도사", newBadges);
+        }
+
+        // 2. 모든 개인 챌린지 유형 1회 이상 인증 성공 → 도전 전부러
+        List<String> allPersonalChallengeTitles = personalVerificationRepository.findAllPersonalChallengeTitles();
+        boolean allPersonalChallengesCleared = allPersonalChallengeTitles.stream().allMatch(title ->
+                personalVerificationRepository.existsByMemberIdAndPersonalChallengeTitleAndStatus(
+                        member.getId(), title, ChallengeStatus.SUCCESS)
+        );
+        if (allPersonalChallengesCleared) {
+            addIfNotExists(member, "도전 전부러", newBadges);
+        }
+
+        // 3. 하나의 단체 챌린지 카테고리에서 10회 이상 인증 성공 → {카테고리명} 마스터
+        for (GroupChallengeCategoryName categoryEnum : requiredCategories) {
+            groupChallengeCategoryRepository.findByName(categoryEnum.name())
+                    .ifPresent(category -> {
+                        long count = groupVerificationRepository.countByMemberIdAndCategoryAndStatus(
+                                member.getId(), category, ChallengeStatus.SUCCESS);
+                        if (count >= 10) {
+                            String badgeName = categoryEnum.getLabel() + " 마스터";
+                            addIfNotExists(member, badgeName, newBadges);
+                        }
+                    });
+        }
+
+        // 4. 30일 연속 개인 챌린지 인증 성공 → 에코 슈퍼루키
+        int streakDays = personalVerificationRepository.countConsecutiveSuccessDays(member.getId());
+        if (streakDays >= 30) {
+            addIfNotExists(member, "에코 슈퍼루키", newBadges);
+        }
+
+        return newBadges;
+    }
+
+    private void addIfNotExists(Member member, String badgeName, List<Badge> newBadges) {
+        badgeRepository.findByName(badgeName).ifPresent(badge -> {
+            if (!memberBadgeRepository.existsByMemberAndBadge(member, badge)) {
+                newBadges.add(badge);
+            }
+        });
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/policy/TotalVerificationCountBadgePolicy.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/policy/TotalVerificationCountBadgePolicy.java
@@ -1,0 +1,53 @@
+package ktb.leafresh.backend.domain.member.application.service.policy;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.service.policy.BadgeGrantPolicy;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class TotalVerificationCountBadgePolicy implements BadgeGrantPolicy {
+
+    private final GroupChallengeVerificationRepository groupVerificationRepository;
+    private final PersonalChallengeVerificationRepository personalVerificationRepository;
+    private final BadgeRepository badgeRepository;
+    private final MemberBadgeRepository memberBadgeRepository;
+
+    private static final Map<Integer, String> countToBadge = Map.of(
+            10, "첫 발자국",
+            30, "실천 중급자",
+            50, "지속가능 파이터",
+            100, "그린 마스터"
+    );
+
+    @Override
+    public List<Badge> evaluateAndGetNewBadges(Member member) {
+        List<Badge> newBadges = new ArrayList<>();
+
+        long total = groupVerificationRepository.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)
+                + personalVerificationRepository.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS);
+
+        for (Map.Entry<Integer, String> entry : countToBadge.entrySet()) {
+            if (total >= entry.getKey()) {
+                badgeRepository.findByName(entry.getValue()).ifPresent(badge -> {
+                    if (!memberBadgeRepository.existsByMemberAndBadge(member, badge)) {
+                        newBadges.add(badge);
+                    }
+                });
+            }
+        }
+
+        return newBadges;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/MemberBadge.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/MemberBadge.java
@@ -28,4 +28,12 @@ public class MemberBadge extends BaseEntity {
 
     @Column(name = "acquired_at", nullable = false)
     private LocalDateTime acquiredAt;
+
+    public static MemberBadge of(Member member, Badge badge) {
+        return MemberBadge.builder()
+                .member(member)
+                .badge(badge)
+                .acquiredAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/member/domain/service/policy/BadgeGrantPolicy.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/domain/service/policy/BadgeGrantPolicy.java
@@ -1,0 +1,10 @@
+package ktb.leafresh.backend.domain.member.domain.service.policy;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+
+import java.util.List;
+
+public interface BadgeGrantPolicy {
+    List<Badge> evaluateAndGetNewBadges(Member member);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberBadgeRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/infrastructure/repository/MemberBadgeRepository.java
@@ -1,8 +1,12 @@
 package ktb.leafresh.backend.domain.member.infrastructure.repository;
 
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.member.domain.entity.MemberBadge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberBadgeRepository extends JpaRepository<MemberBadge, Long>, MemberBadgeQueryRepository {
     // QueryDSL용 custom interface 분리
+
+    boolean existsByMemberAndBadge(Member member, Badge badge);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/VerificationResultProcessor.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/VerificationResultProcessor.java
@@ -2,6 +2,7 @@ package ktb.leafresh.backend.domain.verification.application.service;
 
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.member.application.service.BadgeGrantManager;
 import ktb.leafresh.backend.domain.member.application.service.RewardGrantService;
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.notification.application.service.NotificationCreateService;
@@ -30,6 +31,7 @@ public class VerificationResultProcessor {
     private final PersonalChallengeVerificationRepository personalChallengeVerificationRepository;
     private final NotificationCreateService notificationCreateService;
     private final RewardGrantService rewardGrantService;
+    private final BadgeGrantManager badgeGrantManager;
 
     public ChallengeStatus getCurrentStatus(Long memberId, Long challengeId, ChallengeType type) {
         LocalDateTime now = LocalDateTime.now();
@@ -105,6 +107,7 @@ public class VerificationResultProcessor {
             log.info("[Processor 2차 보너스 지급 완료] memberId={}, bonusGranted=true", member.getId());
         }
 
+        badgeGrantManager.evaluateAllAndGrant(member);
         log.info("[Processor 단체 인증 결과 저장 로직 완료] verificationId={}", verificationId);
     }
 
@@ -149,6 +152,7 @@ public class VerificationResultProcessor {
             }
         }
 
+        badgeGrantManager.evaluateAllAndGrant(member);
         log.info("[Processor 개인 인증 결과 저장 및 보상 로직 완료]");
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/GroupChallengeVerificationRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/GroupChallengeVerificationRepository.java
@@ -1,7 +1,11 @@
 package ktb.leafresh.backend.domain.verification.infrastructure.repository;
 
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
 import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,5 +33,90 @@ public interface GroupChallengeVerificationRepository extends JpaRepository<Grou
             LocalDateTime end
     );
 
-    List<GroupChallengeVerification> findAllByParticipantRecordId(Long participantRecordId);
+    /**
+     * 카테고리별 서로 다른 챌린지 인증 개수 (3개 이상일 때 사용)
+     */
+    @Query("""
+    SELECT COUNT(DISTINCT gcv.participantRecord.groupChallenge.id)
+    FROM GroupChallengeVerification gcv
+    WHERE gcv.participantRecord.member.id = :memberId
+      AND gcv.participantRecord.groupChallenge.category = :category
+      AND gcv.status = :status
+    """)
+    long countDistinctChallengesByMemberIdAndCategoryAndStatus(
+            @Param("memberId") Long memberId,
+            @Param("category") GroupChallengeCategory category,
+            @Param("status") ChallengeStatus status
+    );
+
+    /**
+     * 카테고리별 인증 횟수 (10회 이상 마스터 조건)
+     */
+    @Query("""
+    SELECT COUNT(gcv)
+    FROM GroupChallengeVerification gcv
+    WHERE gcv.participantRecord.member.id = :memberId
+      AND gcv.participantRecord.groupChallenge.category = :category
+      AND gcv.status = :status
+    """)
+    long countByMemberIdAndCategoryAndStatus(
+            @Param("memberId") Long memberId,
+            @Param("category") GroupChallengeCategory category,
+            @Param("status") ChallengeStatus status
+    );
+
+
+    /**
+     * 카테고리별 인증 1회 이상 여부 (지속가능 전도사 조건)
+     */
+    @Query("""
+    SELECT CASE WHEN COUNT(gcv) > 0 THEN true ELSE false END
+    FROM GroupChallengeVerification gcv
+    WHERE gcv.participantRecord.member.id = :memberId
+      AND gcv.participantRecord.groupChallenge.category = :category
+      AND gcv.status = :status
+    """)
+    boolean existsByMemberIdAndCategoryAndStatus(
+            @Param("memberId") Long memberId,
+            @Param("category") GroupChallengeCategory category,
+            @Param("status") ChallengeStatus status
+    );
+
+    /**
+     * 이벤트 챌린지 제목 목록 조회
+     */
+    @Query("""
+    SELECT DISTINCT gcv.participantRecord.groupChallenge.title
+    FROM GroupChallengeVerification gcv
+    WHERE gcv.participantRecord.groupChallenge.eventFlag = true
+    """)
+    List<String> findDistinctEventTitlesWithEventFlagTrue();
+
+    /**
+     * 특정 이벤트명에 대한 인증 횟수
+     */
+    @Query("""
+    SELECT COUNT(gcv)
+    FROM GroupChallengeVerification gcv
+    WHERE gcv.participantRecord.member.id = :memberId
+      AND gcv.participantRecord.groupChallenge.title = :eventTitle
+      AND gcv.participantRecord.groupChallenge.eventFlag = true
+      AND gcv.status = :status
+    """)
+    long countByMemberIdAndEventTitleAndStatus(
+            @Param("memberId") Long memberId,
+            @Param("eventTitle") String eventTitle,
+            @Param("status") ChallengeStatus status
+    );
+
+    @Query("""
+    SELECT COUNT(gcv)
+    FROM GroupChallengeVerification gcv
+    WHERE gcv.participantRecord.member.id = :memberId
+      AND gcv.status = :status
+    """)
+    long countByMemberIdAndStatus(
+            @Param("memberId") Long memberId,
+            @Param("status") ChallengeStatus status
+    );
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/PersonalChallengeVerificationCustomRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/PersonalChallengeVerificationCustomRepository.java
@@ -1,0 +1,5 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.repository;
+
+public interface PersonalChallengeVerificationCustomRepository {
+    int countConsecutiveSuccessDays(Long memberId);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/PersonalChallengeVerificationCustomRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/PersonalChallengeVerificationCustomRepositoryImpl.java
@@ -1,0 +1,52 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PersonalChallengeVerificationCustomRepositoryImpl implements PersonalChallengeVerificationCustomRepository {
+
+    @PersistenceContext
+    private final EntityManager em;
+
+    @Override
+    public int countConsecutiveSuccessDays(Long memberId) {
+        LocalDate thresholdDate = LocalDate.now().minusDays(30);
+
+        List<LocalDate> successDates = em.createQuery("""
+        SELECT pcv.createdAt
+        FROM PersonalChallengeVerification pcv
+        WHERE pcv.member.id = :memberId
+          AND pcv.status = 'SUCCESS'
+          AND pcv.createdAt >= :threshold
+        ORDER BY pcv.createdAt DESC
+        """, java.time.LocalDateTime.class)
+                .setParameter("memberId", memberId)
+                .setParameter("threshold", thresholdDate.atStartOfDay())
+                .getResultList().stream()
+                .map(java.time.LocalDateTime::toLocalDate)
+                .distinct()
+                .sorted((d1, d2) -> d2.compareTo(d1))
+                .toList();
+
+        // 오늘부터 연속 체크
+        int streak = 0;
+        LocalDate current = LocalDate.now();
+
+        for (LocalDate date : successDates) {
+            if (date.equals(current.minusDays(streak))) {
+                streak++;
+            } else {
+                break;
+            }
+        }
+
+        return streak;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/PersonalChallengeVerificationRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/PersonalChallengeVerificationRepository.java
@@ -1,17 +1,63 @@
 package ktb.leafresh.backend.domain.verification.infrastructure.repository;
 
 import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
-public interface PersonalChallengeVerificationRepository extends JpaRepository<PersonalChallengeVerification, Long> {
+public interface PersonalChallengeVerificationRepository extends JpaRepository<PersonalChallengeVerification, Long>,
+        PersonalChallengeVerificationCustomRepository {
 
     Optional<PersonalChallengeVerification> findTopByMemberIdAndPersonalChallengeIdAndCreatedAtBetween(
             Long memberId,
             Long challengeId,
             LocalDateTime startOfDay,
             LocalDateTime endOfDay
+    );
+
+    int countConsecutiveSuccessDays(Long memberId);
+
+    /**
+     * 전체 개인 챌린지 제목 조회
+     */
+    @Query("""
+    SELECT DISTINCT pcv.personalChallenge.title
+    FROM PersonalChallengeVerification pcv
+    """)
+    List<String> findAllPersonalChallengeTitles();
+
+    /**
+     * 특정 개인 챌린지 인증 성공 여부
+     */
+    @Query("""
+    SELECT CASE WHEN COUNT(pcv) > 0 THEN true ELSE false END
+    FROM PersonalChallengeVerification pcv
+    WHERE pcv.member.id = :memberId
+      AND pcv.personalChallenge.title = :title
+      AND pcv.status = :status
+    """)
+    boolean existsByMemberIdAndPersonalChallengeTitleAndStatus(
+            @Param("memberId") Long memberId,
+            @Param("title") String title,
+            @Param("status") ChallengeStatus status
+    );
+
+    /**
+     * 전체 개인 인증 횟수
+     */
+    @Query("""
+    SELECT COUNT(pcv)
+    FROM PersonalChallengeVerification pcv
+    WHERE pcv.member.id = :memberId
+      AND pcv.status = :status
+    """)
+    long countTotalByMemberIdAndStatus(
+            @Param("memberId") Long memberId,
+            @Param("status") ChallengeStatus status
     );
 }

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/BadgeGrantManagerTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/BadgeGrantManagerTest.java
@@ -1,0 +1,95 @@
+package ktb.leafresh.backend.domain.member.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.MemberBadge;
+import ktb.leafresh.backend.domain.member.domain.service.policy.BadgeGrantPolicy;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import ktb.leafresh.backend.support.fixture.BadgeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class BadgeGrantManagerTest {
+
+    private MemberBadgeRepository memberBadgeRepository;
+    private BadgeGrantPolicy policy1;
+    private BadgeGrantPolicy policy2;
+    private BadgeGrantManager badgeGrantManager;
+
+    @BeforeEach
+    void setUp() {
+        memberBadgeRepository = mock(MemberBadgeRepository.class);
+        policy1 = mock(BadgeGrantPolicy.class);
+        policy2 = mock(BadgeGrantPolicy.class);
+        badgeGrantManager = new BadgeGrantManager(List.of(policy1, policy2), memberBadgeRepository);
+    }
+
+
+    @Test
+    @DisplayName("모든 정책에서 나온 새 뱃지들을 저장한다")
+    void evaluateAllAndGrant_SaveNewBadgesFromAllPolicies() {
+        // Given
+        Member member = MemberFixture.of();
+        Badge badge1 = BadgeFixture.of("첫 발자국");
+        Badge badge2 = BadgeFixture.of("지속가능 파이터");
+
+        when(policy1.evaluateAndGetNewBadges(member)).thenReturn(List.of(badge1));
+        when(policy2.evaluateAndGetNewBadges(member)).thenReturn(List.of(badge2));
+
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge1)).thenReturn(false);
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge2)).thenReturn(false);
+
+        ArgumentCaptor<MemberBadge> captor = ArgumentCaptor.forClass(MemberBadge.class);
+
+        // When
+        badgeGrantManager.evaluateAllAndGrant(member);
+
+        // Then
+        verify(memberBadgeRepository, times(2)).save(captor.capture());
+        List<MemberBadge> saved = captor.getAllValues();
+        assertThat(saved).extracting(mb -> mb.getBadge().getName())
+                .containsExactlyInAnyOrder("첫 발자국", "지속가능 파이터");
+    }
+
+
+    @Test
+    @DisplayName("이미 보유한 뱃지는 저장하지 않는다")
+    void evaluateAllAndGrant_SkipAlreadyOwnedBadges() {
+        // Given
+        Member member = MemberFixture.of();
+        Badge badge = BadgeFixture.of("첫 발자국");
+
+        when(policy1.evaluateAndGetNewBadges(member)).thenReturn(List.of(badge));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(true); // 이미 보유
+
+        // When
+        badgeGrantManager.evaluateAllAndGrant(member);
+
+        // Then
+        verify(memberBadgeRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("정책에서 반환된 뱃지가 없을 경우 저장하지 않는다")
+    void evaluateAllAndGrant_NoBadgeToGrant() {
+        // Given
+        Member member = MemberFixture.of();
+
+        when(policy1.evaluateAndGetNewBadges(member)).thenReturn(List.of());
+        when(policy2.evaluateAndGetNewBadges(member)).thenReturn(List.of());
+
+        // When
+        badgeGrantManager.evaluateAllAndGrant(member);
+
+        // Then
+        verify(memberBadgeRepository, never()).save(any());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/EventChallengeBadgePolicyTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/EventChallengeBadgePolicyTest.java
@@ -1,0 +1,129 @@
+package ktb.leafresh.backend.domain.member.application.service.policy;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.support.fixture.BadgeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class EventChallengeBadgePolicyTest {
+
+    private GroupChallengeVerificationRepository groupVerificationRepository;
+    private BadgeRepository badgeRepository;
+    private MemberBadgeRepository memberBadgeRepository;
+    private EventChallengeBadgePolicy policy;
+
+    @BeforeEach
+    void setUp() {
+        groupVerificationRepository = mock(GroupChallengeVerificationRepository.class);
+        badgeRepository = mock(BadgeRepository.class);
+        memberBadgeRepository = mock(MemberBadgeRepository.class);
+        policy = new EventChallengeBadgePolicy(groupVerificationRepository, badgeRepository, memberBadgeRepository);
+    }
+
+    @Test
+    @DisplayName("이벤트 인증 3회 이상 성공 시 뱃지가 지급된다")
+    void evaluateAndGetNewBadges_GivenEventSuccessOver3_ThenGrantBadge() {
+        // Given
+        Member member = MemberFixture.of();
+        String eventTitle = "세계 습지의 날";
+        String badgeName = "습지 전도사";
+        Badge badge = BadgeFixture.of(badgeName);
+
+        when(groupVerificationRepository.findDistinctEventTitlesWithEventFlagTrue())
+                .thenReturn(List.of(eventTitle));
+
+        when(groupVerificationRepository.countByMemberIdAndEventTitleAndStatus(
+                member.getId(), eventTitle, ChallengeStatus.SUCCESS))
+                .thenReturn(3L);
+
+        when(badgeRepository.findByName(badgeName)).thenReturn(Optional.of(badge));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
+
+        // When
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        // Then
+        assertThat(result).containsExactly(badge);
+    }
+
+    @Test
+    @DisplayName("뱃지를 이미 보유한 경우에는 새로 지급되지 않는다")
+    void evaluateAndGetNewBadges_AlreadyOwnedBadge_ThenNoNewBadge() {
+        // Given
+        Member member = MemberFixture.of();
+        String eventTitle = "세계 습지의 날";
+        String badgeName = "습지 전도사";
+        Badge badge = BadgeFixture.of(badgeName);
+
+        when(groupVerificationRepository.findDistinctEventTitlesWithEventFlagTrue())
+                .thenReturn(List.of(eventTitle));
+
+        when(groupVerificationRepository.countByMemberIdAndEventTitleAndStatus(
+                member.getId(), eventTitle, ChallengeStatus.SUCCESS))
+                .thenReturn(3L);
+
+        when(badgeRepository.findByName(badgeName)).thenReturn(Optional.of(badge));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(true);
+
+        // When
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("이벤트명이 뱃지명과 매핑되지 않으면 무시된다")
+    void evaluateAndGetNewBadges_UnmappedEventTitle_ThenSkip() {
+        // Given
+        Member member = MemberFixture.of();
+        String unknownEvent = "무명 이벤트";
+
+        when(groupVerificationRepository.findDistinctEventTitlesWithEventFlagTrue())
+                .thenReturn(List.of(unknownEvent));
+
+        when(groupVerificationRepository.countByMemberIdAndEventTitleAndStatus(
+                member.getId(), unknownEvent, ChallengeStatus.SUCCESS))
+                .thenReturn(5L); // 조건은 만족하지만 매핑 없음
+
+        // When
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("성공 인증 횟수가 부족하면 뱃지를 지급하지 않는다")
+    void evaluateAndGetNewBadges_LessThan3Success_ThenNoBadge() {
+        // Given
+        Member member = MemberFixture.of();
+        String eventTitle = "세계 습지의 날";
+
+        when(groupVerificationRepository.findDistinctEventTitlesWithEventFlagTrue())
+                .thenReturn(List.of(eventTitle));
+
+        when(groupVerificationRepository.countByMemberIdAndEventTitleAndStatus(
+                member.getId(), eventTitle, ChallengeStatus.SUCCESS))
+                .thenReturn(2L); // 조건 미달
+
+        // When
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/GroupChallengeCategoryBadgePolicyTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/GroupChallengeCategoryBadgePolicyTest.java
@@ -1,0 +1,101 @@
+package ktb.leafresh.backend.domain.member.application.service.policy;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.support.fixture.BadgeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class GroupChallengeCategoryBadgePolicyTest {
+
+    private GroupChallengeVerificationRepository groupVerificationRepository;
+    private BadgeRepository badgeRepository;
+    private MemberBadgeRepository memberBadgeRepository;
+    private GroupChallengeCategoryRepository groupChallengeCategoryRepository;
+    private GroupChallengeCategoryBadgePolicy policy;
+
+    @BeforeEach
+    void setUp() {
+        groupVerificationRepository = mock(GroupChallengeVerificationRepository.class);
+        badgeRepository = mock(BadgeRepository.class);
+        memberBadgeRepository = mock(MemberBadgeRepository.class);
+        groupChallengeCategoryRepository = mock(GroupChallengeCategoryRepository.class);
+        policy = new GroupChallengeCategoryBadgePolicy(
+                groupVerificationRepository,
+                badgeRepository,
+                memberBadgeRepository,
+                groupChallengeCategoryRepository
+        );
+    }
+
+    @Test
+    @DisplayName("단체 챌린지 카테고리 인증 3회 이상 성공 시 뱃지가 지급된다")
+    void evaluateAndGetNewBadges_CategorySuccessOver3_ThenGrantBadge() {
+        Member member = MemberFixture.of();
+        String categoryName = "제로웨이스트";
+        String badgeName = "제로 히어로";
+        GroupChallengeCategory categoryEntity = mock(GroupChallengeCategory.class);
+        Badge badge = BadgeFixture.of(badgeName);
+
+        when(groupChallengeCategoryRepository.findByName(categoryName)).thenReturn(Optional.of(categoryEntity));
+        when(groupVerificationRepository.countDistinctChallengesByMemberIdAndCategoryAndStatus(
+                member.getId(), categoryEntity, ChallengeStatus.SUCCESS)).thenReturn(3L);
+        when(badgeRepository.findByName(badgeName)).thenReturn(Optional.of(badge));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        assertThat(result).containsExactly(badge);
+    }
+
+    @Test
+    @DisplayName("이미 해당 카테고리 뱃지를 보유 중이라면 새로 지급하지 않는다")
+    void evaluateAndGetNewBadges_AlreadyHasBadge_ThenNoNewBadge() {
+        Member member = MemberFixture.of();
+        String categoryName = "제로웨이스트";
+        String badgeName = "제로 히어로";
+        GroupChallengeCategory categoryEntity = mock(GroupChallengeCategory.class);
+        Badge badge = BadgeFixture.of(badgeName);
+
+        when(groupChallengeCategoryRepository.findByName(categoryName)).thenReturn(Optional.of(categoryEntity));
+        when(groupVerificationRepository.countDistinctChallengesByMemberIdAndCategoryAndStatus(
+                member.getId(), categoryEntity, ChallengeStatus.SUCCESS)).thenReturn(4L);
+        when(badgeRepository.findByName(badgeName)).thenReturn(Optional.of(badge));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(true);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("해당 카테고리 인증 성공이 부족하면 뱃지를 지급하지 않는다")
+    void evaluateAndGetNewBadges_NotEnoughSuccess_ThenNoBadge() {
+        Member member = MemberFixture.of();
+        String categoryName = "제로웨이스트";
+        String badgeName = "제로 히어로";
+        GroupChallengeCategory categoryEntity = mock(GroupChallengeCategory.class);
+
+        when(groupChallengeCategoryRepository.findByName(categoryName)).thenReturn(Optional.of(categoryEntity));
+        when(groupVerificationRepository.countDistinctChallengesByMemberIdAndCategoryAndStatus(
+                member.getId(), categoryEntity, ChallengeStatus.SUCCESS)).thenReturn(2L);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/PersonalChallengeStreakBadgePolicyTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/PersonalChallengeStreakBadgePolicyTest.java
@@ -1,0 +1,101 @@
+package ktb.leafresh.backend.domain.member.application.service.policy;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
+import ktb.leafresh.backend.support.fixture.BadgeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class PersonalChallengeStreakBadgePolicyTest {
+
+    private PersonalChallengeVerificationRepository verificationRepository;
+    private BadgeRepository badgeRepository;
+    private MemberBadgeRepository memberBadgeRepository;
+    private PersonalChallengeStreakBadgePolicy policy;
+
+    @BeforeEach
+    void setUp() {
+        verificationRepository = mock(PersonalChallengeVerificationRepository.class);
+        badgeRepository = mock(BadgeRepository.class);
+        memberBadgeRepository = mock(MemberBadgeRepository.class);
+        policy = new PersonalChallengeStreakBadgePolicy(verificationRepository, badgeRepository, memberBadgeRepository);
+    }
+
+    @Test
+    @DisplayName("연속 인증 일수에 따라 여러 뱃지가 지급된다")
+    void evaluateAndGetNewBadges_Given30DaysStreak_ThenMultipleBadgesGranted() {
+        // Given
+        Member member = MemberFixture.of();
+        when(verificationRepository.countConsecutiveSuccessDays(member.getId()))
+                .thenReturn(30);
+
+        Badge badge1 = BadgeFixture.of("새싹 실천러");
+        Badge badge2 = BadgeFixture.of("일주일의 습관");
+        Badge badge3 = BadgeFixture.of("반달 에코러");
+        Badge badge4 = BadgeFixture.of("한 달 챌린지 완주자");
+
+        when(badgeRepository.findByName("새싹 실천러")).thenReturn(Optional.of(badge1));
+        when(badgeRepository.findByName("일주일의 습관")).thenReturn(Optional.of(badge2));
+        when(badgeRepository.findByName("반달 에코러")).thenReturn(Optional.of(badge3));
+        when(badgeRepository.findByName("한 달 챌린지 완주자")).thenReturn(Optional.of(badge4));
+
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge1)).thenReturn(false);
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge2)).thenReturn(false);
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge3)).thenReturn(false);
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge4)).thenReturn(false);
+
+        // When
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrder(badge1, badge2, badge3, badge4);
+    }
+
+    @Test
+    @DisplayName("이미 보유한 뱃지는 지급되지 않는다")
+    void evaluateAndGetNewBadges_AlreadyOwned_ThenSkip() {
+        // Given
+        Member member = MemberFixture.of();
+        when(verificationRepository.countConsecutiveSuccessDays(member.getId()))
+                .thenReturn(14);
+
+        Badge badge = BadgeFixture.of("반달 에코러");
+
+        when(badgeRepository.findByName("새싹 실천러")).thenReturn(Optional.empty()); // 못 찾는 경우
+        when(badgeRepository.findByName("일주일의 습관")).thenReturn(Optional.empty());
+        when(badgeRepository.findByName("반달 에코러")).thenReturn(Optional.of(badge));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(true);
+
+        // When
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("연속 인증 일수가 부족하면 뱃지를 지급하지 않는다")
+    void evaluateAndGetNewBadges_StreakTooShort_ThenNoBadge() {
+        // Given
+        Member member = MemberFixture.of();
+        when(verificationRepository.countConsecutiveSuccessDays(member.getId()))
+                .thenReturn(1); // insufficient
+
+        // When
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/SpecialBadgePolicyTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/SpecialBadgePolicyTest.java
@@ -1,0 +1,122 @@
+package ktb.leafresh.backend.domain.member.application.service.policy;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.enums.GroupChallengeCategoryName;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.support.fixture.BadgeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class SpecialBadgePolicyTest {
+
+    private GroupChallengeVerificationRepository groupRepo;
+    private PersonalChallengeVerificationRepository personalRepo;
+    private BadgeRepository badgeRepository;
+    private MemberBadgeRepository memberBadgeRepository;
+    private GroupChallengeCategoryRepository groupChallengeCategoryRepository;
+    private SpecialBadgePolicy policy;
+
+    @BeforeEach
+    void setUp() {
+        groupRepo = mock(GroupChallengeVerificationRepository.class);
+        personalRepo = mock(PersonalChallengeVerificationRepository.class);
+        badgeRepository = mock(BadgeRepository.class);
+        memberBadgeRepository = mock(MemberBadgeRepository.class);
+        groupChallengeCategoryRepository = mock(GroupChallengeCategoryRepository.class);
+        policy = new SpecialBadgePolicy(groupRepo, personalRepo, badgeRepository, memberBadgeRepository, groupChallengeCategoryRepository);
+    }
+
+    @Test
+    @DisplayName("모든 그룹 챌린지 카테고리에서 1회 이상 인증 성공 시 '지속가능 전도사' 뱃지 지급")
+    void evaluateAllGroupCategoriesCleared_ThenGrantSustainabilityBadge() {
+        Member member = MemberFixture.of();
+        Badge badge = BadgeFixture.of("지속가능 전도사");
+
+        for (GroupChallengeCategoryName categoryEnum : GroupChallengeCategoryName.values()) {
+            if (categoryEnum == GroupChallengeCategoryName.ETC) continue;
+            GroupChallengeCategory categoryEntity = mock(GroupChallengeCategory.class);
+            when(groupChallengeCategoryRepository.findByName(categoryEnum.name())).thenReturn(Optional.of(categoryEntity));
+            when(groupRepo.existsByMemberIdAndCategoryAndStatus(member.getId(), categoryEntity, ChallengeStatus.SUCCESS)).thenReturn(true);
+        }
+
+        when(badgeRepository.findByName("지속가능 전도사")).thenReturn(Optional.of(badge));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+        assertThat(result).contains(badge);
+    }
+
+    @Test
+    @DisplayName("모든 개인 챌린지 인증 성공 시 '도전 전부러' 뱃지 지급")
+    void evaluateAllPersonalChallengesCleared_ThenGrantPersonalAllClearBadge() {
+        Member member = MemberFixture.of();
+        Badge badge = BadgeFixture.of("도전 전부러");
+
+        List<String> titles = List.of(
+                "텀블러 사용하기", "에코백 사용하기", "장바구니 사용하기", "자전거 타기",
+                "대중교통 이용하기", "샐러드/채식 식단 먹기", "음식 남기지 않기", "계단 이용하기",
+                "재활용 분리수거하기", "손수건 사용하기", "쓰레기 줍기", "안 쓰는 전기 플러그 뽑기",
+                "고체 비누 사용하기", "하루 만 보 걷기", "도시락 싸먹기", "작은 텃밭 가꾸기",
+                "반려 식물 인증", "전자 영수증 받기", "친환경 인증 마크 상품 구매하기",
+                "다회용기 사용하기", "책·전자책 읽기 인증하기"
+        );
+        when(personalRepo.findAllPersonalChallengeTitles()).thenReturn(titles);
+        titles.forEach(title ->
+                when(personalRepo.existsByMemberIdAndPersonalChallengeTitleAndStatus(member.getId(), title, ChallengeStatus.SUCCESS)).thenReturn(true)
+        );
+
+        when(badgeRepository.findByName("도전 전부러")).thenReturn(Optional.of(badge));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+        assertThat(result).contains(badge);
+    }
+
+    @Test
+    @DisplayName("특정 단체 카테고리에서 10회 인증 성공 시 '{카테고리명} 마스터' 뱃지 지급")
+    void evaluateCategoryMaster_ThenGrantMasterBadge() {
+        Member member = MemberFixture.of();
+        GroupChallengeCategoryName categoryEnum = GroupChallengeCategoryName.PLOGGING;
+        String badgeName = categoryEnum.getLabel() + " 마스터";
+        Badge badge = BadgeFixture.of(badgeName);
+
+        GroupChallengeCategory category = mock(GroupChallengeCategory.class);
+        when(groupChallengeCategoryRepository.findByName(categoryEnum.name())).thenReturn(Optional.of(category));
+        when(groupRepo.countByMemberIdAndCategoryAndStatus(member.getId(), category, ChallengeStatus.SUCCESS)).thenReturn(10L);
+
+        when(badgeRepository.findByName(badgeName)).thenReturn(Optional.of(badge));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+        assertThat(result).contains(badge);
+    }
+
+    @Test
+    @DisplayName("30일 연속 인증 성공 시 '에코 슈퍼루키' 뱃지 지급")
+    void evaluateConsecutive30Days_ThenGrantEcoBadge() {
+        Member member = MemberFixture.of();
+        Badge badge = BadgeFixture.of("에코 슈퍼루키");
+
+        when(personalRepo.countConsecutiveSuccessDays(member.getId())).thenReturn(30);
+        when(badgeRepository.findByName("에코 슈퍼루키")).thenReturn(Optional.of(badge));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+        assertThat(result).contains(badge);
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/TotalVerificationCountBadgePolicyTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/TotalVerificationCountBadgePolicyTest.java
@@ -1,0 +1,245 @@
+package ktb.leafresh.backend.domain.member.application.service.policy;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.support.fixture.BadgeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class TotalVerificationCountBadgePolicyTest {
+
+    private GroupChallengeVerificationRepository groupRepo;
+    private PersonalChallengeVerificationRepository personalRepo;
+    private BadgeRepository badgeRepository;
+    private MemberBadgeRepository memberBadgeRepository;
+    private TotalVerificationCountBadgePolicy policy;
+
+    @BeforeEach
+    void setUp() {
+        groupRepo = mock(GroupChallengeVerificationRepository.class);
+        personalRepo = mock(PersonalChallengeVerificationRepository.class);
+        badgeRepository = mock(BadgeRepository.class);
+        memberBadgeRepository = mock(MemberBadgeRepository.class);
+        policy = new TotalVerificationCountBadgePolicy(groupRepo, personalRepo, badgeRepository, memberBadgeRepository);
+    }
+
+    @Test
+    @DisplayName("총 10회 인증 성공 → '첫 발자국' 뱃지 지급")
+    void totalCount10_ThenGrantBeginnerBadge() {
+        Member member = MemberFixture.of();
+        String badgeName = "첫 발자국";
+        Badge badge = BadgeFixture.of(badgeName);
+
+        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(6L);
+        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(4L);
+        when(badgeRepository.findByName(badgeName)).thenReturn(Optional.of(badge));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        assertThat(result).extracting(Badge::getName).containsExactly(badgeName);
+    }
+
+    @Test
+    @DisplayName("총 30회 인증 성공 + 10회 뱃지 보유 → '실천 중급자' 뱃지만 지급")
+    void totalCount30_WithBeginnerBadgeOwned_ThenGrantOneBadge() {
+        Member member = MemberFixture.of();
+        Badge badge10 = BadgeFixture.of("첫 발자국");
+        Badge badge30 = BadgeFixture.of("실천 중급자");
+
+        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(15L);
+        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(15L);
+
+        when(badgeRepository.findByName("첫 발자국")).thenReturn(Optional.of(badge10));
+        when(badgeRepository.findByName("실천 중급자")).thenReturn(Optional.of(badge30));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge10)).thenReturn(true);
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge30)).thenReturn(false);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        assertThat(result).extracting(Badge::getName).containsExactly("실천 중급자");
+    }
+
+    @Test
+    @DisplayName("총 30회 인증 성공 → 2개 뱃지 지급")
+    void totalCount30_ThenGrantTwoBadges() {
+        Member member = MemberFixture.of();
+
+        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(20L);
+        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(10L);
+
+        List<String> expected = List.of("첫 발자국", "실천 중급자");
+        for (String name : expected) {
+            Badge badge = BadgeFixture.of(name);
+            when(badgeRepository.findByName(name)).thenReturn(Optional.of(badge));
+            when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
+        }
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        assertThat(result).extracting(Badge::getName).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    @Test
+    @DisplayName("총 50회 인증 성공 + 10, 30회 뱃지 보유 → '지속가능 파이터' 뱃지만 지급")
+    void totalCount50_With10And30BadgeOwned_ThenGrantOneBadge() {
+        Member member = MemberFixture.of();
+
+        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(30L);
+        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(20L);
+
+        Badge badge10 = BadgeFixture.of("첫 발자국");
+        Badge badge30 = BadgeFixture.of("실천 중급자");
+        Badge badge50 = BadgeFixture.of("지속가능 파이터");
+
+        when(badgeRepository.findByName("첫 발자국")).thenReturn(Optional.of(badge10));
+        when(badgeRepository.findByName("실천 중급자")).thenReturn(Optional.of(badge30));
+        when(badgeRepository.findByName("지속가능 파이터")).thenReturn(Optional.of(badge50));
+
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge10)).thenReturn(true);
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge30)).thenReturn(true);
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge50)).thenReturn(false);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        assertThat(result).extracting(Badge::getName).containsExactly("지속가능 파이터");
+    }
+
+    @Test
+    @DisplayName("총 50회 인증 성공 → 3개 뱃지 지급")
+    void totalCount50_ThenGrantThreeBadges() {
+        Member member = MemberFixture.of();
+
+        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(30L);
+        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(20L);
+
+        List<String> expected = List.of("첫 발자국", "실천 중급자", "지속가능 파이터");
+        for (String name : expected) {
+            Badge badge = BadgeFixture.of(name);
+            when(badgeRepository.findByName(name)).thenReturn(Optional.of(badge));
+            when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
+        }
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        assertThat(result).extracting(Badge::getName).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    @Test
+    @DisplayName("총 100회 인증 성공 + 10, 30, 50회 뱃지 보유 → '그린 마스터' 뱃지만 지급")
+    void totalCount100_WithAllBut100BadgeOwned_ThenGrantOneBadge() {
+        Member member = MemberFixture.of();
+
+        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(60L);
+        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(40L);
+
+        Badge badge10 = BadgeFixture.of("첫 발자국");
+        Badge badge30 = BadgeFixture.of("실천 중급자");
+        Badge badge50 = BadgeFixture.of("지속가능 파이터");
+        Badge badge100 = BadgeFixture.of("그린 마스터");
+
+        when(badgeRepository.findByName("첫 발자국")).thenReturn(Optional.of(badge10));
+        when(badgeRepository.findByName("실천 중급자")).thenReturn(Optional.of(badge30));
+        when(badgeRepository.findByName("지속가능 파이터")).thenReturn(Optional.of(badge50));
+        when(badgeRepository.findByName("그린 마스터")).thenReturn(Optional.of(badge100));
+
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge10)).thenReturn(true);
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge30)).thenReturn(true);
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge50)).thenReturn(true);
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge100)).thenReturn(false);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        assertThat(result).extracting(Badge::getName).containsExactly("그린 마스터");
+    }
+
+    @Test
+    @DisplayName("총 100회 인증 성공 → 4개 뱃지 지급")
+    void totalCount100_ThenGrantFourBadges() {
+        // Given
+        Member member = MemberFixture.of();
+        long group = 60L;
+        long personal = 40L;
+
+        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(group);
+        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(personal);
+
+        // 10, 30, 50, 100 이상 → 총 4개
+        List<String> expectedBadges = List.of("첫 발자국", "실천 중급자", "지속가능 파이터", "그린 마스터");
+
+        for (String badgeName : expectedBadges) {
+            Badge badge = BadgeFixture.of(badgeName);
+            when(badgeRepository.findByName(badgeName)).thenReturn(Optional.of(badge));
+            when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
+        }
+
+        // When
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        // Then
+        assertThat(result).extracting(Badge::getName).containsExactlyInAnyOrderElementsOf(expectedBadges);
+    }
+
+    @Test
+    @DisplayName("총 100회 인증 성공 + 모든 뱃지 보유 → 지급 없음")
+    void totalCount100_WithAllBadgesOwned_ThenGrantNone() {
+        Member member = MemberFixture.of();
+
+        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(60L);
+        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(40L);
+
+        List<String> allBadges = List.of("첫 발자국", "실천 중급자", "지속가능 파이터", "그린 마스터");
+        for (String name : allBadges) {
+            Badge badge = BadgeFixture.of(name);
+            when(badgeRepository.findByName(name)).thenReturn(Optional.of(badge));
+            when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(true);
+        }
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("성공 횟수 부족 시 뱃지 없음")
+    void totalCountUnder10_ThenNoBadge() {
+        Member member = MemberFixture.of();
+
+        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(3L);
+        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(5L);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("이미 보유한 뱃지는 중복 지급되지 않음")
+    void alreadyOwnedBadge_ThenSkip() {
+        Member member = MemberFixture.of();
+        String badgeName = "첫 발자국";
+        Badge badge = BadgeFixture.of(badgeName);
+
+        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(8L);
+        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(5L);
+        when(badgeRepository.findByName(badgeName)).thenReturn(Optional.of(badge));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(true);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/VerificationResultProcessorTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/VerificationResultProcessorTest.java
@@ -1,0 +1,124 @@
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.member.application.service.BadgeGrantManager;
+import ktb.leafresh.backend.domain.member.application.service.RewardGrantService;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.notification.application.service.NotificationCreateService;
+import ktb.leafresh.backend.domain.notification.domain.entity.enums.NotificationType;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+class VerificationResultProcessorTest {
+
+    private GroupChallengeVerificationRepository groupRepo;
+    private PersonalChallengeVerificationRepository personalRepo;
+    private NotificationCreateService notificationService;
+    private RewardGrantService rewardGrantService;
+    private BadgeGrantManager badgeGrantManager;
+    private VerificationResultProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        groupRepo = mock(GroupChallengeVerificationRepository.class);
+        personalRepo = mock(PersonalChallengeVerificationRepository.class);
+        notificationService = mock(NotificationCreateService.class);
+        rewardGrantService = mock(RewardGrantService.class);
+        badgeGrantManager = mock(BadgeGrantManager.class);
+        processor = new VerificationResultProcessor(groupRepo, personalRepo, notificationService, rewardGrantService, badgeGrantManager);
+    }
+
+    @Test
+    @DisplayName("단체 인증 성공 → 상태 업데이트 + 알림 + 보상 + 뱃지 지급")
+    void processGroupSuccess_ShouldGrantRewardAndBadge() {
+        // Given
+        Long verificationId = 1L;
+        VerificationResultRequestDto dto = VerificationResultRequestDto.builder()
+                .type(ChallengeType.GROUP)
+                .memberId(1L)
+                .challengeId(1L)
+                .date("2025-05-28")
+                .result(true)
+                .build();
+
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(1L);
+
+        GroupChallenge challenge = mock(GroupChallenge.class);
+        when(challenge.getTitle()).thenReturn("제로 챌린지");
+        when(challenge.getLeafReward()).thenReturn(10);
+        when(challenge.getDurationInDays()).thenReturn(3);
+
+        GroupChallengeVerification verification = mock(GroupChallengeVerification.class);
+        GroupChallengeParticipantRecord record = mock(GroupChallengeParticipantRecord.class);
+
+        when(groupRepo.findById(verificationId)).thenReturn(Optional.of(verification));
+        when(verification.getParticipantRecord()).thenReturn(record);
+        when(verification.getImageUrl()).thenReturn("url");
+        when(verification.isRewarded()).thenReturn(false);
+        when(record.getMember()).thenReturn(member);
+        when(record.getGroupChallenge()).thenReturn(challenge);
+        when(record.isAllSuccess()).thenReturn(false);
+
+        // When
+        processor.process(verificationId, dto);
+
+        // Then
+        verify(verification).markVerified(ChallengeStatus.SUCCESS);
+        verify(rewardGrantService).grantLeafPoints(member, 10);
+        verify(verification).markRewarded();
+        verify(notificationService).createChallengeVerificationResultNotification(eq(member), eq("제로 챌린지"), eq(true), eq(NotificationType.GROUP), eq("url"), any());
+        verify(badgeGrantManager).evaluateAllAndGrant(member);
+    }
+
+    @Test
+    @DisplayName("개인 인증 실패 → 상태만 업데이트 + 알림")
+    void processPersonalFail_ShouldUpdateStatusOnly() {
+        // Given
+        Long verificationId = 2L;
+        VerificationResultRequestDto dto = VerificationResultRequestDto.builder()
+                .type(ChallengeType.PERSONAL)
+                .memberId(1L)
+                .challengeId(1L)
+                .date("2025-05-28")
+                .result(false)
+                .build();
+
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(2L);
+
+        var challenge = mock(ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge.class);
+        when(challenge.getTitle()).thenReturn("텀블러 사용");
+        when(challenge.getId()).thenReturn(99L);
+
+        PersonalChallengeVerification verification = mock(PersonalChallengeVerification.class);
+        when(verification.getMember()).thenReturn(member);
+        when(verification.getImageUrl()).thenReturn("img");
+        when(verification.getPersonalChallenge()).thenReturn(challenge);
+        when(personalRepo.findById(verificationId)).thenReturn(Optional.of(verification));
+
+        // When
+        processor.process(verificationId, dto);
+
+        // Then
+        verify(verification).markVerified(ChallengeStatus.FAILURE);
+        verify(notificationService).createChallengeVerificationResultNotification(
+                eq(member), eq("텀블러 사용"), eq(false), eq(NotificationType.PERSONAL), eq("img"), eq(99L)
+        );
+        verifyNoInteractions(rewardGrantService);
+        verify(badgeGrantManager).evaluateAllAndGrant(member);
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/support/fixture/BadgeFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/BadgeFixture.java
@@ -1,0 +1,20 @@
+package ktb.leafresh.backend.support.fixture;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.enums.BadgeType;
+
+import java.util.ArrayList;
+
+public class BadgeFixture {
+
+    public static Badge of(String name) {
+        return Badge.builder()
+                .id(1L)
+                .memberBadges(new ArrayList<>())
+                .type(BadgeType.EVENT)
+                .name(name)
+                .condition("이벤트 인증 3회 성공 시 지급")
+                .imageUrl("https://dummy.image/badge/" + name + ".png")
+                .build();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/support/fixture/GroupChallengeCategoryFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/GroupChallengeCategoryFixture.java
@@ -1,0 +1,19 @@
+package ktb.leafresh.backend.support.fixture;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+
+import java.util.ArrayList;
+
+public class GroupChallengeCategoryFixture {
+
+    public static GroupChallengeCategory of(String name) {
+        return GroupChallengeCategory.builder()
+                .id(1L)
+                .groupChallenges(new ArrayList<>())
+                .name(name)
+                .imageUrl("https://dummy.image/category/" + name + ".png")
+                .sequenceNumber(1)
+                .activated(true)
+                .build();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/support/fixture/GroupChallengeFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/GroupChallengeFixture.java
@@ -1,0 +1,30 @@
+package ktb.leafresh.backend.support.fixture;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class GroupChallengeFixture {
+
+    public static GroupChallenge of(Member member, GroupChallengeCategory category) {
+        return GroupChallenge.builder()
+                .id(1L)
+                .member(member)
+                .category(category)
+                .title("제로웨이스트 챌린지")
+                .description("지속가능한 삶을 위한 실천")
+                .imageUrl("https://dummy.image/challenge.png")
+                .leafReward(10)
+                .startDate(LocalDateTime.now().minusDays(7))
+                .endDate(LocalDateTime.now().plusDays(7))
+                .verificationStartTime(LocalTime.of(6, 0))
+                .verificationEndTime(LocalTime.of(22, 0))
+                .maxParticipantCount(100)
+                .currentParticipantCount(10)
+                .eventFlag(true)
+                .build();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/support/fixture/GroupChallengeVerificationFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/GroupChallengeVerificationFixture.java
@@ -1,0 +1,18 @@
+package ktb.leafresh.backend.support.fixture;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+
+public class GroupChallengeVerificationFixture {
+
+    public static GroupChallengeVerification of(GroupChallengeParticipantRecord participantRecord) {
+        return GroupChallengeVerification.builder()
+                .participantRecord(participantRecord)
+                .imageUrl("https://dummy.image/verify.jpg")
+                .content("참여 인증")
+                .status(ChallengeStatus.SUCCESS)
+                .rewarded(true)
+                .build();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/support/fixture/MemberBadgeFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/MemberBadgeFixture.java
@@ -1,0 +1,22 @@
+package ktb.leafresh.backend.support.fixture;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.MemberBadge;
+
+import java.time.LocalDateTime;
+
+public class MemberBadgeFixture {
+
+    public static MemberBadge of(Member member, Badge badge) {
+        return MemberBadge.of(member, badge);
+    }
+
+    public static MemberBadge of(Member member, Badge badge, LocalDateTime acquiredAt) {
+        return MemberBadge.builder()
+                .member(member)
+                .badge(badge)
+                .acquiredAt(acquiredAt)
+                .build();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/support/fixture/MemberFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/MemberFixture.java
@@ -1,0 +1,31 @@
+package ktb.leafresh.backend.support.fixture;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.TreeLevel;
+import ktb.leafresh.backend.domain.member.domain.entity.enums.LoginType;
+import ktb.leafresh.backend.domain.member.domain.entity.enums.Role;
+
+import java.util.ArrayList;
+
+public class MemberFixture {
+
+    public static Member of() {
+        return of(1L, "test@leafresh.com", "테스터");
+    }
+
+    public static Member of(Long id, String email, String nickname) {
+        return Member.builder()
+                .id(id)
+                .treeLevel(TreeLevelFixture.defaultLevel())
+                .loginType(LoginType.SOCIAL)
+                .email(email)
+                .password(null)
+                .nickname(nickname)
+                .imageUrl("https://dummy.image/profile.png")
+                .role(Role.USER)
+                .activated(true)
+                .totalLeafPoints(0)
+                .currentLeafPoints(0)
+                .build();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/support/fixture/PersonalChallengeFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/PersonalChallengeFixture.java
@@ -1,0 +1,22 @@
+package ktb.leafresh.backend.support.fixture;
+
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
+
+import java.time.LocalTime;
+
+public class PersonalChallengeFixture {
+
+    public static PersonalChallenge of(String title) {
+        return PersonalChallenge.builder()
+                .id(1L)
+                .title(title)
+                .description("개인 챌린지 설명")
+                .imageUrl("https://dummy.image/personal.png")
+                .leafReward(5)
+                .dayOfWeek(DayOfWeek.MONDAY)
+                .verificationStartTime(LocalTime.of(5, 0))
+                .verificationEndTime(LocalTime.of(23, 0))
+                .build();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/support/fixture/PersonalChallengeVerificationFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/PersonalChallengeVerificationFixture.java
@@ -1,0 +1,24 @@
+package ktb.leafresh.backend.support.fixture;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+
+import java.time.LocalDateTime;
+
+public class PersonalChallengeVerificationFixture {
+
+    public static PersonalChallengeVerification of(Member member, PersonalChallenge challenge) {
+        return PersonalChallengeVerification.builder()
+                .member(member)
+                .personalChallenge(challenge)
+                .joinedAt(LocalDateTime.now().minusDays(1))
+                .imageUrl("https://dummy.image/personal-verify.jpg")
+                .content("개인 챌린지 인증")
+                .status(ChallengeStatus.SUCCESS)
+                .verifiedAt(LocalDateTime.now())
+                .rewarded(true)
+                .build();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/support/fixture/TreeLevelFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/TreeLevelFixture.java
@@ -1,0 +1,20 @@
+package ktb.leafresh.backend.support.fixture;
+
+import ktb.leafresh.backend.domain.member.domain.entity.TreeLevel;
+import ktb.leafresh.backend.domain.member.domain.entity.enums.TreeLevelName;
+
+import java.util.ArrayList;
+
+public class TreeLevelFixture {
+
+    public static TreeLevel defaultLevel() {
+        return TreeLevel.builder()
+                .id(1L)
+                .members(new ArrayList<>())
+                .name(TreeLevelName.SPROUT)
+                .minLeafPoint(0)
+                .imageUrl("https://dummy.image/tree/sprout.png")
+                .description("기본 트리 레벨")
+                .build();
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 뱃지 지급 정책을 설계하고 각 타입별 정책 클래스 (이벤트, 그룹, 개인, 누적, 스페셜)를 구현하였습니다.
- BadgeGrantPolicy 인터페이스와 BadgeGrantManager를 도입하여 전략 패턴 기반 구조로 적용했습니다.
- 각 정책별 단위 테스트를 작성하고, 필요한 Fixture와 Repository, CustomRepository를 구성했습니다.

## 주요 변경 사항
- 도메인 정책 클래스: EventChallengeBadgePolicy 등 5종
- 테스트 클래스: 정책 테스트 6종, Fixture 10종
- Repository: Custom 메서드 추가 및 구현