### PR TITLE
feat: 상품 주문 메시지 Pub/Sub publisher 및 subscriber 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/publisher/FakePurchaseMessagePublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/publisher/FakePurchaseMessagePublisher.java
@@ -1,0 +1,17 @@
+package ktb.leafresh.backend.domain.store.order.infrastructure.publisher;
+
+import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("local")
+@Slf4j
+public class FakePurchaseMessagePublisher implements PurchaseMessagePublisher {
+    @Override
+    public void publish(PurchaseCommand command) {
+        log.info("[로컬용 가짜 PubSub 발행] {}", command);
+        // 로컬에서는 로그만 찍거나, 테스트용 로컬 큐에 저장해도 됨
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/publisher/GcpPurchaseMessagePublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/publisher/GcpPurchaseMessagePublisher.java
@@ -1,0 +1,46 @@
+package ktb.leafresh.backend.domain.store.order.infrastructure.publisher;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("!local")
+@RequiredArgsConstructor
+@Slf4j
+public class GcpPurchaseMessagePublisher implements PurchaseMessagePublisher {
+
+    @Qualifier("purchasePubSubPublisher")
+    private final Publisher publisher;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void publish(PurchaseCommand command) {
+        try {
+            String message = objectMapper.writeValueAsString(command);
+            PubsubMessage pubsubMessage = PubsubMessage.newBuilder()
+                    .setData(ByteString.copyFromUtf8(message))
+                    .build();
+
+            publisher.publish(pubsubMessage); // 비동기 발행
+            log.info("[PubSub 메시지 발행 성공] {}", message);
+        } catch (JsonProcessingException e) {
+            log.error("[PubSub 직렬화 실패]", e);
+            throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR, "구매 요청 직렬화에 실패했습니다.");
+        } catch (Exception e) {
+            log.error("[PubSub 발행 실패]", e);
+            throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR, "구매 요청 발행에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/publisher/PurchaseMessagePublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/publisher/PurchaseMessagePublisher.java
@@ -1,0 +1,7 @@
+package ktb.leafresh.backend.domain.store.order.infrastructure.publisher;
+
+import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
+
+public interface PurchaseMessagePublisher {
+    void publish(PurchaseCommand command);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/subscriber/PurchaseDlqMessageSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/subscriber/PurchaseDlqMessageSubscriber.java
@@ -1,0 +1,74 @@
+package ktb.leafresh.backend.domain.store.order.infrastructure.subscriber;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
+import ktb.leafresh.backend.domain.store.order.domain.entity.PurchaseFailureLog;
+import ktb.leafresh.backend.domain.store.order.domain.entity.PurchaseProcessingLog;
+import ktb.leafresh.backend.domain.store.order.domain.entity.enums.PurchaseProcessingStatus;
+import ktb.leafresh.backend.domain.store.order.infrastructure.repository.PurchaseFailureLogRepository;
+import ktb.leafresh.backend.domain.store.order.infrastructure.repository.PurchaseProcessingLogRepository;
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@Profile("!local")
+@RequiredArgsConstructor
+@Slf4j
+public class PurchaseDlqMessageSubscriber {
+
+    private final ObjectMapper objectMapper;
+    private final PurchaseFailureLogRepository purchaseFailureLogRepository;
+    private final PurchaseProcessingLogRepository purchaseProcessingLogRepository;
+
+    @PostConstruct
+    public void subscribe() {
+        ProjectSubscriptionName dlqSubscription = ProjectSubscriptionName.of("leafresh2", "leafresh-order-dlq-topic-sub");
+
+        MessageReceiver receiver = (message, consumer) -> {
+            String rawData = message.getData().toStringUtf8();
+            log.error("[DLQ 수신] messageId={}, data={}", message.getMessageId(), rawData);
+
+            try {
+                PurchaseCommand failedCommand = objectMapper.readValue(rawData, PurchaseCommand.class);
+
+                purchaseFailureLogRepository.save(PurchaseFailureLog.builder()
+                        .member(Member.builder().id(failedCommand.memberId()).build())
+                        .product(Product.builder().id(failedCommand.productId()).build())
+                        .reason("DLQ로 이동된 메시지입니다.")
+                        .requestBody(rawData)
+                        .occurredAt(LocalDateTime.now())
+                        .build());
+
+                purchaseProcessingLogRepository.save(PurchaseProcessingLog.builder()
+                        .product(Product.builder().id(failedCommand.productId()).build())
+                        .status(PurchaseProcessingStatus.FAILURE)
+                        .message("DLQ 처리됨")
+                        .build());
+
+                log.warn("[DLQ 처리] memberId={}, productId={}, quantity={}",
+                        failedCommand.memberId(), failedCommand.productId(), failedCommand.quantity());
+
+                // TODO: Discord/DB/이메일 저장 로직 분리
+
+                consumer.ack(); // DLQ는 반드시 ack 처리해야 다시 쌓이지 않음
+            } catch (Exception e) {
+                log.error("[DLQ 메시지 파싱 실패] {}", e.getMessage(), e);
+                consumer.ack(); // 파싱 실패해도 ack로 종료 (무한 재시도 방지)
+            }
+        };
+
+        Subscriber subscriber = Subscriber.newBuilder(dlqSubscription, receiver).build();
+        subscriber.startAsync().awaitRunning();
+        log.info("[DLQ 메시지 구독 시작]");
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/subscriber/PurchaseMessageSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/subscriber/PurchaseMessageSubscriber.java
@@ -1,0 +1,59 @@
+package ktb.leafresh.backend.domain.store.order.infrastructure.subscriber;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
+import ktb.leafresh.backend.domain.store.order.application.service.ProductPurchaseProcessingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+
+@Slf4j
+@Profile("!local")
+@Component
+@RequiredArgsConstructor
+public class PurchaseMessageSubscriber {
+
+    private final ProductPurchaseProcessingService processingService;
+    private final ObjectMapper objectMapper;
+
+    @PostConstruct
+    public void subscribe() {
+        ProjectSubscriptionName subscriptionName =
+                ProjectSubscriptionName.of("leafresh2", "leafresh-order-topic-sub");
+
+        MessageReceiver receiver = (message, consumer) -> {
+            String rawData = message.getData().toStringUtf8();
+            String attemptStr = message.getAttributesOrDefault("googclient_deliveryattempt", null);
+            Integer attempt = attemptStr != null ? Integer.parseInt(attemptStr) : null;
+
+            log.info("[메시지 수신] messageId={}, deliveryAttempt={}, data={}",
+                    message.getMessageId(), attempt, rawData);
+
+            // DLQ 대상이면 더 이상 처리하지 않고 ack() 후 종료
+//            if (attempt != null && attempt >= 5) {
+//                log.warn("[deliveryAttempt {}] DLQ 대상 - nack 처리하여 DLQ로 이동 시도", attempt);
+//                consumer.nack(); // GCP가 DLQ로 이동시킴
+//                return;
+//            }
+
+            try {
+                PurchaseCommand command = objectMapper.readValue(rawData, PurchaseCommand.class);
+                processingService.process(command);
+                consumer.ack(); // 성공적으로 처리되면 ack
+            } catch (Exception e) {
+                log.error("[구매 메시지 처리 실패] {}", e.getMessage(), e);
+                consumer.nack(); // 실패 시 재시도 (DLQ 조건에 따라)
+            }
+        };
+
+        Subscriber subscriber = Subscriber.newBuilder(subscriptionName, receiver).build();
+        subscriber.startAsync().awaitRunning();
+        log.info("[구매 메시지 구독 시작]");
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/config/PubSubPublisherConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/PubSubPublisherConfig.java
@@ -1,0 +1,35 @@
+package ktb.leafresh.backend.global.config;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.rpc.FixedTransportChannelProvider;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.pubsub.v1.TopicName;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+
+import java.io.IOException;
+
+@Configuration
+@Profile("!local")
+@RequiredArgsConstructor
+public class PubSubPublisherConfig {
+
+    private final Environment environment;
+
+    @Bean(name = "purchasePubSubPublisher")
+    public Publisher purchasePubSubPublisher() throws IOException {
+        String projectId = environment.getProperty("gcp.project-id");
+        String topicId = "leafresh-order-topic";
+
+        TopicName topicName = TopicName.of(projectId, topicId);
+
+        return Publisher.newBuilder(topicName)
+                .setCredentialsProvider(() -> GoogleCredentials.getApplicationDefault())
+                .build();
+    }
+}


### PR DESCRIPTION
## 요약
상품 주문 요청을 비동기 처리하기 위해 GCP Pub/Sub 기반 publisher 및 subscriber 구조를 도입했습니다. 이를 통해 주문 처리 로직을 메시지 기반으로 분리하고, 확장성과 장애 대응력을 강화했습니다.

## 작업 내용
- `PurchaseMessagePublisher` 인터페이스 정의 및 구현체(GCP/Fake) 추가
- `PurchaseMessageSubscriber` 클래스 작성하여 메시지 수신 후 주문 처리 연동
- 메시지 처리 상태 및 재시도 로직을 위한 로그 추가
- 기본 Pub/Sub 설정 및 메시지 수신/처리 구조 정립
