### PR TITLE
feat: 상품 재고 Redis 캐싱 로직 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/ProductCacheKeys.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/ProductCacheKeys.java
@@ -16,6 +16,14 @@ public class ProductCacheKeys {
         return "store:products:single:" + productId;
     }
 
+    public static String productStock(Long productId) {
+        return "stock:product:" + productId;
+    }
+
+    public static String timedealStock(Long timedealPolicyId) {
+        return "stock:timedeal:" + timedealPolicyId;
+    }
+
     public static String timedealSingle(Long policyId) {
         return "store:products:timedeal:single:" + policyId;
     }

--- a/src/main/java/ktb/leafresh/backend/global/initializer/ProductStockCacheInitializer.java
+++ b/src/main/java/ktb/leafresh/backend/global/initializer/ProductStockCacheInitializer.java
@@ -1,0 +1,40 @@
+package ktb.leafresh.backend.global.initializer;
+
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductStockCacheInitializer {
+
+    private final ProductRepository productRepository;
+    private final ProductCacheService productCacheService;
+
+    /**
+     * 서비스 시작 시 모든 상품 재고를 Redis에 캐싱
+     */
+    @PostConstruct
+    public void initProductStockCache() {
+        List<Product> products = productRepository.findAll();
+
+        int successCount = 0;
+        for (Product product : products) {
+            try {
+                productCacheService.cacheProductStock(product.getId(), product.getStock());
+                successCount++;
+            } catch (Exception e) {
+                log.error("[ProductStockCacheInitializer] 캐시 등록 실패 - productId={}", product.getId(), e);
+            }
+        }
+
+        log.info("[ProductStockCacheInitializer] Redis 재고 캐시 초기화 완료 - 총 {}건", successCount);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/initializer/TimedealStockCacheInitializer.java
+++ b/src/main/java/ktb/leafresh/backend/global/initializer/TimedealStockCacheInitializer.java
@@ -1,0 +1,43 @@
+package ktb.leafresh.backend.global.initializer;
+
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.TimedealPolicyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TimedealStockCacheInitializer {
+
+    private final TimedealPolicyRepository timedealPolicyRepository;
+    private final ProductCacheService productCacheService;
+
+    @PostConstruct
+    public void initTimedealStockCache() {
+        List<TimedealPolicy> validPolicies = timedealPolicyRepository.findAllValidWithProduct(LocalDateTime.now());
+
+        int successCount = 0;
+        for (TimedealPolicy policy : validPolicies) {
+            try {
+                productCacheService.cacheTimedealStock(
+                        policy.getId(),
+                        policy.getStock(),
+                        policy.getEndTime()
+                );
+                productCacheService.updateSingleTimedealCache(policy);
+                successCount++;
+            } catch (Exception e) {
+                log.error("[TimedealStockCacheInitializer] 캐시 등록 실패 - timedealId={}", policy.getId(), e);
+            }
+        }
+
+        log.info("[TimedealStockCacheInitializer] Redis 타임딜 재고 캐시 초기화 완료 - 총 {}건", successCount);
+    }
+}


### PR DESCRIPTION
## 요약
상품 주문 처리의 성능 향상을 위해 상품 재고 정보를 Redis에 캐싱하는 로직을 구현했습니다.

## 작업 내용
- `ProductCacheKeys`, `ProductCacheService` 구현
- `ProductStockCacheInitializer` 작성
- `TimedealStockCacheInitializer` 포함
