### PR TITLE
feat: 타임딜 정책 수정 기능 및 상품 캐시 갱신 로직 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealUpdateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealUpdateService.java
@@ -1,0 +1,63 @@
+package ktb.leafresh.backend.domain.store.product.application.service;
+
+import jakarta.transaction.Transactional;
+import ktb.leafresh.backend.domain.store.product.application.event.ProductUpdatedEvent;
+import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.TimedealPolicyRepository;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.request.TimedealUpdateRequestDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.TimedealErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TimedealUpdateService {
+
+    private final TimedealPolicyRepository timedealPolicyRepository;
+    private final ProductCacheService productCacheService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void update(Long dealId, TimedealUpdateRequestDto dto) {
+        log.info("타임딜 수정 요청 - dealId={}, start={}, end={}", dealId, dto.startTime(), dto.endTime());
+
+        TimedealPolicy policy = timedealPolicyRepository.findById(dealId)
+                .orElseThrow(() -> new CustomException(TimedealErrorCode.PRODUCT_NOT_FOUND));
+
+        if (dto.startTime() != null && dto.endTime() != null && dto.startTime().isAfter(dto.endTime())) {
+            throw new CustomException(TimedealErrorCode.INVALID_TIME);
+        }
+
+        if (dto.startTime() != null && dto.endTime() != null) {
+            boolean hasOverlap = timedealPolicyRepository.existsByProductIdAndTimeOverlapExceptSelf(
+                    policy.getProduct().getId(), dto.startTime(), dto.endTime(), dealId);
+            if (hasOverlap) throw new CustomException(TimedealErrorCode.OVERLAPPING_TIME);
+            policy.updateTime(dto.startTime(), dto.endTime());
+        }
+
+        if (dto.discountedPrice() != null && dto.discountedPrice() < 1) {
+            throw new CustomException(TimedealErrorCode.INVALID_PRICE);
+        }
+        if (dto.discountedPercentage() != null && dto.discountedPercentage() < 1) {
+            throw new CustomException(TimedealErrorCode.INVALID_PERCENT);
+        }
+
+        policy.updatePriceAndPercent(dto.discountedPrice(), dto.discountedPercentage());
+
+        productCacheService.evictTimedealCache(policy);
+        productCacheService.updateSingleTimedealCache(policy);
+        eventPublisher.publishEvent(new ProductUpdatedEvent(policy.getProduct().getId(), true));
+
+        try {
+            log.info("타임딜 수정 완료 - id={}", policy.getId());
+        } catch (Exception e) {
+            log.error("타임딜 수정 실패", e);
+            throw new CustomException(TimedealErrorCode.TIMEDEAL_SAVE_FAIL);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/ProductCacheKeys.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/ProductCacheKeys.java
@@ -1,0 +1,45 @@
+package ktb.leafresh.backend.domain.store.product.infrastructure.cache;
+
+import java.util.Optional;
+
+public class ProductCacheKeys {
+
+    public static final String PRODUCT_SORTED_SET = "store:products:zset";
+    public static final String TIMEDEAL_ZSET = "store:products:timedeal:zset";
+    public static final String TIMEDEAL_ACTIVE = "store:products:timedeal:active";
+    public static final String TIMEDEAL_LIST = "store:products:timedeal:list";
+
+    private static final String START_CURSOR = "start";
+    private static final String EMPTY_INPUT = "none";
+
+    public static String single(Long productId) {
+        return "store:products:single:" + productId;
+    }
+
+    public static String timedealSingle(Long policyId) {
+        return "store:products:timedeal:single:" + policyId;
+    }
+
+    public static String productList(String input, Long cursorId, String cursorTimestamp, int size) {
+        return String.format("store:products:list:%s:%s:%s:%d",
+                Optional.ofNullable(input).orElse(EMPTY_INPUT),
+                Optional.ofNullable(cursorId).map(String::valueOf).orElse(START_CURSOR),
+                Optional.ofNullable(cursorTimestamp).orElse(START_CURSOR),
+                size
+        );
+    }
+
+    public static String productListFirstPage(String input, int size) {
+        return String.format("store:products:list:first:%s:%d",
+                Optional.ofNullable(input).orElse(EMPTY_INPUT),
+                size
+        );
+    }
+
+    public static String productIdListFirstPage(String input, int size) {
+        return String.format("store:products:ids:first:%s:%d",
+                Optional.ofNullable(input).orElse(EMPTY_INPUT),
+                size
+        );
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/ProductCacheService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/ProductCacheService.java
@@ -1,0 +1,103 @@
+package ktb.leafresh.backend.domain.store.product.infrastructure.cache;
+
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.dto.ProductSummaryCacheDto;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.dto.TimedealProductSummaryCacheDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductCacheService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    /**
+     * 일반 상품 캐시 등록
+     */
+    public void updateSingleProductCache(Product product) {
+        String key = ProductCacheKeys.single(product.getId());
+        ProductSummaryCacheDto dto = ProductSummaryCacheDtoMapper.from(product);
+
+        redisTemplate.opsForValue().set(key, dto);
+        log.info("[ProductCacheService] 일반 상품 캐시 저장 - key={}", key);
+
+        double score = product.getCreatedAt().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        redisTemplate.opsForZSet().add(ProductCacheKeys.PRODUCT_SORTED_SET, product.getId(), score);
+        log.info("[ProductCacheService] 일반 상품 ZSet 동기화 - productId={}, score={}", product.getId(), score);
+    }
+
+    /**
+     * 타임딜 단건 캐시 등록
+     */
+    public void updateSingleTimedealCache(TimedealPolicy policy) {
+        Product product = policy.getProduct();
+        String key = ProductCacheKeys.timedealSingle(policy.getId());
+        TimedealProductSummaryCacheDto dto = TimedealProductSummaryCacheDtoMapper.from(product, policy);
+
+        Duration ttl = calculateTtl(policy.getEndTime().plusMinutes(1));
+        if (ttl != null) {
+            redisTemplate.opsForValue().set(key, dto, ttl);
+            log.info("[ProductCacheService] 타임딜 단건 캐시 저장 - key={}, TTL={}초", key, ttl.getSeconds());
+        } else {
+            redisTemplate.opsForValue().set(key, dto);
+            log.warn("[ProductCacheService] TTL 없이 타임딜 캐시 저장 - key={}", key);
+        }
+
+        updateTimedealZSet(policy);
+
+        redisTemplate.delete(ProductCacheKeys.TIMEDEAL_LIST);
+        log.info("[ProductCacheService] 타임딜 목록 캐시 무효화 - key={}", ProductCacheKeys.TIMEDEAL_LIST);
+    }
+
+    /**
+     * 타임딜 ZSet 등록
+     */
+    public void updateTimedealZSet(TimedealPolicy policy) {
+        long score = policy.getStartTime().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        redisTemplate.opsForZSet().add(ProductCacheKeys.TIMEDEAL_ZSET, policy.getId(), score);
+        log.info("[ProductCacheService] 타임딜 ZSet 등록 - policyId={}, score={}", policy.getId(), score);
+    }
+
+    /**
+     * 기존 모든 캐시 제거
+     */
+    public void evictCacheByProduct(Product product) {
+        redisTemplate.delete(ProductCacheKeys.single(product.getId()));
+        redisTemplate.opsForZSet().remove(ProductCacheKeys.PRODUCT_SORTED_SET, product.getId());
+
+        log.info("[ProductCacheService] 일반 상품 캐시 및 ZSet 제거 - productId={}", product.getId());
+
+        if (product.getActiveTimedealPolicy(LocalDateTime.now()).isPresent()) {
+            redisTemplate.opsForZSet().remove(ProductCacheKeys.TIMEDEAL_ZSET, product.getId());
+            redisTemplate.delete(ProductCacheKeys.TIMEDEAL_ACTIVE);
+            log.info("[ProductCacheService] 타임딜 ZSet 및 ACTIVE 캐시 제거 - productId={}", product.getId());
+        }
+    }
+
+    /**
+     * 타임딜 캐시 제거 (단건 + ZSet)
+     */
+    public void evictTimedealCache(TimedealPolicy policy) {
+        redisTemplate.delete(ProductCacheKeys.timedealSingle(policy.getId()));
+        redisTemplate.opsForZSet().remove(ProductCacheKeys.TIMEDEAL_ZSET, policy.getId());
+
+        log.info("[ProductCacheService] 타임딜 캐시 제거 - policyId={}", policy.getId());
+    }
+
+    /**
+     * TTL 계산 (현재 시점 기준으로 endTime까지 남은 시간)
+     */
+    private Duration calculateTtl(LocalDateTime expireTime) {
+        Duration ttl = Duration.between(LocalDateTime.now(), expireTime);
+        return ttl.isNegative() || ttl.isZero() ? null : ttl;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/TimedealProductSummaryCacheDtoMapper.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/TimedealProductSummaryCacheDtoMapper.java
@@ -1,0 +1,31 @@
+package ktb.leafresh.backend.domain.store.product.infrastructure.cache;
+
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.dto.TimedealProductSummaryCacheDto;
+
+import java.time.LocalDateTime;
+
+public class TimedealProductSummaryCacheDtoMapper {
+
+    public static TimedealProductSummaryCacheDto from(Product product, TimedealPolicy policy) {
+        LocalDateTime now = LocalDateTime.now();
+        String timeDealStatus = now.isBefore(policy.getStartTime()) ? "UPCOMING" : "ONGOING";
+
+        return new TimedealProductSummaryCacheDto(
+                policy.getId(),
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getPrice(),
+                policy.getDiscountedPrice(),
+                policy.getDiscountedPercentage(),
+                policy.getStock(),
+                product.getImageUrl(),
+                policy.getStartTime(),
+                policy.getEndTime(),
+                product.getStatus().name(),
+                timeDealStatus
+        );
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/dto/TimedealProductSummaryCacheDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/dto/TimedealProductSummaryCacheDto.java
@@ -1,0 +1,23 @@
+package ktb.leafresh.backend.domain.store.product.infrastructure.cache.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record TimedealProductSummaryCacheDto(
+        Long dealId,
+        Long productId,
+        String title,
+        String description,
+        int defaultPrice,
+        int discountedPrice,
+        int discountedPercentage,
+        int stock,
+        String imageUrl,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime dealStartTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime dealEndTime,
+        String productStatus,      // ACTIVE or SOLD_OUT
+        String timeDealStatus      // ONGOING or UPCOMING
+) {}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/request/TimedealUpdateRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/request/TimedealUpdateRequestDto.java
@@ -1,0 +1,10 @@
+package ktb.leafresh.backend.domain.store.product.presentation.dto.request;
+
+import java.time.LocalDateTime;
+
+public record TimedealUpdateRequestDto(
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        Integer discountedPrice,
+        Integer discountedPercentage
+) {}


### PR DESCRIPTION
## 요약
타임딜 정책 수정 기능을 구현하고, 수정 시 관련 상품 목록 캐시를 갱신할 수 있도록 CacheKey, CacheService, 캐싱 DTO 등을 추가하였습니다.

## 작업 내용
- 타임딜 정책 수정 요청 DTO 추가 (`TimedealUpdateRequestDto`)
- 타임딜 정책 수정 서비스 로직 추가 (`TimedealUpdateService`)
- 상품 캐시 키 상수 클래스 (`ProductCacheKeys`) 추가
- 상품 캐시 무효화를 위한 캐시 서비스 (`ProductCacheService`) 구현
  - 타임딜 생성/수정 시 상품 목록, 요약 캐시 제거
- 타임딜 상품 목록 캐싱용 DTO 및 매핑 로직 추가
  - `TimedealProductSummaryCacheDto`
  - `TimedealProductSummaryCacheDtoMapper`
