### PR TITLE
refactor: products 및 product_purchases 테이블 필드 및 인덱스 정비

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/order/domain/entity/ProductPurchase.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/domain/entity/ProductPurchase.java
@@ -7,13 +7,15 @@ import ktb.leafresh.backend.global.common.entity.BaseEntity;
 import ktb.leafresh.backend.domain.store.order.domain.entity.enums.PurchaseType;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
-@Table(name = "product_purchases", indexes = @Index(name = "idx_purchase_deleted", columnList = "deleted_at"))
+@Table(name = "product_purchases")
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProductPurchase extends BaseEntity {
+public class ProductPurchase {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,8 +31,14 @@ public class ProductPurchase extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    private PurchaseType purchaseType;
+    private PurchaseType type;
 
     @Column(nullable = false)
-    private Integer purchasePrice;
+    private Integer price;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @Column(name = "purchased_at", nullable = false)
+    private LocalDateTime purchasedAt;
 }

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/domain/entity/Product.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/domain/entity/Product.java
@@ -23,14 +23,17 @@ public class Product extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String name;
 
+    @Column(nullable = false, length = 40)
+    private String description;
+
+    @Column(nullable = false, length = 512)
+    private String imageUrl;
+
     @Column(nullable = false)
     private Integer price;
 
     @Column(nullable = false)
     private Integer stock;
-
-    @Column(nullable = false, length = 512)
-    private String imageUrl;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)


### PR DESCRIPTION
- products 테이블에 description 필드 추가 및 엔티티 반영
- product_purchases 테이블에 purchased_at 필드 추가
- purchase_price → price, purchase_quantity → quantity로 컬럼명 변경
- product_purchases 테이블에서 BaseEntity 상속 제거
- created_at, updated_at, deleted_at 컬럼 및 관련 인덱스 제거
- 관련 엔티티 필드 및 애노테이션 정리