### PR TITLE
feat: 피드백 요청/응답 DTO 이름 변경 및 관련 의존성 정리

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/client/FakeFeedbackCreationClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/client/FakeFeedbackCreationClient.java
@@ -1,6 +1,6 @@
 package ktb.leafresh.backend.domain.feedback.infrastructure.client;
 
-import ktb.leafresh.backend.domain.feedback.infrastructure.dto.request.FeedbackCreationRequestDto;
+import ktb.leafresh.backend.domain.feedback.infrastructure.dto.request.AiFeedbackCreationRequestDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 public class FakeFeedbackCreationClient implements FeedbackCreationClient {
 
     @Override
-    public void requestWeeklyFeedback(FeedbackCreationRequestDto requestDto) {
+    public void requestWeeklyFeedback(AiFeedbackCreationRequestDto requestDto) {
         log.info("[FAKE 피드백 요청] 로컬 환경에서는 요청을 전송하지 않습니다. 요청 DTO: {}", requestDto);
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/client/FeedbackCreationClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/client/FeedbackCreationClient.java
@@ -1,7 +1,7 @@
 package ktb.leafresh.backend.domain.feedback.infrastructure.client;
 
-import ktb.leafresh.backend.domain.feedback.infrastructure.dto.request.FeedbackCreationRequestDto;
+import ktb.leafresh.backend.domain.feedback.infrastructure.dto.request.AiFeedbackCreationRequestDto;
 
 public interface FeedbackCreationClient {
-    void requestWeeklyFeedback(FeedbackCreationRequestDto requestDto);
+    void requestWeeklyFeedback(AiFeedbackCreationRequestDto requestDto);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/dto/request/AiFeedbackCreationRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/dto/request/AiFeedbackCreationRequestDto.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
-public record FeedbackCreationRequestDto(
+public record AiFeedbackCreationRequestDto(
         Long memberId,
         List<PersonalChallengeDto> personalChallenges,
         List<GroupChallengeDto> groupChallenges

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/dto/response/AiFeedbackApiResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/dto/response/AiFeedbackApiResponseDto.java
@@ -1,0 +1,7 @@
+package ktb.leafresh.backend.domain.feedback.infrastructure.dto.response;
+
+public record AiFeedbackApiResponseDto(
+        int status,
+        String message,
+        AiFeedbackResponseDto data
+) {}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/dto/response/AiFeedbackResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/dto/response/AiFeedbackResponseDto.java
@@ -1,0 +1,5 @@
+package ktb.leafresh.backend.domain.feedback.infrastructure.dto.response;
+
+public record AiFeedbackResponseDto(
+        String content
+) {}


### PR DESCRIPTION
## 요약
AI 피드백 요청/응답 DTO를 `AiFeedbackCreationRequestDto`, `AiFeedbackApiResponseDto`, `AiFeedbackResponseDto`로 명확하게 구분하고 명명 정비했습니다.

## 작업 내용
- `FeedbackCreationRequestDto` → `AiFeedbackCreationRequestDto`로 이름 변경
- 응답용 DTO `AiFeedbackApiResponseDto`, `AiFeedbackResponseDto` 분리 및 도입
- 관련 interface (`FeedbackCreationClient`) 및 구현체 수정