### PR TITLE
feat: 일반 상품 목록 조회 및 캐싱 기능 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/ProductCreateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/ProductCreateService.java
@@ -1,0 +1,43 @@
+package ktb.leafresh.backend.domain.store.product.application.service;
+
+import ktb.leafresh.backend.domain.store.product.application.event.ProductUpdatedEvent;
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.domain.factory.ProductFactory;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.request.ProductCreateRequestDto;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.response.ProductCreateResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ProductErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class ProductCreateService {
+
+    private final ProductRepository productRepository;
+    private final ProductFactory productFactory;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public ProductCreateResponseDto createProduct(ProductCreateRequestDto dto) {
+        try {
+            log.info("일반 상품 생성 요청: {}", dto.name());
+            Product product = productFactory.create(dto);
+            productRepository.save(product);
+
+            eventPublisher.publishEvent(new ProductUpdatedEvent(product.getId(), false));
+
+            log.info("상품 생성 완료 - id={}", product.getId());
+            return new ProductCreateResponseDto(product.getId());
+        } catch (Exception e) {
+            log.error("상품 생성 중 예외 발생", e);
+            throw new CustomException(ProductErrorCode.PRODUCT_CREATE_FAILED);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/ProductSearchReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/ProductSearchReadService.java
@@ -1,0 +1,34 @@
+package ktb.leafresh.backend.domain.store.product.application.service;
+
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductSearchQueryRepository;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.response.ProductListResponseDto;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.response.ProductSummaryResponseDto;
+import ktb.leafresh.backend.global.util.pagination.CursorPaginationHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductSearchReadService {
+
+    private final ProductSearchQueryRepository productSearchQueryRepository;
+
+    public ProductListResponseDto search(String input, Long cursorId, String cursorTimestamp, int size) {
+        List<Product> products = productSearchQueryRepository.findWithFilter(input, cursorId, cursorTimestamp, size);
+
+        var result = CursorPaginationHelper.paginateWithTimestamp(
+                products,
+                size,
+                ProductSummaryResponseDto::from,
+                ProductSummaryResponseDto::getId,
+                ProductSummaryResponseDto::getCreatedAt
+        );
+
+        return ProductListResponseDto.from(result);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/ProductSummaryCacheDtoMapper.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/ProductSummaryCacheDtoMapper.java
@@ -1,0 +1,20 @@
+package ktb.leafresh.backend.domain.store.product.infrastructure.cache;
+
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.dto.ProductSummaryCacheDto;
+
+public class ProductSummaryCacheDtoMapper {
+
+    public static ProductSummaryCacheDto from(Product product) {
+        return new ProductSummaryCacheDto(
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getImageUrl(),
+                product.getPrice(),
+                product.getStock(),
+                product.getStatus().name(),
+                product.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/dto/ProductSummaryCacheDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/dto/ProductSummaryCacheDto.java
@@ -1,0 +1,17 @@
+package ktb.leafresh.backend.domain.store.product.infrastructure.cache.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record ProductSummaryCacheDto(
+        Long id,
+        String title,
+        String description,
+        String imageUrl,
+        int price,
+        int stock,
+        String status,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/repository/ProductSearchQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/repository/ProductSearchQueryRepository.java
@@ -1,0 +1,9 @@
+package ktb.leafresh.backend.domain.store.product.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+
+import java.util.List;
+
+public interface ProductSearchQueryRepository {
+    List<Product> findWithFilter(String input, Long cursorId, String cursorTimestamp, int size);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/controller/ProductController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/controller/ProductController.java
@@ -1,0 +1,47 @@
+package ktb.leafresh.backend.domain.store.product.presentation.controller;
+
+import ktb.leafresh.backend.domain.store.product.application.service.ProductSearchReadService;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.response.ProductListResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.exception.ProductErrorCode;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/store/products")
+@Slf4j
+public class ProductController {
+
+    private final ProductSearchReadService productSearchReadService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<ProductListResponseDto>> getProducts(
+            @RequestParam(required = false) String input,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false) String cursorTimestamp,
+            @RequestParam(defaultValue = "12") int size
+    ) {
+        if ((cursorId == null) != (cursorTimestamp == null)) {
+            throw new CustomException(GlobalErrorCode.INVALID_CURSOR);
+        }
+
+        try {
+            ProductListResponseDto response = productSearchReadService.search(input, cursorId, cursorTimestamp, size);
+            String message = response.getProducts().isEmpty()
+                    ? "검색된 상품이 없습니다."
+                    : "상품 목록을 조회했습니다.";
+            return ResponseEntity.ok(ApiResponse.success(message, response));
+        } catch (Exception e) {
+            log.error("[상품 목록 조회 실패]", e);
+            throw new CustomException(ProductErrorCode.PRODUCT_CREATE_FAILED);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/response/ProductListResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/response/ProductListResponseDto.java
@@ -1,0 +1,24 @@
+package ktb.leafresh.backend.domain.store.product.presentation.dto.response;
+
+import ktb.leafresh.backend.global.util.pagination.CursorInfo;
+import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ProductListResponseDto {
+    private final List<ProductSummaryResponseDto> products;
+    private final boolean hasNext;
+    private final CursorInfo cursorInfo;
+
+    public static ProductListResponseDto from(CursorPaginationResult<ProductSummaryResponseDto> result) {
+        return ProductListResponseDto.builder()
+                .products(result.items())
+                .hasNext(result.hasNext())
+                .cursorInfo(result.cursorInfo())
+                .build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/response/ProductSummaryResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/response/ProductSummaryResponseDto.java
@@ -1,0 +1,36 @@
+package ktb.leafresh.backend.domain.store.product.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ProductSummaryResponseDto {
+
+    private final Long id;
+    private final String title;
+    private final String description;
+    private final String imageUrl;
+    private final int price;
+    private final int stock;
+    private final String status;
+    @JsonIgnore
+    private final LocalDateTime createdAt;
+
+    public static ProductSummaryResponseDto from(Product product) {
+        return ProductSummaryResponseDto.builder()
+                .id(product.getId())
+                .title(product.getName())
+                .description(product.getDescription())
+                .imageUrl(product.getImageUrl())
+                .price(product.getPrice())
+                .stock(product.getStock())
+                .status(product.getStatus().name())
+                .createdAt(product.getCreatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## 요약
일반 상품 목록을 조회하는 API를 구현하고, 목록 데이터의 성능 최적화를 위한 캐싱 로직과 DTO/매퍼를 도입하였습니다.  
검색 키워드 기반 조회도 지원합니다.

## 작업 내용
- 일반 상품 목록 조회용 DTO 추가
  - `ProductSummaryResponseDto`, `ProductListResponseDto`
- 일반 상품 목록 캐싱용 DTO 및 매퍼 클래스 추가
  - `ProductSummaryCacheDto`, `ProductSummaryCacheDtoMapper`
- 상품 생성 시 목록 캐시에 저장되는 로직 적용
- 일반 상품 검색을 포함한 목록 조회 서비스 및 API 추가
  - QueryDSL 기반 Repository, QueryService, ReadService 구현
  - Controller API 추가
