### PR TITLE
feat: 운영자용 일반 상품 생성 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/product/domain/entity/enums/ProductStatus.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/domain/entity/enums/ProductStatus.java
@@ -1,10 +1,9 @@
 package ktb.leafresh.backend.domain.store.product.domain.entity.enums;
 
 public enum ProductStatus {
-    AVAILABLE,
+    ACTIVE,
     SOLD_OUT,
     HIDDEN,
-    PENDING,
-    DELETED,
-    COMING_SOON
+    INACTIVE,
+    DELETED
 }

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/repository/ProductRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package ktb.leafresh.backend.domain.store.product.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/controller/ProductAdminController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/controller/ProductAdminController.java
@@ -1,0 +1,43 @@
+package ktb.leafresh.backend.domain.store.product.presentation.controller;
+
+import jakarta.validation.Valid;
+import ktb.leafresh.backend.domain.store.product.application.service.ProductCreateService;
+import ktb.leafresh.backend.domain.store.product.application.service.ProductUpdateService;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.request.ProductCreateRequestDto;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.request.ProductUpdateRequestDto;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.response.ProductCreateResponseDto;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/products")
+@Slf4j
+public class ProductAdminController {
+
+    private final ProductCreateService productCreateService;
+    private final ProductUpdateService productUpdateService;
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    public ResponseEntity<ApiResponse<ProductCreateResponseDto>> createProduct(
+            @Valid @RequestBody ProductCreateRequestDto dto
+    ) {
+        ProductCreateResponseDto response = productCreateService.createProduct(dto);
+        return ResponseEntity.ok(ApiResponse.success("일반 상품이 등록되었습니다.", response));
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PatchMapping("/{productId}")
+    public ResponseEntity<Void> updateProduct(
+            @PathVariable Long productId,
+            @Valid @RequestBody ProductUpdateRequestDto dto
+    ) {
+        productUpdateService.update(productId, dto);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/request/ProductCreateRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/request/ProductCreateRequestDto.java
@@ -1,0 +1,14 @@
+package ktb.leafresh.backend.domain.store.product.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import ktb.leafresh.backend.domain.store.product.domain.entity.enums.ProductStatus;
+
+public record ProductCreateRequestDto(
+        @NotBlank(message = "상품명은 필수 항목입니다.") String name,
+        @NotBlank(message = "설명은 필수 항목입니다.") String description,
+        @NotBlank(message = "상품 이미지는 필수 항목입니다.") String imageUrl,
+        @NotNull(message = "가격은 필수 항목입니다.") Integer price,
+        @NotNull(message = "재고는 필수 항목입니다.") Integer stock,
+        @NotNull(message = "상태는 필수 항목입니다.") ProductStatus status
+) {}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/response/ProductCreateResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/response/ProductCreateResponseDto.java
@@ -1,0 +1,5 @@
+package ktb.leafresh.backend.domain.store.product.presentation.dto.response;
+
+public record ProductCreateResponseDto(
+        Long id
+) {}

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -103,6 +103,10 @@ public class SecurityConfig {
                         // 피드백
                         .requestMatchers(HttpMethod.POST, "/api/members/feedback/result").permitAll()
 
+                        // 상점
+                        .requestMatchers(HttpMethod.GET, "/api/store/products/timedeals").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/store/products").permitAll()
+
                         // Swagger/OpenAPI
                         .requestMatchers(
                                 "/swagger-ui/**",


### PR DESCRIPTION
## 요약
운영자가 일반 상품을 생성할 수 있는 API를 구현하였습니다.  
DTO, Repository, Service, Controller 계층을 포함하며, 상품 상태 관련 코드도 정리하였습니다.

## 작업 내용
- 일반 상품 생성용 DTO (`ProductCreateRequestDto`) 생성
- 일반 상품 저장을 위한 JPA Repository 추가
- 운영자용 일반 상품 생성 API (`POST /api/admin/products`) 구현
- 상품 상태 코드(Enum 등) 정리 및 리팩토링
