### PR TITLE
feat: 뱃지 목록 조회 API 구현 및 테스트 일괄 수정

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/BadgeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/BadgeReadService.java
@@ -1,0 +1,69 @@
+package ktb.leafresh.backend.domain.member.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.enums.BadgeType;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.BadgeListResponseDto;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.BadgeResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BadgeReadService {
+
+    private final BadgeRepository badgeRepository;
+    private final MemberRepository memberRepository;
+
+    private static final String LOCK_IMAGE_URL = "https://storage.googleapis.com/leafresh-images/init/badge/common/%E1%84%8C%E1%85%A1%E1%84%86%E1%85%AE%E1%86%AF%E1%84%89%E1%85%B3%E1%84%8B%E1%85%B5.png";
+
+    public BadgeListResponseDto getAllBadges(Long memberId) {
+        log.debug("[뱃지 목록 조회] 요청 시작 - memberId: {}", memberId);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> {
+                    log.warn("[뱃지 목록 조회] 존재하지 않는 회원 - memberId: {}", memberId);
+                    return new CustomException(MemberErrorCode.MEMBER_NOT_FOUND); // 404
+                });
+
+        try {
+            List<Badge> allBadges = badgeRepository.findAll();
+            if (allBadges.isEmpty()) {
+                log.warn("[뱃지 목록 조회] 뱃지 데이터 없음 - memberId: {}", memberId);
+                throw new CustomException(MemberErrorCode.BADGE_QUERY_FAILED); // 500
+            }
+
+            Set<Long> acquiredBadgeIds = member.getMemberBadges().stream()
+                    .map(memberBadge -> memberBadge.getBadge().getId())
+                    .collect(Collectors.toSet());
+
+            Map<BadgeType, List<BadgeResponseDto>> grouped = new EnumMap<>(BadgeType.class);
+            for (Badge badge : allBadges) {
+                boolean isLocked = !acquiredBadgeIds.contains(badge.getId());
+
+                BadgeResponseDto dto = BadgeResponseDto.of(badge, isLocked, LOCK_IMAGE_URL);
+                grouped.computeIfAbsent(badge.getType(), k -> new ArrayList<>()).add(dto);
+            }
+
+            log.debug("[뱃지 목록 조회] 성공 - memberId: {}", memberId);
+            return BadgeListResponseDto.from(grouped);
+
+        } catch (CustomException e) {
+            throw e;
+
+        } catch (Exception e) {
+            log.error("[뱃지 목록 조회] 처리 중 알 수 없는 오류 발생", e);
+            throw new CustomException(MemberErrorCode.BADGE_QUERY_FAILED); // 500
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/MemberBadgeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/MemberBadgeController.java
@@ -1,8 +1,14 @@
 package ktb.leafresh.backend.domain.member.presentation.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import ktb.leafresh.backend.domain.member.application.service.BadgeReadService;
 import ktb.leafresh.backend.domain.member.application.service.RecentBadgeReadService;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.BadgeListResponseDto;
 import ktb.leafresh.backend.domain.member.presentation.dto.response.RecentBadgeListResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 
@@ -20,6 +26,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 public class MemberBadgeController {
 
     private final RecentBadgeReadService recentBadgeReadService;
+    private final BadgeReadService badgeReadService;
 
     @GetMapping("/recent")
     @Operation(summary = "최근 획득한 뱃지 조회", description = "회원이 최근에 획득한 뱃지를 최신순으로 조회합니다.")
@@ -33,5 +40,27 @@ public class MemberBadgeController {
         RecentBadgeListResponseDto badges = recentBadgeReadService.getRecentBadges(memberId, count);
 
         return ResponseEntity.ok(ApiResponse.success("최근 획득한 뱃지 조회에 성공하였습니다.", badges));
+    }
+
+    @GetMapping
+    @Operation(summary = "뱃지 목록 전체 조회", description = "회원이 획득한 뱃지와 아직 획득하지 못한 뱃지를 모두 조회합니다.")
+    public ResponseEntity<ApiResponse<BadgeListResponseDto>> getAllBadges(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long memberId = userDetails.getMemberId();
+        log.debug("[뱃지 전체 조회 API] 요청 수신 - memberId: {}", memberId);
+
+        try {
+            BadgeListResponseDto badgeList = badgeReadService.getAllBadges(memberId);
+            return ResponseEntity.ok(ApiResponse.success("뱃지 목록 조회에 성공하였습니다.", badgeList));
+
+        } catch (CustomException e) {
+            log.warn("[뱃지 목록 조회] 처리 실패 - memberId: {}, reason: {}", memberId, e.getMessage());
+            throw e;
+
+        } catch (Exception e) {
+            log.error("[뱃지 목록 조회] 서버 내부 오류 발생 - memberId: {}", memberId, e);
+            throw new CustomException(MemberErrorCode.BADGE_QUERY_FAILED);
+        }
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/BadgeListResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/BadgeListResponseDto.java
@@ -1,0 +1,40 @@
+package ktb.leafresh.backend.domain.member.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.member.domain.entity.enums.BadgeType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class BadgeListResponseDto {
+
+    private final Map<String, List<BadgeResponseDto>> badges;
+
+    public static BadgeListResponseDto from(Map<BadgeType, List<BadgeResponseDto>> grouped) {
+        // 순서 보장 위해 LinkedHashMap 사용
+        Map<String, List<BadgeResponseDto>> result = new LinkedHashMap<>();
+
+        // 순서 명시
+        List<BadgeType> order = List.of(
+                BadgeType.GROUP,
+                BadgeType.PERSONAL,
+                BadgeType.TOTAL,
+                BadgeType.SPECIAL,
+                BadgeType.EVENT
+        );
+
+        for (BadgeType type : order) {
+            if (grouped.containsKey(type)) {
+                result.put(type.name().toLowerCase(), grouped.get(type));
+            }
+        }
+
+        return BadgeListResponseDto.builder()
+                .badges(result)
+                .build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/BadgeResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/BadgeResponseDto.java
@@ -1,0 +1,27 @@
+package ktb.leafresh.backend.domain.member.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BadgeResponseDto {
+    private Long id;
+    private String name;
+    private String condition;
+    private String imageUrl;
+    @JsonProperty("isLocked")
+    private boolean isLocked;
+
+    public static BadgeResponseDto of(Badge badge, boolean isLocked, String lockImageUrl) {
+        return BadgeResponseDto.builder()
+                .id(badge.getId())
+                .name(badge.getName())
+                .condition(badge.getCondition())
+                .imageUrl(isLocked ? lockImageUrl : badge.getImageUrl())
+                .isLocked(isLocked)
+                .build();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/BadgeGrantManagerTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/BadgeGrantManagerTest.java
@@ -32,14 +32,13 @@ class BadgeGrantManagerTest {
         badgeGrantManager = new BadgeGrantManager(List.of(policy1, policy2), memberBadgeRepository);
     }
 
-
     @Test
     @DisplayName("모든 정책에서 나온 새 뱃지들을 저장한다")
     void evaluateAllAndGrant_SaveNewBadgesFromAllPolicies() {
         // Given
         Member member = MemberFixture.of();
-        Badge badge1 = BadgeFixture.of("첫 발자국");
-        Badge badge2 = BadgeFixture.of("지속가능 파이터");
+        Badge badge1 = BadgeFixture.of(1L, "첫 발자국");
+        Badge badge2 = BadgeFixture.of(2L, "지속가능 파이터");
 
         when(policy1.evaluateAndGetNewBadges(member)).thenReturn(List.of(badge1));
         when(policy2.evaluateAndGetNewBadges(member)).thenReturn(List.of(badge2));
@@ -59,13 +58,12 @@ class BadgeGrantManagerTest {
                 .containsExactlyInAnyOrder("첫 발자국", "지속가능 파이터");
     }
 
-
     @Test
     @DisplayName("이미 보유한 뱃지는 저장하지 않는다")
     void evaluateAllAndGrant_SkipAlreadyOwnedBadges() {
         // Given
         Member member = MemberFixture.of();
-        Badge badge = BadgeFixture.of("첫 발자국");
+        Badge badge = BadgeFixture.of(1L, "첫 발자국");
 
         when(policy1.evaluateAndGetNewBadges(member)).thenReturn(List.of(badge));
         when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(true); // 이미 보유

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/BadgeReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/BadgeReadServiceTest.java
@@ -1,0 +1,90 @@
+package ktb.leafresh.backend.domain.member.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.BadgeListResponseDto;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.BadgeResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
+import ktb.leafresh.backend.support.fixture.BadgeFixture;
+import ktb.leafresh.backend.support.fixture.MemberBadgeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class BadgeReadServiceTest {
+
+    private BadgeRepository badgeRepository;
+    private MemberRepository memberRepository;
+    private BadgeReadService badgeReadService;
+
+    @BeforeEach
+    void setUp() {
+        badgeRepository = mock(BadgeRepository.class);
+        memberRepository = mock(MemberRepository.class);
+        badgeReadService = new BadgeReadService(badgeRepository, memberRepository);
+    }
+
+    @Test
+    @DisplayName("성공: 획득한 뱃지와 잠긴 뱃지를 구분해 반환한다")
+    void getAllBadges_GivenValidMember_WhenSomeBadgesAcquired_ThenReturnWithLockStatus() {
+        // Given
+        Long memberId = 1L;
+        Member member = MemberFixture.of(memberId, "tester@leafresh.com", "테스터");
+
+        Badge acquiredBadge = BadgeFixture.of(1L, "습지 전도사");
+        Badge lockedBadge = BadgeFixture.of(2L, "지속가능 전도사");
+
+        member.getMemberBadges().add(MemberBadgeFixture.of(member, acquiredBadge));
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(badgeRepository.findAll()).thenReturn(List.of(acquiredBadge, lockedBadge));
+
+        // When
+        BadgeListResponseDto response = badgeReadService.getAllBadges(memberId);
+
+        // Then
+        List<BadgeResponseDto> eventBadges = response.getBadges().get("event");
+        assertThat(eventBadges).hasSize(2);
+
+        assertThat(eventBadges)
+                .anySatisfy(badge -> assertThat(badge.isLocked()).isFalse())
+                .anySatisfy(badge -> assertThat(badge.isLocked()).isTrue());
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 회원 ID일 경우 예외를 던진다")
+    void getAllBadges_WhenMemberNotFound_ThenThrow404() {
+        // Given
+        Long memberId = 999L;
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // Expect
+        assertThatThrownBy(() -> badgeReadService.getAllBadges(memberId))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("실패: 뱃지 목록이 비어 있을 경우 예외를 던진다")
+    void getAllBadges_WhenBadgesEmpty_ThenThrow500() {
+        // Given
+        Member member = MemberFixture.of();
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(badgeRepository.findAll()).thenReturn(Collections.emptyList());
+
+        // Expect
+        assertThatThrownBy(() -> badgeReadService.getAllBadges(member.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(MemberErrorCode.BADGE_QUERY_FAILED.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/EventChallengeBadgePolicyTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/EventChallengeBadgePolicyTest.java
@@ -40,7 +40,7 @@ class EventChallengeBadgePolicyTest {
         Member member = MemberFixture.of();
         String eventTitle = "세계 습지의 날";
         String badgeName = "습지 전도사";
-        Badge badge = BadgeFixture.of(badgeName);
+        Badge badge = BadgeFixture.of(1L, badgeName);
 
         when(groupVerificationRepository.findDistinctEventTitlesWithEventFlagTrue())
                 .thenReturn(List.of(eventTitle));
@@ -66,7 +66,7 @@ class EventChallengeBadgePolicyTest {
         Member member = MemberFixture.of();
         String eventTitle = "세계 습지의 날";
         String badgeName = "습지 전도사";
-        Badge badge = BadgeFixture.of(badgeName);
+        Badge badge = BadgeFixture.of(2L, badgeName);
 
         when(groupVerificationRepository.findDistinctEventTitlesWithEventFlagTrue())
                 .thenReturn(List.of(eventTitle));

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/GroupChallengeCategoryBadgePolicyTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/GroupChallengeCategoryBadgePolicyTest.java
@@ -4,6 +4,7 @@ import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeC
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
 import ktb.leafresh.backend.domain.member.domain.entity.Badge;
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.enums.BadgeType;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
 import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
@@ -49,7 +50,7 @@ class GroupChallengeCategoryBadgePolicyTest {
         String categoryName = "제로웨이스트";
         String badgeName = "제로 히어로";
         GroupChallengeCategory categoryEntity = mock(GroupChallengeCategory.class);
-        Badge badge = BadgeFixture.of(badgeName);
+        Badge badge = BadgeFixture.of(1L, badgeName, BadgeType.GROUP);
 
         when(groupChallengeCategoryRepository.findByName(categoryName)).thenReturn(Optional.of(categoryEntity));
         when(groupVerificationRepository.countDistinctChallengesByMemberIdAndCategoryAndStatus(
@@ -69,7 +70,7 @@ class GroupChallengeCategoryBadgePolicyTest {
         String categoryName = "제로웨이스트";
         String badgeName = "제로 히어로";
         GroupChallengeCategory categoryEntity = mock(GroupChallengeCategory.class);
-        Badge badge = BadgeFixture.of(badgeName);
+        Badge badge = BadgeFixture.of(2L, badgeName, BadgeType.GROUP);
 
         when(groupChallengeCategoryRepository.findByName(categoryName)).thenReturn(Optional.of(categoryEntity));
         when(groupVerificationRepository.countDistinctChallengesByMemberIdAndCategoryAndStatus(

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/PersonalChallengeStreakBadgePolicyTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/PersonalChallengeStreakBadgePolicyTest.java
@@ -2,6 +2,7 @@ package ktb.leafresh.backend.domain.member.application.service.policy;
 
 import ktb.leafresh.backend.domain.member.domain.entity.Badge;
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.enums.BadgeType;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
 import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
@@ -40,10 +41,10 @@ class PersonalChallengeStreakBadgePolicyTest {
         when(verificationRepository.countConsecutiveSuccessDays(member.getId()))
                 .thenReturn(30);
 
-        Badge badge1 = BadgeFixture.of("새싹 실천러");
-        Badge badge2 = BadgeFixture.of("일주일의 습관");
-        Badge badge3 = BadgeFixture.of("반달 에코러");
-        Badge badge4 = BadgeFixture.of("한 달 챌린지 완주자");
+        Badge badge1 = BadgeFixture.of(1L, "새싹 실천러", BadgeType.PERSONAL);
+        Badge badge2 = BadgeFixture.of(2L, "일주일의 습관", BadgeType.PERSONAL);
+        Badge badge3 = BadgeFixture.of(3L, "반달 에코러", BadgeType.PERSONAL);
+        Badge badge4 = BadgeFixture.of(4L, "한 달 챌린지 완주자", BadgeType.PERSONAL);
 
         when(badgeRepository.findByName("새싹 실천러")).thenReturn(Optional.of(badge1));
         when(badgeRepository.findByName("일주일의 습관")).thenReturn(Optional.of(badge2));
@@ -70,7 +71,7 @@ class PersonalChallengeStreakBadgePolicyTest {
         when(verificationRepository.countConsecutiveSuccessDays(member.getId()))
                 .thenReturn(14);
 
-        Badge badge = BadgeFixture.of("반달 에코러");
+        Badge badge = BadgeFixture.of(5L, "반달 에코러", BadgeType.PERSONAL);
 
         when(badgeRepository.findByName("새싹 실천러")).thenReturn(Optional.empty()); // 못 찾는 경우
         when(badgeRepository.findByName("일주일의 습관")).thenReturn(Optional.empty());

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/SpecialBadgePolicyTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/SpecialBadgePolicyTest.java
@@ -5,6 +5,7 @@ import ktb.leafresh.backend.domain.challenge.group.domain.entity.enums.GroupChal
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
 import ktb.leafresh.backend.domain.member.domain.entity.Badge;
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.enums.BadgeType;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
 import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
@@ -45,7 +46,7 @@ class SpecialBadgePolicyTest {
     @DisplayName("모든 그룹 챌린지 카테고리에서 1회 이상 인증 성공 시 '지속가능 전도사' 뱃지 지급")
     void evaluateAllGroupCategoriesCleared_ThenGrantSustainabilityBadge() {
         Member member = MemberFixture.of();
-        Badge badge = BadgeFixture.of("지속가능 전도사");
+        Badge badge = BadgeFixture.of(1L, "지속가능 전도사", BadgeType.SPECIAL);
 
         for (GroupChallengeCategoryName categoryEnum : GroupChallengeCategoryName.values()) {
             if (categoryEnum == GroupChallengeCategoryName.ETC) continue;
@@ -65,7 +66,7 @@ class SpecialBadgePolicyTest {
     @DisplayName("모든 개인 챌린지 인증 성공 시 '도전 전부러' 뱃지 지급")
     void evaluateAllPersonalChallengesCleared_ThenGrantPersonalAllClearBadge() {
         Member member = MemberFixture.of();
-        Badge badge = BadgeFixture.of("도전 전부러");
+        Badge badge = BadgeFixture.of(2L, "도전 전부러", BadgeType.SPECIAL);
 
         List<String> titles = List.of(
                 "텀블러 사용하기", "에코백 사용하기", "장바구니 사용하기", "자전거 타기",
@@ -93,7 +94,7 @@ class SpecialBadgePolicyTest {
         Member member = MemberFixture.of();
         GroupChallengeCategoryName categoryEnum = GroupChallengeCategoryName.PLOGGING;
         String badgeName = categoryEnum.getLabel() + " 마스터";
-        Badge badge = BadgeFixture.of(badgeName);
+        Badge badge = BadgeFixture.of(3L, badgeName, BadgeType.SPECIAL);
 
         GroupChallengeCategory category = mock(GroupChallengeCategory.class);
         when(groupChallengeCategoryRepository.findByName(categoryEnum.name())).thenReturn(Optional.of(category));
@@ -110,7 +111,7 @@ class SpecialBadgePolicyTest {
     @DisplayName("30일 연속 인증 성공 시 '에코 슈퍼루키' 뱃지 지급")
     void evaluateConsecutive30Days_ThenGrantEcoBadge() {
         Member member = MemberFixture.of();
-        Badge badge = BadgeFixture.of("에코 슈퍼루키");
+        Badge badge = BadgeFixture.of(4L, "에코 슈퍼루키", BadgeType.SPECIAL);
 
         when(personalRepo.countConsecutiveSuccessDays(member.getId())).thenReturn(30);
         when(badgeRepository.findByName("에코 슈퍼루키")).thenReturn(Optional.of(badge));

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/TotalVerificationCountBadgePolicyTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/policy/TotalVerificationCountBadgePolicyTest.java
@@ -2,6 +2,7 @@ package ktb.leafresh.backend.domain.member.application.service.policy;
 
 import ktb.leafresh.backend.domain.member.domain.entity.Badge;
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.enums.BadgeType;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberBadgeRepository;
 import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
@@ -40,25 +41,24 @@ class TotalVerificationCountBadgePolicyTest {
     @DisplayName("총 10회 인증 성공 → '첫 발자국' 뱃지 지급")
     void totalCount10_ThenGrantBeginnerBadge() {
         Member member = MemberFixture.of();
-        String badgeName = "첫 발자국";
-        Badge badge = BadgeFixture.of(badgeName);
+        Badge badge = BadgeFixture.of(1L, "첫 발자국", BadgeType.TOTAL);
 
         when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(6L);
         when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(4L);
-        when(badgeRepository.findByName(badgeName)).thenReturn(Optional.of(badge));
+        when(badgeRepository.findByName("첫 발자국")).thenReturn(Optional.of(badge));
         when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
 
         List<Badge> result = policy.evaluateAndGetNewBadges(member);
 
-        assertThat(result).extracting(Badge::getName).containsExactly(badgeName);
+        assertThat(result).extracting(Badge::getName).containsExactly("첫 발자국");
     }
 
     @Test
     @DisplayName("총 30회 인증 성공 + 10회 뱃지 보유 → '실천 중급자' 뱃지만 지급")
     void totalCount30_WithBeginnerBadgeOwned_ThenGrantOneBadge() {
         Member member = MemberFixture.of();
-        Badge badge10 = BadgeFixture.of("첫 발자국");
-        Badge badge30 = BadgeFixture.of("실천 중급자");
+        Badge badge10 = BadgeFixture.of(1L, "첫 발자국", BadgeType.TOTAL);
+        Badge badge30 = BadgeFixture.of(2L, "실천 중급자", BadgeType.TOTAL);
 
         when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(15L);
         when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(15L);
@@ -81,34 +81,33 @@ class TotalVerificationCountBadgePolicyTest {
         when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(20L);
         when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(10L);
 
-        List<String> expected = List.of("첫 발자국", "실천 중급자");
-        for (String name : expected) {
-            Badge badge = BadgeFixture.of(name);
-            when(badgeRepository.findByName(name)).thenReturn(Optional.of(badge));
-            when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
-        }
+        Badge badge10 = BadgeFixture.of(1L, "첫 발자국", BadgeType.TOTAL);
+        Badge badge30 = BadgeFixture.of(2L, "실천 중급자", BadgeType.TOTAL);
+
+        when(badgeRepository.findByName("첫 발자국")).thenReturn(Optional.of(badge10));
+        when(badgeRepository.findByName("실천 중급자")).thenReturn(Optional.of(badge30));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge10)).thenReturn(false);
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge30)).thenReturn(false);
 
         List<Badge> result = policy.evaluateAndGetNewBadges(member);
 
-        assertThat(result).extracting(Badge::getName).containsExactlyInAnyOrderElementsOf(expected);
+        assertThat(result).extracting(Badge::getName).containsExactlyInAnyOrder("첫 발자국", "실천 중급자");
     }
 
     @Test
     @DisplayName("총 50회 인증 성공 + 10, 30회 뱃지 보유 → '지속가능 파이터' 뱃지만 지급")
     void totalCount50_With10And30BadgeOwned_ThenGrantOneBadge() {
         Member member = MemberFixture.of();
+        Badge badge10 = BadgeFixture.of(1L, "첫 발자국", BadgeType.TOTAL);
+        Badge badge30 = BadgeFixture.of(2L, "실천 중급자", BadgeType.TOTAL);
+        Badge badge50 = BadgeFixture.of(3L, "지속가능 파이터", BadgeType.TOTAL);
 
         when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(30L);
         when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(20L);
 
-        Badge badge10 = BadgeFixture.of("첫 발자국");
-        Badge badge30 = BadgeFixture.of("실천 중급자");
-        Badge badge50 = BadgeFixture.of("지속가능 파이터");
-
         when(badgeRepository.findByName("첫 발자국")).thenReturn(Optional.of(badge10));
         when(badgeRepository.findByName("실천 중급자")).thenReturn(Optional.of(badge30));
         when(badgeRepository.findByName("지속가능 파이터")).thenReturn(Optional.of(badge50));
-
         when(memberBadgeRepository.existsByMemberAndBadge(member, badge10)).thenReturn(true);
         when(memberBadgeRepository.existsByMemberAndBadge(member, badge30)).thenReturn(true);
         when(memberBadgeRepository.existsByMemberAndBadge(member, badge50)).thenReturn(false);
@@ -119,97 +118,40 @@ class TotalVerificationCountBadgePolicyTest {
     }
 
     @Test
-    @DisplayName("총 50회 인증 성공 → 3개 뱃지 지급")
-    void totalCount50_ThenGrantThreeBadges() {
-        Member member = MemberFixture.of();
-
-        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(30L);
-        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(20L);
-
-        List<String> expected = List.of("첫 발자국", "실천 중급자", "지속가능 파이터");
-        for (String name : expected) {
-            Badge badge = BadgeFixture.of(name);
-            when(badgeRepository.findByName(name)).thenReturn(Optional.of(badge));
-            when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
-        }
-
-        List<Badge> result = policy.evaluateAndGetNewBadges(member);
-
-        assertThat(result).extracting(Badge::getName).containsExactlyInAnyOrderElementsOf(expected);
-    }
-
-    @Test
-    @DisplayName("총 100회 인증 성공 + 10, 30, 50회 뱃지 보유 → '그린 마스터' 뱃지만 지급")
-    void totalCount100_WithAllBut100BadgeOwned_ThenGrantOneBadge() {
-        Member member = MemberFixture.of();
-
-        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(60L);
-        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(40L);
-
-        Badge badge10 = BadgeFixture.of("첫 발자국");
-        Badge badge30 = BadgeFixture.of("실천 중급자");
-        Badge badge50 = BadgeFixture.of("지속가능 파이터");
-        Badge badge100 = BadgeFixture.of("그린 마스터");
-
-        when(badgeRepository.findByName("첫 발자국")).thenReturn(Optional.of(badge10));
-        when(badgeRepository.findByName("실천 중급자")).thenReturn(Optional.of(badge30));
-        when(badgeRepository.findByName("지속가능 파이터")).thenReturn(Optional.of(badge50));
-        when(badgeRepository.findByName("그린 마스터")).thenReturn(Optional.of(badge100));
-
-        when(memberBadgeRepository.existsByMemberAndBadge(member, badge10)).thenReturn(true);
-        when(memberBadgeRepository.existsByMemberAndBadge(member, badge30)).thenReturn(true);
-        when(memberBadgeRepository.existsByMemberAndBadge(member, badge50)).thenReturn(true);
-        when(memberBadgeRepository.existsByMemberAndBadge(member, badge100)).thenReturn(false);
-
-        List<Badge> result = policy.evaluateAndGetNewBadges(member);
-
-        assertThat(result).extracting(Badge::getName).containsExactly("그린 마스터");
-    }
-
-    @Test
     @DisplayName("총 100회 인증 성공 → 4개 뱃지 지급")
     void totalCount100_ThenGrantFourBadges() {
-        // Given
         Member member = MemberFixture.of();
-        long group = 60L;
-        long personal = 40L;
-
-        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(group);
-        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(personal);
-
-        // 10, 30, 50, 100 이상 → 총 4개
-        List<String> expectedBadges = List.of("첫 발자국", "실천 중급자", "지속가능 파이터", "그린 마스터");
-
-        for (String badgeName : expectedBadges) {
-            Badge badge = BadgeFixture.of(badgeName);
-            when(badgeRepository.findByName(badgeName)).thenReturn(Optional.of(badge));
-            when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
-        }
-
-        // When
-        List<Badge> result = policy.evaluateAndGetNewBadges(member);
-
-        // Then
-        assertThat(result).extracting(Badge::getName).containsExactlyInAnyOrderElementsOf(expectedBadges);
-    }
-
-    @Test
-    @DisplayName("총 100회 인증 성공 + 모든 뱃지 보유 → 지급 없음")
-    void totalCount100_WithAllBadgesOwned_ThenGrantNone() {
-        Member member = MemberFixture.of();
+        List<Badge> badges = List.of(
+                BadgeFixture.of(1L, "첫 발자국", BadgeType.TOTAL),
+                BadgeFixture.of(2L, "실천 중급자", BadgeType.TOTAL),
+                BadgeFixture.of(3L, "지속가능 파이터", BadgeType.TOTAL),
+                BadgeFixture.of(4L, "그린 마스터", BadgeType.TOTAL)
+        );
 
         when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(60L);
         when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(40L);
 
-        List<String> allBadges = List.of("첫 발자국", "실천 중급자", "지속가능 파이터", "그린 마스터");
-        for (String name : allBadges) {
-            Badge badge = BadgeFixture.of(name);
-            when(badgeRepository.findByName(name)).thenReturn(Optional.of(badge));
-            when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(true);
+        for (Badge badge : badges) {
+            when(badgeRepository.findByName(badge.getName())).thenReturn(Optional.of(badge));
+            when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(false);
         }
 
         List<Badge> result = policy.evaluateAndGetNewBadges(member);
+        assertThat(result).extracting(Badge::getName).containsExactlyInAnyOrder("첫 발자국", "실천 중급자", "지속가능 파이터", "그린 마스터");
+    }
 
+    @Test
+    @DisplayName("이미 보유한 뱃지는 중복 지급되지 않음")
+    void alreadyOwnedBadge_ThenSkip() {
+        Member member = MemberFixture.of();
+        Badge badge = BadgeFixture.of(1L, "첫 발자국", BadgeType.TOTAL);
+
+        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(8L);
+        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(5L);
+        when(badgeRepository.findByName("첫 발자국")).thenReturn(Optional.of(badge));
+        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(true);
+
+        List<Badge> result = policy.evaluateAndGetNewBadges(member);
         assertThat(result).isEmpty();
     }
 
@@ -222,24 +164,6 @@ class TotalVerificationCountBadgePolicyTest {
         when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(5L);
 
         List<Badge> result = policy.evaluateAndGetNewBadges(member);
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    @DisplayName("이미 보유한 뱃지는 중복 지급되지 않음")
-    void alreadyOwnedBadge_ThenSkip() {
-        Member member = MemberFixture.of();
-        String badgeName = "첫 발자국";
-        Badge badge = BadgeFixture.of(badgeName);
-
-        when(groupRepo.countByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(8L);
-        when(personalRepo.countTotalByMemberIdAndStatus(member.getId(), ChallengeStatus.SUCCESS)).thenReturn(5L);
-        when(badgeRepository.findByName(badgeName)).thenReturn(Optional.of(badge));
-        when(memberBadgeRepository.existsByMemberAndBadge(member, badge)).thenReturn(true);
-
-        List<Badge> result = policy.evaluateAndGetNewBadges(member);
-
         assertThat(result).isEmpty();
     }
 }

--- a/src/test/java/ktb/leafresh/backend/support/fixture/BadgeFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/BadgeFixture.java
@@ -7,14 +7,31 @@ import java.util.ArrayList;
 
 public class BadgeFixture {
 
-    public static Badge of(String name) {
+    // 기본 EVENT 타입 사용
+    public static Badge of(Long id, String name) {
+        return of(id, name, BadgeType.EVENT);
+    }
+
+    // BadgeType을 명시적으로 지정하는 오버로드 메서드
+    public static Badge of(Long id, String name, BadgeType type) {
         return Badge.builder()
-                .id(1L)
+                .id(id)
                 .memberBadges(new ArrayList<>())
-                .type(BadgeType.EVENT)
+                .type(type)
                 .name(name)
-                .condition("이벤트 인증 3회 성공 시 지급")
+                .condition(getConditionByType(type, name))
                 .imageUrl("https://dummy.image/badge/" + name + ".png")
                 .build();
+    }
+
+    // 조건 문구는 테스트용으로 대략적인 구분만 해둡니다
+    private static String getConditionByType(BadgeType type, String name) {
+        return switch (type) {
+            case GROUP -> name + " 카테고리 챌린지 10회 인증 시 지급";
+            case PERSONAL -> name + " 연속 인증 달성 시 지급";
+            case TOTAL -> name + " 누적 챌린지 인증 성공 수 기준 달성 시 지급";
+            case SPECIAL -> "특정 조건 달성 시 지급되는 스페셜 뱃지";
+            case EVENT -> "이벤트 인증 3회 성공 시 지급";
+        };
     }
 }

--- a/src/test/java/ktb/leafresh/backend/support/fixture/MemberFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/MemberFixture.java
@@ -1,7 +1,6 @@
 package ktb.leafresh.backend.support.fixture;
 
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
-import ktb.leafresh.backend.domain.member.domain.entity.TreeLevel;
 import ktb.leafresh.backend.domain.member.domain.entity.enums.LoginType;
 import ktb.leafresh.backend.domain.member.domain.entity.enums.Role;
 
@@ -26,6 +25,7 @@ public class MemberFixture {
                 .activated(true)
                 .totalLeafPoints(0)
                 .currentLeafPoints(0)
+                .memberBadges(new ArrayList<>())
                 .build();
     }
 }


### PR DESCRIPTION
## 요약

뱃지 목록을 조회하는 API를 구현하고, `BadgeFixture` 구조 변경에 따라 관련 테스트 코드를 전면 수정하였습니다.

## 작업 내용

1. 뱃지 목록 조회 API 기능 추가

- `BadgeReadService`, `BadgeListResponseDto`, `BadgeResponseDto` 구현
- 획득/미획득 상태 구분하여 응답하는 구조 설계 (`isLocked` 포함)
- `BadgeType` 기준으로 그룹화된 응답 형태 적용 (`group`, `personal`, `total`, `special`, `event`)

2. BadgeFixture 구조 변경

- `BadgeFixture.of(id, name, type)` 형태로 개선
- `getConditionByType()` 로 테스트 설명 문구 자동 생성

3. 테스트 전면 수정

- 모든 뱃지 관련 테스트 코드에서 기존 `BadgeFixture.of(name)` 사용 → `of(id, name, type)` 방식으로 일괄 변경
- 테스트 클래스 7개 이상 수정 (`BadgeReadServiceTest`, `SpecialBadgePolicyTest`, `TotalVerificationCountBadgePolicyTest` 등)
- 중복 제거, 가독성 개선, 의미 있는 테스트 ID 부여