### PR TITLE
feat: AI 서버로부터 수신한 주간 피드백 저장 및 조회 기능 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/feedback/application/listener/FeedbackResultEventListener.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/application/listener/FeedbackResultEventListener.java
@@ -1,0 +1,51 @@
+package ktb.leafresh.backend.domain.feedback.application.listener;
+
+import ktb.leafresh.backend.domain.feedback.domain.entity.Feedback;
+import ktb.leafresh.backend.domain.feedback.domain.event.FeedbackCreatedEvent;
+import ktb.leafresh.backend.domain.feedback.infrastructure.repository.FeedbackRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
+import ktb.leafresh.backend.global.exception.FeedbackErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FeedbackResultEventListener {
+
+    private final FeedbackRepository feedbackRepository;
+    private final MemberRepository memberRepository;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(FeedbackCreatedEvent event) {
+        try {
+            log.info("[이벤트 수신] 피드백 저장 시작 memberId={}", event.memberId());
+
+            Member member = memberRepository.findById(event.memberId())
+                    .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+            LocalDateTime weekMonday = LocalDate.now().with(DayOfWeek.MONDAY).minusWeeks(1).atStartOfDay();
+
+            Feedback feedback = Feedback.of(member, event.content(), weekMonday);
+            feedbackRepository.save(feedback);
+
+            log.info("[피드백 저장 완료] memberId={}", event.memberId());
+
+        } catch (Exception e) {
+            log.error("[피드백 저장 실패] error={}", e.getMessage(), e);
+            throw new CustomException(FeedbackErrorCode.FEEDBACK_SAVE_FAIL);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultQueryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultQueryService.java
@@ -1,0 +1,48 @@
+package ktb.leafresh.backend.domain.feedback.application.service;
+
+import ktb.leafresh.backend.domain.feedback.presentation.dto.response.FeedbackResponseDto;
+import ktb.leafresh.backend.domain.feedback.infrastructure.repository.FeedbackRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.FeedbackErrorCode;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.util.polling.FeedbackPollingExecutor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.DayOfWeek;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedbackResultQueryService {
+
+    private final MemberRepository memberRepository;
+    private final FeedbackRepository feedbackRepository;
+    private final FeedbackPollingExecutor feedbackPollingExecutor;
+
+    public FeedbackResponseDto waitForFeedback(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(GlobalErrorCode.UNAUTHORIZED));
+
+        if (!member.getActivated()) {
+            throw new CustomException(GlobalErrorCode.ACCESS_DENIED);
+        }
+
+        log.info("[피드백 롱폴링 시작] memberId={}", memberId);
+
+        return feedbackPollingExecutor.poll(() -> getLatestFeedback(member));
+    }
+
+    private FeedbackResponseDto getLatestFeedback(Member member) {
+        LocalDateTime thisWeekMonday = LocalDate.now().with(DayOfWeek.MONDAY).atStartOfDay();
+        return feedbackRepository
+                .findFeedbackByMemberAndWeekMonday(member, thisWeekMonday.minusWeeks(1))
+                .map(fb -> new FeedbackResponseDto(fb.getContent()))
+                .orElse(new FeedbackResponseDto(null));
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultService.java
@@ -1,0 +1,48 @@
+package ktb.leafresh.backend.domain.feedback.application.service;
+
+import ktb.leafresh.backend.domain.feedback.domain.event.FeedbackCreatedEvent;
+import ktb.leafresh.backend.domain.feedback.infrastructure.repository.FeedbackRepository;
+import ktb.leafresh.backend.domain.feedback.presentation.dto.request.FeedbackResultRequestDto;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
+import ktb.leafresh.backend.global.exception.FeedbackErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FeedbackResultService {
+
+    private final MemberRepository memberRepository;
+    private final FeedbackRepository feedbackRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void receiveFeedback(FeedbackResultRequestDto dto) {
+        log.info("[피드백 저장 사전 검증] memberId={}", dto.memberId());
+
+        Member member = memberRepository.findById(dto.memberId())
+                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        LocalDateTime weekMonday = LocalDate.now().with(DayOfWeek.MONDAY).minusWeeks(1).atStartOfDay();
+
+        boolean exists = feedbackRepository.existsByMemberIdAndWeekMonday(member.getId(), weekMonday);
+        if (exists) {
+            throw new CustomException(FeedbackErrorCode.ALREADY_FEEDBACK_EXISTS);
+        }
+
+        // 이벤트 발행 (실제 저장은 AFTER_COMMIT에서 수행)
+        eventPublisher.publishEvent(new FeedbackCreatedEvent(dto.memberId(), dto.content()));
+        log.info("[피드백 저장 이벤트 발행 완료] memberId={}", dto.memberId());
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/presentation/controller/FeedbackResultController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/presentation/controller/FeedbackResultController.java
@@ -1,0 +1,59 @@
+package ktb.leafresh.backend.domain.feedback.presentation.controller;
+
+import jakarta.validation.Valid;
+import ktb.leafresh.backend.domain.feedback.application.service.FeedbackResultQueryService;
+import ktb.leafresh.backend.domain.feedback.application.service.FeedbackResultService;
+import ktb.leafresh.backend.domain.feedback.presentation.dto.request.FeedbackResultRequestDto;
+import ktb.leafresh.backend.domain.feedback.presentation.dto.response.FeedbackResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.FeedbackErrorCode;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members/feedback")
+@Slf4j
+public class FeedbackResultController {
+
+    private final FeedbackResultService feedbackResultService;
+    private final FeedbackResultQueryService feedbackResultQueryService;
+
+    @PostMapping("/result")
+    public ResponseEntity<ApiResponse<Void>> receiveFeedbackResult(
+            @Valid @RequestBody FeedbackResultRequestDto requestDto) {
+
+        log.info("[피드백 결과 수신 요청] memberId={}, content={}", requestDto.memberId(), requestDto.content());
+
+        feedbackResultService.receiveFeedback(requestDto);
+        return ResponseEntity.ok(ApiResponse.success("피드백 결과 수신 완료"));
+    }
+
+    @GetMapping("/result")
+    public ResponseEntity<ApiResponse<FeedbackResponseDto>> getFeedbackResult(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        Long memberId = userDetails.getMemberId();
+        log.info("[피드백 결과 조회 요청] memberId={}", memberId);
+
+        FeedbackResponseDto response = feedbackResultQueryService.waitForFeedback(memberId);
+
+        if (response.getContent() == null) {
+            log.info("[피드백 결과 없음] memberId={}", memberId);
+            throw new CustomException(FeedbackErrorCode.FEEDBACK_NOT_READY);
+        }
+
+        log.info("[피드백 결과 반환] memberId={}, content={}", memberId, response.getContent());
+        return ResponseEntity.ok(ApiResponse.success("피드백 결과 수신 완료", response));
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/presentation/dto/request/FeedbackResultRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/presentation/dto/request/FeedbackResultRequestDto.java
@@ -1,0 +1,12 @@
+package ktb.leafresh.backend.domain.feedback.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record FeedbackResultRequestDto(
+        @NotNull(message = "memberId는 필수 항목입니다.")
+        Long memberId,
+
+        @NotBlank(message = "feedback는 필수 항목입니다.")
+        String content
+) {}

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -98,6 +98,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/chatbot/recommendation/base-info").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/chatbot/recommendation/free-text").permitAll()
 
+                        // 피드백
+                        .requestMatchers(HttpMethod.POST, "/api/members/feedback/result").permitAll()
+
                         // Swagger/OpenAPI
                         .requestMatchers(
                                 "/swagger-ui/**",

--- a/src/main/java/ktb/leafresh/backend/global/util/polling/FeedbackPollingExecutor.java
+++ b/src/main/java/ktb/leafresh/backend/global/util/polling/FeedbackPollingExecutor.java
@@ -1,0 +1,36 @@
+package ktb.leafresh.backend.global.util.polling;
+
+import ktb.leafresh.backend.domain.feedback.presentation.dto.response.FeedbackResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Supplier;
+
+@Slf4j
+@Component
+public class FeedbackPollingExecutor {
+
+    private static final int TIMEOUT_MS = 10000;
+    private static final int INTERVAL_MS = 500;
+
+    public FeedbackResponseDto poll(Supplier<FeedbackResponseDto> supplier) {
+        long start = System.currentTimeMillis();
+
+        while (System.currentTimeMillis() - start < TIMEOUT_MS) {
+            FeedbackResponseDto result = supplier.get();
+
+            if (result.getContent() != null) {
+                return result;
+            }
+
+            try {
+                Thread.sleep(INTERVAL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        return new FeedbackResponseDto(null);
+    }
+}


### PR DESCRIPTION
## 요약
AI 서버로부터 수신한 주간 피드백을 저장하고, 사용자 마이페이지에서 이를 확인할 수 있도록 하는 기능을 구현했습니다. 주차 기준 중복 저장을 방지하며, 롱폴링 방식으로 결과를 조회할 수 있습니다.

## 작업 내용
- 피드백 저장 흐름:
  - AI → BE로 전송된 피드백 결과 저장
  - 동일 주차 중복 저장 방지 (member_id + week_monday 기준 existsBy 쿼리)
  - 저장 완료 후 `FeedbackCreatedEvent` 발행
- 피드백 조회 기능:
  - 로그인 사용자 기준, 현재 주차에 해당하는 피드백 결과 롱폴링 방식 조회
  - 주간 피드백이 존재할 경우, 결과 content 반환
- 응답 Dto 및 polling executor 작성