### PR TITLE
refactor: 컨트롤러의 인증 체크 방식을 ResponseEntity → CustomException 로 변경

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupChallengeVerificationSubmitController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupChallengeVerificationSubmitController.java
@@ -5,6 +5,8 @@ import ktb.leafresh.backend.domain.verification.application.service.GroupChallen
 import ktb.leafresh.backend.domain.verification.presentation.dto.request.GroupChallengeVerificationRequestDto;
 import ktb.leafresh.backend.domain.verification.presentation.util.ChallengeStatusMessageResolver;
 import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +17,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
-
-import static ktb.leafresh.backend.global.exception.GlobalErrorCode.UNAUTHORIZED;
 
 @Slf4j
 @RestController
@@ -37,8 +37,7 @@ public class GroupChallengeVerificationSubmitController {
                 challengeId, requestDto.imageUrl(), requestDto.content());
 
         if (userDetails == null) {
-            log.warn("[단체 인증 제출 실패] 인증 정보가 없습니다.");
-            throw new IllegalStateException("로그인 정보가 존재하지 않습니다.");
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
         }
 
         Long memberId = userDetails.getMemberId();
@@ -56,9 +55,7 @@ public class GroupChallengeVerificationSubmitController {
             @PathVariable Long challengeId
     ) {
         if (userDetails == null) {
-            return ResponseEntity
-                    .status(UNAUTHORIZED.getStatus())
-                    .body(ApiResponse.error(UNAUTHORIZED.getStatus(), UNAUTHORIZED.getMessage()));
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
         }
 
         Long memberId = userDetails.getMemberId();

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/PersonalChallengeVerificationSubmitController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/PersonalChallengeVerificationSubmitController.java
@@ -5,6 +5,8 @@ import ktb.leafresh.backend.domain.verification.application.service.PersonalChal
 import ktb.leafresh.backend.domain.verification.presentation.dto.request.PersonalChallengeVerificationRequestDto;
 import ktb.leafresh.backend.domain.verification.presentation.util.ChallengeStatusMessageResolver;
 import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +17,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
-
-import static ktb.leafresh.backend.global.exception.GlobalErrorCode.UNAUTHORIZED;
 
 @Slf4j
 @RestController
@@ -37,8 +37,7 @@ public class PersonalChallengeVerificationSubmitController {
                 challengeId, requestDto.imageUrl(), requestDto.content());
 
         if (userDetails == null) {
-            log.warn("[인증 제출 실패] 인증 정보가 없습니다.");
-            throw new IllegalStateException("로그인 정보가 존재하지 않습니다.");
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
         }
 
         Long memberId = userDetails.getMemberId();
@@ -56,9 +55,7 @@ public class PersonalChallengeVerificationSubmitController {
             @PathVariable Long challengeId
     ) {
         if (userDetails == null) {
-            return ResponseEntity
-                    .status(UNAUTHORIZED.getStatus())
-                    .body(ApiResponse.error(UNAUTHORIZED.getStatus(), UNAUTHORIZED.getMessage()));
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
         }
 
         Long memberId = userDetails.getMemberId();


### PR DESCRIPTION
## 요약
컨트롤러에서 `userDetails == null`일 때 `ResponseEntity`로 직접 응답을 내려주던 방식에서,
전역 예외 처리 로직을 따르도록 `CustomException(GlobalErrorCode.UNAUTHORIZED)`를 던지는 방식으로 변경하였습니다.

## 작업 내용
- 인증 체크 부분에서 `ResponseEntity.status().body()` 방식 제거
- `CustomException(GlobalErrorCode.UNAUTHORIZED)`를 던지도록 리팩토링
- 글로벌 예외 핸들러를 통해 일관된 에러 응답 형식 유지=