### PR TITLE
feat: 운영자용 타임딜 정책 생성 기능 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealCreateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealCreateService.java
@@ -1,0 +1,72 @@
+package ktb.leafresh.backend.domain.store.product.application.service;
+
+import jakarta.transaction.Transactional;
+import ktb.leafresh.backend.domain.store.product.application.event.ProductUpdatedEvent;
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.TimedealPolicyRepository;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.request.TimedealCreateRequestDto;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.response.TimedealCreateResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.TimedealErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TimedealCreateService {
+    private final ProductRepository productRepository;
+    private final TimedealPolicyRepository timedealPolicyRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final ProductCacheService productCacheService;
+
+    @Transactional
+    public TimedealCreateResponseDto create(TimedealCreateRequestDto dto) {
+        log.info("타임딜 등록 요청 - productId={}, start={}, end={}", dto.productId(), dto.startTime(), dto.endTime());
+
+        Product product = productRepository.findById(dto.productId())
+                .orElseThrow(() -> new CustomException(TimedealErrorCode.PRODUCT_NOT_FOUND));
+
+        if (dto.startTime().isAfter(dto.endTime())) {
+            throw new CustomException(TimedealErrorCode.INVALID_TIME);
+        }
+
+        boolean hasOverlap = timedealPolicyRepository.existsByProductIdAndTimeOverlap(
+                dto.productId(), dto.startTime(), dto.endTime()
+        );
+
+        if (hasOverlap) {
+            throw new CustomException(TimedealErrorCode.OVERLAPPING_TIME);
+        }
+
+        TimedealPolicy policy = TimedealPolicy.builder()
+                .product(product)
+                .discountedPrice(dto.discountedPrice())
+                .discountedPercentage(dto.discountedPercentage())
+                .stock(product.getStock())
+                .startTime(dto.startTime())
+                .endTime(dto.endTime())
+                .build();
+
+        try {
+            timedealPolicyRepository.save(policy);
+
+            Product updatedProduct = productRepository.findById(dto.productId())
+                    .orElseThrow(() -> new CustomException(TimedealErrorCode.PRODUCT_NOT_FOUND));
+
+            productCacheService.updateSingleTimedealCache(policy);
+            eventPublisher.publishEvent(new ProductUpdatedEvent(updatedProduct.getId(), true));
+            log.info("타임딜 저장 및 캐시 반영 완료 - productId={}", product.getId());
+
+            return new TimedealCreateResponseDto(policy.getId());
+        } catch (Exception e) {
+            log.error("타임딜 저장 실패", e);
+            throw new CustomException(TimedealErrorCode.TIMEDEAL_SAVE_FAIL);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/domain/entity/TimedealPolicy.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/domain/entity/TimedealPolicy.java
@@ -17,7 +17,7 @@ public class TimedealPolicy extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
@@ -35,4 +35,14 @@ public class TimedealPolicy extends BaseEntity {
 
     @Column(nullable = false)
     private LocalDateTime endTime;
+
+    public void updateTime(LocalDateTime startTime, LocalDateTime endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public void updatePriceAndPercent(Integer discountedPrice, Integer discountedPercentage) {
+        if (discountedPrice != null) this.discountedPrice = discountedPrice;
+        if (discountedPercentage != null) this.discountedPercentage = discountedPercentage;
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/repository/TimedealPolicyRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/repository/TimedealPolicyRepository.java
@@ -1,0 +1,29 @@
+package ktb.leafresh.backend.domain.store.product.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+
+public interface TimedealPolicyRepository extends JpaRepository<TimedealPolicy, Long> {
+
+    @Query("SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END FROM TimedealPolicy t " +
+            "WHERE t.product.id = :productId " +
+            "AND t.deletedAt IS NULL " +
+            "AND (t.startTime < :endTime AND t.endTime > :startTime)")
+    boolean existsByProductIdAndTimeOverlap(@Param("productId") Long productId,
+                                            @Param("startTime") LocalDateTime startTime,
+                                            @Param("endTime") LocalDateTime endTime);
+
+    @Query("SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END FROM TimedealPolicy t " +
+            "WHERE t.product.id = :productId " +
+            "AND t.deletedAt IS NULL " +
+            "AND t.id != :dealId " +
+            "AND (t.startTime < :endTime AND t.endTime > :startTime)")
+    boolean existsByProductIdAndTimeOverlapExceptSelf(@Param("productId") Long productId,
+                                                      @Param("startTime") LocalDateTime startTime,
+                                                      @Param("endTime") LocalDateTime endTime,
+                                                      @Param("dealId") Long dealId);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/repository/TimedealProductQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/repository/TimedealProductQueryRepository.java
@@ -1,0 +1,12 @@
+package ktb.leafresh.backend.domain.store.product.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.store.product.presentation.dto.response.TimedealProductSummaryResponseDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface TimedealProductQueryRepository {
+    List<TimedealProductSummaryResponseDto> findTimedeals(LocalDateTime now, LocalDateTime oneWeekLater);
+
+    List<TimedealProductSummaryResponseDto> findByIds(List<Long> ids);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/repository/TimedealProductQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/repository/TimedealProductQueryRepositoryImpl.java
@@ -1,0 +1,99 @@
+package ktb.leafresh.backend.domain.store.product.infrastructure.repository;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import ktb.leafresh.backend.domain.store.product.domain.entity.QProduct;
+import ktb.leafresh.backend.domain.store.product.domain.entity.QTimedealPolicy;
+import ktb.leafresh.backend.domain.store.product.domain.entity.enums.ProductStatus;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.response.TimedealProductSummaryResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TimedealProductQueryRepositoryImpl implements TimedealProductQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    QTimedealPolicy tp = QTimedealPolicy.timedealPolicy;
+    QProduct p = QProduct.product;
+
+    @Override
+    public List<TimedealProductSummaryResponseDto> findTimedeals(LocalDateTime now, LocalDateTime oneWeekLater) {
+        return queryFactory
+                .select(Projections.constructor(TimedealProductSummaryResponseDto.class,
+                        tp.id,
+                        p.id,
+                        p.name,                     // title
+                        p.description,
+                        p.price,                    // defaultPrice
+                        tp.discountedPrice,
+                        tp.discountedPercentage,
+                        tp.stock,
+                        p.imageUrl,
+                        tp.startTime,               // dealStartTime
+                        tp.endTime,                 // dealEndTime
+                        getProductStatusCase(),       // CASE WHEN p.status == SOLD_OUT THEN SOLD_OUT ELSE ACTIVE
+                        getTimeDealStatusCase(now)    // CASE WHEN start < now AND end > now THEN ONGOING ELSE UPCOMING
+                ))
+                .from(tp)
+                .join(tp.product, p)
+                .where(
+                        tp.deletedAt.isNull(),
+                        p.deletedAt.isNull(),
+                        p.status.in(ProductStatus.ACTIVE, ProductStatus.SOLD_OUT),
+                        tp.startTime.between(now, oneWeekLater)
+                                .or(tp.startTime.before(now).and(tp.endTime.after(now)))
+                )
+                .orderBy(tp.startTime.asc())
+                .fetch();
+    }
+
+    private Expression<String> getProductStatusCase() {
+        return new CaseBuilder()
+                .when(p.status.eq(ProductStatus.SOLD_OUT)).then("SOLD_OUT")
+                .otherwise("ACTIVE");
+    }
+
+    private Expression<String> getTimeDealStatusCase(LocalDateTime now) {
+        return new CaseBuilder()
+                .when(tp.startTime.before(now).and(tp.endTime.after(now))).then("ONGOING")
+                .otherwise("UPCOMING");
+    }
+
+    @Override
+    public List<TimedealProductSummaryResponseDto> findByIds(List<Long> ids) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return queryFactory
+                .select(Projections.constructor(TimedealProductSummaryResponseDto.class,
+                        tp.id,
+                        p.id,
+                        p.name,
+                        p.description,
+                        p.price,
+                        tp.discountedPrice,
+                        tp.discountedPercentage,
+                        tp.stock,
+                        p.imageUrl,
+                        tp.startTime,
+                        tp.endTime,
+                        getProductStatusCase(),
+                        getTimeDealStatusCase(now)
+                ))
+                .from(tp)
+                .join(tp.product, p)
+                .where(
+                        tp.deletedAt.isNull(),
+                        p.deletedAt.isNull(),
+                        p.status.in(ProductStatus.ACTIVE, ProductStatus.SOLD_OUT),
+                        tp.id.in(ids)
+                )
+                .fetch();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/controller/TimedealAdminController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/controller/TimedealAdminController.java
@@ -1,0 +1,43 @@
+package ktb.leafresh.backend.domain.store.product.presentation.controller;
+
+import jakarta.validation.Valid;
+import ktb.leafresh.backend.domain.store.product.application.service.TimedealCreateService;
+import ktb.leafresh.backend.domain.store.product.application.service.TimedealUpdateService;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.request.TimedealCreateRequestDto;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.request.TimedealUpdateRequestDto;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.response.TimedealCreateResponseDto;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/timedeals")
+@Slf4j
+public class TimedealAdminController {
+
+    private final TimedealCreateService timedealCreateService;
+    private final TimedealUpdateService timedealUpdateService;
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    public ResponseEntity<ApiResponse<TimedealCreateResponseDto>> createTimedeal(
+            @Valid @RequestBody TimedealCreateRequestDto dto
+    ) {
+        TimedealCreateResponseDto response = timedealCreateService.create(dto);
+        return ResponseEntity.ok(ApiResponse.success("타임딜 상품이 등록되었습니다.", response));
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PatchMapping("/{dealId}")
+    public ResponseEntity<Void> updateTimedeal(
+            @PathVariable Long dealId,
+            @Valid @RequestBody TimedealUpdateRequestDto dto
+    ) {
+        timedealUpdateService.update(dealId, dto);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/request/TimedealCreateRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/request/TimedealCreateRequestDto.java
@@ -1,0 +1,25 @@
+package ktb.leafresh.backend.domain.store.product.presentation.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record TimedealCreateRequestDto(
+        @NotNull(message = "상품 ID는 필수입니다.")
+        Long productId,
+
+        @NotNull(message = "시작 시간은 필수입니다.")
+        LocalDateTime startTime,
+
+        @NotNull(message = "종료 시간은 필수입니다.")
+        LocalDateTime endTime,
+
+        @NotNull(message = "할인 가격은 필수입니다.")
+        @Min(value = 1, message = "할인 가격은 1 이상이어야 합니다.")
+        Integer discountedPrice,
+
+        @NotNull(message = "할인율은 필수입니다.")
+        @Min(value = 1, message = "할인율은 1 이상이어야 합니다.")
+        Integer discountedPercentage
+) {}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/response/TimedealCreateResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/response/TimedealCreateResponseDto.java
@@ -1,0 +1,3 @@
+package ktb.leafresh.backend.domain.store.product.presentation.dto.response;
+
+public record TimedealCreateResponseDto(Long dealId) {}

--- a/src/main/java/ktb/leafresh/backend/global/exception/TimedealErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/TimedealErrorCode.java
@@ -1,0 +1,25 @@
+package ktb.leafresh.backend.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum TimedealErrorCode implements BaseErrorCode {
+    PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 상품을 찾을 수 없습니다."),
+    INVALID_TIME(HttpStatus.BAD_REQUEST, "시작 시간은 종료 시간보다 앞서야 합니다."),
+    OVERLAPPING_TIME(HttpStatus.BAD_REQUEST, "해당 시간대에 이미 타임딜이 등록되어 있습니다."),
+    TIMEDEAL_SAVE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "타임딜 정책을 연결하지 못했습니다."),
+    INVALID_PRICE(HttpStatus.BAD_REQUEST, "할인 가격은 1 이상이어야 합니다."),
+    INVALID_PERCENT(HttpStatus.BAD_REQUEST, "할인율은 1 이상이어야 합니다."),
+    TIMEDEAL_LOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "타임딜 상품을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.");
+
+
+    private final HttpStatus status;
+    private final String message;
+
+    TimedealErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public HttpStatus getStatus() { return status; }
+    public String getMessage() { return message; }
+}


### PR DESCRIPTION
## 요약
타임딜 상품 등록을 위한 정책 정보를 생성할 수 있도록 도메인, 서비스, API를 구현하였습니다.

## 작업 내용
- `TimedealPolicy` 엔티티 및 JPA 레포지토리 구현
- `TimedealCreateRequestDto`, `TimedealCreateResponseDto` 생성
- 타임딜 정책 생성 서비스(`TimedealCreateService`) 구현
- 운영자 컨트롤러(`TimedealAdminController`)에 생성 API 추가
- 관련 에러 코드(`TimedealErrorCode`) 정의
