### PR TITLE
refactor: 회원 정보 수정 API 응답 204 → 200 OK 및 수정 결과 포함 형태로 변경

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/MemberUpdateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/MemberUpdateService.java
@@ -2,8 +2,8 @@ package ktb.leafresh.backend.domain.member.application.service;
 
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.MemberUpdateResponseDto;
 import ktb.leafresh.backend.global.exception.CustomException;
-import ktb.leafresh.backend.global.exception.GlobalErrorCode;
 import ktb.leafresh.backend.global.exception.MemberErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +18,7 @@ public class MemberUpdateService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void updateMemberInfo(Member member, String newNickname, String newImageUrl) {
+    public MemberUpdateResponseDto updateMemberInfo(Member member, String newNickname, String newImageUrl) {
         boolean updated = false;
 
         log.debug("[회원 정보 수정] 시작 - memberId: {}", member.getId());
@@ -45,6 +45,11 @@ public class MemberUpdateService {
             if (!updated) {
                 throw new CustomException(MemberErrorCode.NO_CHANGES);
             }
+
+            return MemberUpdateResponseDto.builder()
+                    .nickname(member.getNickname())
+                    .imageUrl(member.getImageUrl())
+                    .build();
 
         } catch (CustomException e) {
             throw e;

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/MemberController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/controller/MemberController.java
@@ -8,6 +8,7 @@ import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
 import ktb.leafresh.backend.domain.member.presentation.dto.request.MemberUpdateRequestDto;
 import ktb.leafresh.backend.domain.member.presentation.dto.response.MemberInfoResponseDto;
+import ktb.leafresh.backend.domain.member.presentation.dto.response.MemberUpdateResponseDto;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.MemberErrorCode;
 import ktb.leafresh.backend.global.response.ApiResponse;
@@ -38,7 +39,7 @@ public class MemberController {
     @Operation(summary = "회원 정보 수정", description = "닉네임, 이미지 URL을 수정합니다.")
     @ApiResponseConstants.ClientErrorResponses
     @ApiResponseConstants.ServerErrorResponses
-    public ResponseEntity<ApiResponse<Void>> updateMemberInfo(
+    public ResponseEntity<ApiResponse<MemberUpdateResponseDto>> updateMemberInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody MemberUpdateRequestDto requestDto) {
 
@@ -51,12 +52,14 @@ public class MemberController {
                         return new CustomException(MemberErrorCode.MEMBER_NOT_FOUND);
                     });
 
-            memberUpdateService.updateMemberInfo(member, requestDto.getNickname(), requestDto.getImageUrl());
+            MemberUpdateResponseDto responseDto = memberUpdateService.updateMemberInfo(
+                    member, requestDto.getNickname(), requestDto.getImageUrl()
+            );
 
             log.info("[회원 정보 수정] 성공 - memberId: {}", userDetails.getMemberId());
 
-            return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                    .body(ApiResponse.success("회원 정보가 성공적으로 수정되었습니다."));
+            return ResponseEntity.ok(ApiResponse.success("회원 정보 수정이 완료되었습니다.", responseDto));
+
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/MemberUpdateResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/MemberUpdateResponseDto.java
@@ -1,0 +1,11 @@
+package ktb.leafresh.backend.domain.member.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberUpdateResponseDto {
+    private final String nickname;
+    private final String imageUrl;
+}


### PR DESCRIPTION
## 요약
회원 정보 수정 API 응답을 기존의 204 No Content에서 200 OK + 수정된 nickname/imageUrl을 포함하는 형태로 변경했습니다.

## 작업 내용
- MemberUpdateResponseDto 생성 및 빌더 패턴 적용
- MemberUpdateService가 MemberUpdateResponseDto를 반환하도록 변경 (SRP 원칙 반영)
- MemberController에서 상태 코드 200과 응답 본문 포함되도록 수정
