### PR TITLE
feat: 주문 중복 방지를 위한 Idempotency Key 처리 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/order/domain/entity/PurchaseIdempotencyKey.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/domain/entity/PurchaseIdempotencyKey.java
@@ -28,4 +28,9 @@ public class PurchaseIdempotencyKey extends BaseEntity {
     // 중복 방지 키 (e.g. 클라이언트가 생성한 UUID)
     @Column(name = "idempotency_key", nullable = false, length = 255)
     private String idempotencyKey;
+
+    public PurchaseIdempotencyKey(Member member, String idempotencyKey) {
+        this.member = member;
+        this.idempotencyKey = idempotencyKey;
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/repository/PurchaseIdempotencyKeyRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/repository/PurchaseIdempotencyKeyRepository.java
@@ -1,0 +1,9 @@
+package ktb.leafresh.backend.domain.store.order.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.store.order.domain.entity.PurchaseIdempotencyKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PurchaseIdempotencyKeyRepository extends JpaRepository<PurchaseIdempotencyKey, Long> {
+}


### PR DESCRIPTION
## 요약
중복된 주문 요청을 방지하기 위해 Idempotency Key 기반의 중복 처리 방지 로직을 도입했습니다. 클라이언트에서 발급한 키를 기준으로 서버에서 선행 요청 여부를 판별할 수 있습니다.

## 작업 내용
- `PurchaseIdempotencyKey` 엔티티 생성 및 관련 필드 정의
- `PurchaseIdempotencyKeyRepository` 구현
- memberId + idempotencyKey 기준으로 유니크 제약 조건 부여
- 주문 생성 시 이 키를 사용한 중복 요청 차단 로직과 연동
