### PR TITLE
refactor: client 내부 요청 DTO 및 응답 DTO 변경에 따른 의존성 수정

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackCommandService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackCommandService.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import ktb.leafresh.backend.domain.feedback.application.assembler.FeedbackDtoAssembler;
 import ktb.leafresh.backend.domain.feedback.infrastructure.client.FeedbackCreationClient;
-import ktb.leafresh.backend.domain.feedback.infrastructure.dto.request.FeedbackCreationRequestDto;
+import ktb.leafresh.backend.domain.feedback.infrastructure.dto.request.AiFeedbackCreationRequestDto;
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
 import ktb.leafresh.backend.global.exception.CustomException;
@@ -38,7 +38,7 @@ public class FeedbackCommandService {
         LocalDate sunday = monday.plusDays(6);
         log.debug("[주차 계산] monday={}, sunday={}", monday, sunday);
 
-        FeedbackCreationRequestDto requestDto = dtoAssembler.assemble(memberId, monday, sunday);
+        AiFeedbackCreationRequestDto requestDto = dtoAssembler.assemble(memberId, monday, sunday);
 
         int personalCount = requestDto.personalChallenges().size();
         int groupSubmissionCount = requestDto.groupChallenges().stream()


### PR DESCRIPTION
## 요약
AI 피드백 요청/응답 DTO를 `AiFeedbackCreationRequestDto`, `AiFeedbackApiResponseDto`, `AiFeedbackResponseDto`로 명확하게 구분하고 명명 정비했습니다.

## 작업 내용
- `FeedbackCreationRequestDto` → `AiFeedbackCreationRequestDto`로 이름 변경
- 응답용 DTO `AiFeedbackApiResponseDto`, `AiFeedbackResponseDto` 분리 및 도입
- 관련 interface (`FeedbackCreationClient`) 및 구현체 수정
