### PR TITLE
feat: 챗봇 추천 SSE 응답 중계 구조 도입

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandler.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandler.java
@@ -1,0 +1,13 @@
+package ktb.leafresh.backend.domain.chatbot.application.handler;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * AI 서버로부터 받은 SSE 응답을 그대로 FE로 전달하는 중계 핸들러
+ * - WebClient를 통해 AI 서버로 GET 요청을 보냄
+ * - ServerSentEvent<String> 형식으로 수신
+ * - 받은 SSE 메시지를 포맷 유지한 채 SseEmitter를 통해 FE로 전송
+ */
+public interface ChatbotSseStreamHandler {
+    void streamToEmitter(SseEmitter emitter, String uriWithQueryParams);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/FakeChatbotSseStreamHandler.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/FakeChatbotSseStreamHandler.java
@@ -1,0 +1,26 @@
+package ktb.leafresh.backend.domain.chatbot.application.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@Profile("local")
+public class FakeChatbotSseStreamHandler implements ChatbotSseStreamHandler {
+
+    @Override
+    public void streamToEmitter(SseEmitter emitter, String uriWithQueryParams) {
+        try {
+            emitter.send("event: challenge\ndata: {\"message\":\"fake1\"}\n\n");
+            emitter.send("event: challenge\ndata: {\"message\":\"fake2\"}\n\n");
+            emitter.send("event: close\ndata: {\"message\":\"모든 챌린지 추천 완료\"}\n\n");
+            emitter.complete();
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/HttpChatbotSseStreamHandler.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/HttpChatbotSseStreamHandler.java
@@ -1,0 +1,58 @@
+package ktb.leafresh.backend.domain.chatbot.application.handler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.publisher.Flux;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@Profile("!local")
+public class HttpChatbotSseStreamHandler implements ChatbotSseStreamHandler {
+
+    private final WebClient aiWebClient;
+
+    public HttpChatbotSseStreamHandler(
+            @Qualifier("aiServerWebClient") WebClient aiWebClient
+    ) {
+        this.aiWebClient = aiWebClient;
+    }
+
+    @Override
+    public void streamToEmitter(SseEmitter emitter, String uriWithQueryParams) {
+        Flux<ServerSentEvent<String>> flux = aiWebClient.get()
+                .uri(uriWithQueryParams)
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .retrieve()
+                .bodyToFlux(new ParameterizedTypeReference<>() {});
+
+        flux.doOnNext(event -> {
+                    StringBuilder sb = new StringBuilder();
+                    if (event.event() != null) sb.append("event: ").append(event.event()).append("\n");
+                    if (event.data() != null) sb.append("data: ").append(event.data()).append("\n");
+                    sb.append("\n");
+
+                    try {
+                        emitter.send(sb.toString());
+                    } catch (IOException e) {
+                        log.warn("[SSE 전송 실패] {}", e.getMessage());
+                        emitter.completeWithError(e);
+                    }
+                })
+                .doOnComplete(emitter::complete)
+                .doOnError(e -> {
+                    log.error("[SSE 스트림 오류] {}", e.getMessage());
+                    emitter.completeWithError(e);
+                })
+                .subscribe();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationSseService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationSseService.java
@@ -1,0 +1,40 @@
+package ktb.leafresh.backend.domain.chatbot.application.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ktb.leafresh.backend.domain.chatbot.application.handler.ChatbotSseStreamHandler;
+import ktb.leafresh.backend.global.util.sse.SseStreamExecutor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatbotRecommendationSseService {
+
+    private final ChatbotSseStreamHandler streamHandler;
+    private final SseStreamExecutor sseStreamExecutor;
+    private final ObjectMapper objectMapper;
+
+    public SseEmitter stream(String aiUri, Object dto) {
+        SseEmitter emitter = new SseEmitter(60_000L);
+        String uri = buildUriWithParams(aiUri, dto);
+
+        sseStreamExecutor.execute(emitter, () ->
+                streamHandler.streamToEmitter(emitter, uri)
+        );
+
+        return emitter;
+    }
+
+    private String buildUriWithParams(String aiUri, Object dto) {
+        Map<String, String> map = objectMapper.convertValue(dto, Map.class);
+        UriComponentsBuilder builder = UriComponentsBuilder.fromPath(aiUri);
+        map.forEach(builder::queryParam);
+        return builder.toUriString();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/presentation/controller/ChatbotRecommendationSseController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/presentation/controller/ChatbotRecommendationSseController.java
@@ -1,0 +1,43 @@
+package ktb.leafresh.backend.domain.chatbot.presentation.controller;
+
+import ktb.leafresh.backend.domain.chatbot.application.service.ChatbotRecommendationSseService;
+import ktb.leafresh.backend.domain.chatbot.presentation.dto.request.ChatbotBaseInfoRequestDto;
+import ktb.leafresh.backend.domain.chatbot.presentation.dto.request.ChatbotFreeTextRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chatbot/recommendation")
+public class ChatbotRecommendationSseController {
+
+    private final ChatbotRecommendationSseService chatbotRecommendationSseService;
+
+    @GetMapping(value = "/base-info", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter baseInfo(
+            @RequestParam String sessionId,
+            @RequestParam String location,
+            @RequestParam String workType,
+            @RequestParam String category
+    ) {
+        return chatbotRecommendationSseService.stream(
+                "/ai/chatbot/recommendation/base-info",
+                new ChatbotBaseInfoRequestDto(sessionId, location, workType, category)
+        );
+    }
+
+    @GetMapping(value = "/free-text", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter freeText(
+            @RequestParam String sessionId,
+            @RequestParam String message
+    ) {
+        return chatbotRecommendationSseService.stream(
+                "/ai/chatbot/recommendation/free-text",
+                new ChatbotFreeTextRequestDto(sessionId, message)
+        );
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -97,6 +97,8 @@ public class SecurityConfig {
                         // 챗봇
                         .requestMatchers(HttpMethod.POST, "/api/chatbot/recommendation/base-info").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/chatbot/recommendation/free-text").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/chatbot/recommendation/base-info").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/chatbot/recommendation/free-text").permitAll()
 
                         // 피드백
                         .requestMatchers(HttpMethod.POST, "/api/members/feedback/result").permitAll()

--- a/src/main/java/ktb/leafresh/backend/global/util/sse/SseStreamExecutor.java
+++ b/src/main/java/ktb/leafresh/backend/global/util/sse/SseStreamExecutor.java
@@ -1,4 +1,4 @@
-package ktb.leafresh.backend.global.util.stream;
+package ktb.leafresh.backend.global.util.sse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,6 +8,9 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+/**
+ * 비동기 실행기
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor


### PR DESCRIPTION
## 요약
AI 챗봇 추천 응답을 SSE(Server-Sent Events)로 전달하는 구조를 도입하였습니다.  
FE → BE → AI → BE → FE 흐름에서 AI 응답을 포맷 그대로 프론트에 전달하도록 구현하였습니다.

## 작업 내용
- `ChatbotRecommendationSseController.java`: `/base-info`, `/free-text` SSE 엔드포인트 추가 (GET)
- `ChatbotRecommendationSseService.java`: AI SSE 응답을 받아 SseEmitter로 프론트에 전달
- `ChatbotSseStreamHandler.java`: SSE 핸들러 인터페이스 정의 (전략 패턴 적용)
- `HttpChatbotSseStreamHandler.java`: 실제 AI 서버와 WebClient 통해 통신하는 구현체
- `FakeChatbotSseStreamHandler.java`: 로컬 개발용 가짜 이벤트 핸들러 (Profile: local)
- `SseStreamExecutor.java`: SSE 비동기 실행 유틸리티 (위치 변경 및 재정비)
- `SecurityConfig.java`: `/api/chatbot/recommendation/**` 경로 인증 제외 처리
