### PR TITLE
feat: 상품 구매 내역 조회 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductPurchaseReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductPurchaseReadService.java
@@ -1,0 +1,34 @@
+package ktb.leafresh.backend.domain.store.order.application.service;
+
+import ktb.leafresh.backend.domain.store.order.domain.entity.ProductPurchase;
+import ktb.leafresh.backend.domain.store.order.infrastructure.repository.ProductPurchaseQueryRepository;
+import ktb.leafresh.backend.domain.store.order.presentation.dto.response.ProductPurchaseListResponseDto;
+import ktb.leafresh.backend.domain.store.order.presentation.dto.response.ProductPurchaseSummaryResponseDto;
+import ktb.leafresh.backend.global.util.pagination.CursorPaginationHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductPurchaseReadService {
+
+    private final ProductPurchaseQueryRepository productPurchaseQueryRepository;
+
+    public ProductPurchaseListResponseDto getPurchases(Long memberId, String input, Long cursorId, String cursorTimestamp, int size) {
+        List<ProductPurchase> purchases = productPurchaseQueryRepository.findByMemberWithCursorAndSearch(memberId, input, cursorId, cursorTimestamp, size);
+
+        var result = CursorPaginationHelper.paginateWithTimestamp(
+                purchases,
+                size,
+                ProductPurchaseSummaryResponseDto::from,
+                ProductPurchaseSummaryResponseDto::id,
+                ProductPurchaseSummaryResponseDto::purchasedAt
+        );
+
+        return ProductPurchaseListResponseDto.from(result);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/repository/ProductPurchaseQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/repository/ProductPurchaseQueryRepository.java
@@ -1,0 +1,9 @@
+package ktb.leafresh.backend.domain.store.order.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.store.order.domain.entity.ProductPurchase;
+
+import java.util.List;
+
+public interface ProductPurchaseQueryRepository {
+    List<ProductPurchase> findByMemberWithCursorAndSearch(Long memberId, String input, Long cursorId, String cursorTimestamp, int size);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/controller/ProductPurchaseController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/controller/ProductPurchaseController.java
@@ -1,0 +1,51 @@
+package ktb.leafresh.backend.domain.store.order.presentation.controller;
+
+import ktb.leafresh.backend.domain.store.order.application.service.ProductPurchaseReadService;
+import ktb.leafresh.backend.domain.store.order.presentation.dto.response.ProductPurchaseListResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members/products")
+@Slf4j
+public class ProductPurchaseController {
+
+    private final ProductPurchaseReadService productPurchaseReadService;
+
+    @GetMapping("/list")
+    public ResponseEntity<ApiResponse<ProductPurchaseListResponseDto>> getPurchaseHistory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) String input,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false) String cursorTimestamp,
+            @RequestParam(defaultValue = "12") int size
+    ) {
+        if ((cursorId == null) != (cursorTimestamp == null)) {
+            throw new CustomException(GlobalErrorCode.INVALID_CURSOR);
+        }
+
+        try {
+            ProductPurchaseListResponseDto response = productPurchaseReadService.getPurchases(userDetails.getMemberId(), input, cursorId, cursorTimestamp, size);
+
+            String message = response.getPurchases().isEmpty()
+                    ? "구매 내역이 없습니다."
+                    : "구매 내역을 불러왔습니다.";
+
+            return ResponseEntity.ok(ApiResponse.success(message, response));
+        } catch (Exception e) {
+            log.error("[구매 내역 조회 실패] {}", e.getMessage(), e);
+            throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/dto/response/ProductPurchaseListResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/dto/response/ProductPurchaseListResponseDto.java
@@ -1,0 +1,25 @@
+package ktb.leafresh.backend.domain.store.order.presentation.dto.response;
+
+import ktb.leafresh.backend.global.util.pagination.CursorInfo;
+import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ProductPurchaseListResponseDto {
+
+    private final List<ProductPurchaseSummaryResponseDto> purchases;
+    private final boolean hasNext;
+    private final CursorInfo cursorInfo;
+
+    public static ProductPurchaseListResponseDto from(CursorPaginationResult<ProductPurchaseSummaryResponseDto> result) {
+        return ProductPurchaseListResponseDto.builder()
+                .purchases(result.items())
+                .hasNext(result.hasNext())
+                .cursorInfo(result.cursorInfo())
+                .build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/dto/response/ProductPurchaseSummaryResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/dto/response/ProductPurchaseSummaryResponseDto.java
@@ -1,0 +1,57 @@
+package ktb.leafresh.backend.domain.store.order.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import ktb.leafresh.backend.domain.store.order.domain.entity.ProductPurchase;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ProductPurchaseSummaryResponseDto {
+
+    private final Long id;
+
+    private final ProductInfo product;
+
+    private final int quantity;
+
+    private final int price;
+
+    private final String purchasedAt;
+
+    @JsonIgnore
+    private final String type;
+
+    @Getter
+    @Builder
+    public static class ProductInfo {
+        private final Long id;
+        private final String title;
+        private final String imageUrl;
+    }
+
+    public static ProductPurchaseSummaryResponseDto from(ProductPurchase entity) {
+        return ProductPurchaseSummaryResponseDto.builder()
+                .id(entity.getId())
+                .product(ProductInfo.builder()
+                        .id(entity.getProduct().getId())
+                        .title(entity.getProduct().getName())
+                        .imageUrl(entity.getProduct().getImageUrl())
+                        .build())
+                .quantity(entity.getQuantity())
+                .price(entity.getPrice())
+                .purchasedAt(entity.getPurchasedAt().toString())
+                .type(entity.getType().name()) // JsonIgnore로 제외됨
+                .build();
+    }
+
+    public static Long id(ProductPurchaseSummaryResponseDto dto) {
+        return dto.getId();
+    }
+
+    public static LocalDateTime purchasedAt(ProductPurchaseSummaryResponseDto dto) {
+        return LocalDateTime.parse(dto.getPurchasedAt());
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/repository/ProductSearchQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/repository/ProductSearchQueryRepositoryImpl.java
@@ -1,0 +1,43 @@
+package ktb.leafresh.backend.domain.store.product.infrastructure.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.domain.entity.QProduct;
+import ktb.leafresh.backend.domain.store.product.domain.entity.enums.ProductStatus;
+import ktb.leafresh.backend.global.util.pagination.CursorConditionUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductSearchQueryRepositoryImpl implements ProductSearchQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QProduct p = QProduct.product;
+
+    @Override
+    public List<Product> findWithFilter(String input, Long cursorId, String cursorTimestamp, int size) {
+        LocalDateTime ts = CursorConditionUtils.parseTimestamp(cursorTimestamp);
+
+        return queryFactory
+                .selectFrom(p)
+                .where(
+                        p.deletedAt.isNull(),
+                        p.status.in(ProductStatus.ACTIVE, ProductStatus.SOLD_OUT),
+                        likeInput(input),
+                        CursorConditionUtils.ltCursorWithTimestamp(p.createdAt, p.id, ts, cursorId)
+                )
+                .orderBy(p.createdAt.desc(), p.id.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+
+    private BooleanExpression likeInput(String input) {
+        if (input == null || input.trim().isEmpty()) return null;
+        return p.name.containsIgnoreCase(input).or(p.description.containsIgnoreCase(input));
+    }
+}


### PR DESCRIPTION
## 요약
회원의 상품 구매 이력을 조회하는 API를 구현하였습니다.  
응답 데이터 구성을 위한 DTO 정의부터 레포지토리, 서비스, 컨트롤러까지 전반적인 기능이 포함되어 있습니다.

## 작업 내용
- 상품 구매 내역 조회 응답 DTO 추가
  - `ProductPurchaseSummaryResponseDto`, `ProductPurchaseListResponseDto`
- 구매 내역 조회용 QueryRepository 및 구현체 추가
- 구매 내역 조회 서비스 로직 추가
  - `ProductPurchaseQueryService`, `ProductPurchaseReadService` 등
- 구매 내역 조회 API 구현
  - `GET /api/mypage/purchases` 또는 해당 컨트롤러 내 목록 조회 엔드포인트 추가
