### PR TITLE
feat: 일반 상품 수정 로직 및 이벤트 리스너 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/product/application/event/ProductUpdatedEvent.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/application/event/ProductUpdatedEvent.java
@@ -1,0 +1,6 @@
+package ktb.leafresh.backend.domain.store.product.application.event;
+
+public record ProductUpdatedEvent(
+        Long productId,
+        boolean isTimeDeal
+) {}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/application/listener/ProductEventListener.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/application/listener/ProductEventListener.java
@@ -1,0 +1,29 @@
+package ktb.leafresh.backend.domain.store.product.application.listener;
+
+import ktb.leafresh.backend.domain.store.product.application.event.ProductUpdatedEvent;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductEventListener {
+
+    private final ProductCacheService productCacheService;
+    private final ProductRepository productRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProductUpdated(ProductUpdatedEvent event) {
+        Long productId = event.productId();
+
+        productRepository.findById(productId).ifPresent(product -> {
+            productCacheService.updateSingleProductCache(product);
+            log.info("[ProductEventListener] 개별 상품 캐시 갱신 완료 - productId={}, isTimeDeal={}", productId, event.isTimeDeal());
+        });
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/ProductUpdateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/ProductUpdateService.java
@@ -1,0 +1,69 @@
+package ktb.leafresh.backend.domain.store.product.application.service;
+
+import jakarta.transaction.Transactional;
+import ktb.leafresh.backend.domain.store.product.application.event.ProductUpdatedEvent;
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.domain.entity.enums.ProductStatus;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.request.ProductUpdateRequestDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ProductErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductUpdateService {
+
+    private final ProductRepository productRepository;
+    private final ProductCacheService productCacheService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void update(Long productId, ProductUpdateRequestDto dto) {
+        log.info("일반 상품 수정 요청 - productId={}, dto={}", productId, dto);
+
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new CustomException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        try {
+            if (dto.name() != null) product.updateName(dto.name());
+            if (dto.description() != null) product.updateDescription(dto.description());
+            if (dto.imageUrl() != null) product.updateImageUrl(dto.imageUrl());
+            if (dto.price() != null) {
+                if (dto.price() < 1) throw new CustomException(ProductErrorCode.INVALID_PRICE);
+                product.updatePrice(dto.price());
+            }
+            if (dto.stock() != null) {
+                if (dto.stock() < 0) throw new CustomException(ProductErrorCode.INVALID_STOCK);
+                product.updateStock(dto.stock());
+            }
+            if (dto.status() != null) {
+                try {
+                    ProductStatus status = ProductStatus.valueOf(dto.status());
+                    product.updateStatus(status);
+                } catch (IllegalArgumentException e) {
+                    throw new CustomException(ProductErrorCode.INVALID_STATUS);
+                }
+            }
+
+            productCacheService.evictCacheByProduct(product);
+
+            boolean hasActiveTimedeal = product.getActiveTimedealPolicy(LocalDateTime.now()).isPresent();
+            eventPublisher.publishEvent(new ProductUpdatedEvent(productId, hasActiveTimedeal));
+
+            log.info("일반 상품 수정 완료 - productId={}", productId);
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("일반 상품 수정 중 예외 발생", e);
+            throw new CustomException(ProductErrorCode.PRODUCT_UPDATE_FAILED);
+        }
+    }
+}


### PR DESCRIPTION
## 요약
일반 상품 수정 기능을 구현하고, 생성/수정 이벤트 기반 리스너를 추가하여 후속 처리를 비동기 방식으로 분리하였습니다.

## 작업 내용
- 일반 상품 수정 로직 구현
  - `ProductUpdateRequestDto` 기반 수정 서비스 추가
- 상품 수정 시 발생하는 도메인 이벤트 정의
  - `ProductUpdatedEvent` 추가
- 생성/수정 이벤트 처리용 리스너(`ProductEventListener`) 추가
  - 상품 정보 변경 후 필요한 후속 작업 트리거 가능하도록 설계
