### PR TITLE
feat: 주문 메시지 소비 후 주문 처리 및 재고 차감 로직 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/Member.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/Member.java
@@ -142,4 +142,8 @@ public class Member extends BaseEntity {
     public void updateImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }
+
+    public void updateCurrentLeafPoints(int newPoints) {
+        this.currentLeafPoints = newPoints;
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/dto/PurchaseCommand.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/dto/PurchaseCommand.java
@@ -1,0 +1,11 @@
+package ktb.leafresh.backend.domain.store.order.application.dto;
+
+import java.time.LocalDateTime;
+
+public record PurchaseCommand(
+        Long memberId,
+        Long productId,
+        Integer quantity,
+        String idempotencyKey,
+        LocalDateTime requestedAt
+) {}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateService.java
@@ -1,0 +1,67 @@
+package ktb.leafresh.backend.domain.store.order.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.store.order.domain.entity.PurchaseIdempotencyKey;
+import ktb.leafresh.backend.domain.store.order.infrastructure.publisher.PurchaseMessagePublisher;
+import ktb.leafresh.backend.domain.store.order.infrastructure.repository.PurchaseIdempotencyKeyRepository;
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheKeys;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.exception.ProductErrorCode;
+import ktb.leafresh.backend.global.exception.PurchaseErrorCode;
+import ktb.leafresh.backend.global.util.redis.RedisLuaService;
+import ktb.leafresh.backend.domain.store.order.infrastructure.publisher.GcpPurchaseMessagePublisher;
+import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductOrderCreateService {
+
+    private final MemberRepository memberRepository;
+    private final ProductRepository productRepository;
+    private final PurchaseIdempotencyKeyRepository idempotencyRepository;
+    private final RedisLuaService redisLuaService;
+    private final PurchaseMessagePublisher purchaseMessagePublisher;
+
+    @Transactional
+    public void create(Long memberId, Long productId, int quantity, String idempotencyKey) {
+        // 1. 사용자 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(GlobalErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        // 2. Idempotency 키 저장
+        try {
+            idempotencyRepository.save(new PurchaseIdempotencyKey(member, idempotencyKey));
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(PurchaseErrorCode.DUPLICATE_PURCHASE_REQUEST);
+        }
+
+        // 3. 상품 존재 여부 확인 (재고 키 조회용)
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new CustomException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        // 4. Redis 재고 선점
+        String redisKey = ProductCacheKeys.productStock(productId);
+        Long result = redisLuaService.decreaseStock(redisKey, quantity);
+
+        if (result == -1) throw new CustomException(ProductErrorCode.PRODUCT_NOT_FOUND);
+        if (result == -2) throw new CustomException(ProductErrorCode.OUT_OF_STOCK);
+
+        // 5. 메시지 큐 발행
+        PurchaseCommand command = new PurchaseCommand(memberId, productId, quantity, idempotencyKey, LocalDateTime.now());
+        purchaseMessagePublisher.publish(command);
+
+        log.info("[주문 큐 발행 완료] memberId={}, productId={}, quantity={}", memberId, productId, quantity);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductPurchaseProcessingService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductPurchaseProcessingService.java
@@ -1,0 +1,120 @@
+package ktb.leafresh.backend.domain.store.order.application.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
+import ktb.leafresh.backend.domain.store.order.domain.entity.*;
+import ktb.leafresh.backend.domain.store.order.domain.entity.enums.PurchaseProcessingStatus;
+import ktb.leafresh.backend.domain.store.order.domain.entity.enums.PurchaseType;
+import ktb.leafresh.backend.domain.store.order.infrastructure.repository.*;
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductPurchaseProcessingService {
+
+    private final MemberRepository memberRepository;
+    private final ProductRepository productRepository;
+    private final ProductPurchaseRepository purchaseRepository;
+    private final PurchaseProcessingLogRepository processingLogRepository;
+    private final PurchaseFailureLogRepository failureLogRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Transactional
+    public void process(PurchaseCommand cmd) {
+        log.info("[구매 처리 시작] memberId={}, productId={}, quantity={}",
+                cmd.memberId(), cmd.productId(), cmd.quantity());
+
+        try {
+            log.debug("1. 사용자 조회 시작");
+            Member member = memberRepository.findById(cmd.memberId())
+                    .orElseThrow(() -> new CustomException(GlobalErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+            log.debug("1. 사용자 조회 완료: {}", member.getNickname());
+
+            log.debug("2. 상품 조회 시작");
+            Product product = productRepository.findById(cmd.productId())
+                    .orElseThrow(() -> new CustomException(GlobalErrorCode.NOT_FOUND, "상품을 찾을 수 없습니다."));
+            log.debug("2. 상품 조회 완료: {}", product.getName());
+
+            log.debug("3. 재고 및 포인트 검증 시작");
+            if (product.getStock() < cmd.quantity()) {
+                throw new CustomException(GlobalErrorCode.INVALID_REQUEST, "재고가 부족합니다.");
+            }
+
+            int totalPrice = product.getPrice() * cmd.quantity();
+
+            if (member.getCurrentLeafPoints() < totalPrice) {
+                throw new CustomException(GlobalErrorCode.INVALID_REQUEST, "보유한 나뭇잎 포인트가 부족합니다.");
+            }
+            log.debug("3. 검증 통과 - 현재 재고: {}, 보유 포인트: {}", product.getStock(), member.getCurrentLeafPoints());
+
+            log.debug("4. 포인트 차감 및 재고 차감 시작");
+            member.updateCurrentLeafPoints(member.getCurrentLeafPoints() - totalPrice);
+            product.updateStock(product.getStock() - cmd.quantity());
+            productRepository.save(product); // 🔥 명시적 저장 (dirty checking 이슈 예방)
+            log.debug("4. 차감 완료 - 남은 재고: {}, 남은 포인트: {}", product.getStock(), member.getCurrentLeafPoints());
+
+            log.debug("5. 구매 정보 저장 시작");
+            ProductPurchase purchase = ProductPurchase.builder()
+                    .member(member)
+                    .product(product)
+                    .quantity(cmd.quantity())
+                    .price(product.getPrice())
+                    .type(PurchaseType.NORMAL)
+                    .purchasedAt(LocalDateTime.now())
+                    .build();
+            purchaseRepository.save(purchase);
+            log.debug("5. 구매 정보 저장 완료: purchaseId={}", purchase.getId());
+
+            log.debug("6. 성공 로그 저장 시작");
+            processingLogRepository.save(PurchaseProcessingLog.builder()
+                    .product(product)
+                    .status(PurchaseProcessingStatus.SUCCESS)
+                    .message("구매 성공")
+                    .build());
+            log.debug("6. 성공 로그 저장 완료");
+
+            log.info("[구매 처리 완료] memberId={}, productId={}, price={}, points left={}",
+                    cmd.memberId(), cmd.productId(), totalPrice, member.getCurrentLeafPoints());
+
+        } catch (Exception e) {
+            log.warn("예외 발생 - 실패 로그 저장 시작");
+
+            String requestBodyJson;
+            try {
+                requestBodyJson = objectMapper.writeValueAsString(cmd);
+            } catch (JsonProcessingException jsonException) {
+                requestBodyJson = String.format("{\"fallback\": \"%s\"}", cmd.toString().replace("\"", "\\\""));
+            }
+
+            failureLogRepository.save(PurchaseFailureLog.builder()
+                    .member(Member.builder().id(cmd.memberId()).build())
+                    .product(Product.builder().id(cmd.productId()).build())
+                    .reason(e.getMessage())
+                    .requestBody(requestBodyJson)
+                    .occurredAt(LocalDateTime.now())
+                    .build());
+
+            processingLogRepository.save(PurchaseProcessingLog.builder()
+                    .product(Product.builder().id(cmd.productId()).build())
+                    .status(PurchaseProcessingStatus.FAILURE)
+                    .message(e.getMessage())
+                    .build());
+
+            log.error("[구매 처리 실패] {}", e.getMessage(), e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/repository/ProductPurchaseRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/repository/ProductPurchaseRepository.java
@@ -1,0 +1,9 @@
+package ktb.leafresh.backend.domain.store.order.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.store.order.domain.entity.ProductPurchase;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductPurchaseRepository extends JpaRepository<ProductPurchase, Long> {
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/repository/PurchaseProcessingLogRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/repository/PurchaseProcessingLogRepository.java
@@ -1,0 +1,9 @@
+package ktb.leafresh.backend.domain.store.order.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.store.order.domain.entity.PurchaseProcessingLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PurchaseProcessingLogRepository extends JpaRepository<PurchaseProcessingLog, Long> {
+}

--- a/src/main/java/ktb/leafresh/backend/global/util/redis/RedisLuaService.java
+++ b/src/main/java/ktb/leafresh/backend/global/util/redis/RedisLuaService.java
@@ -1,0 +1,40 @@
+package ktb.leafresh.backend.global.util.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class RedisLuaService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private static final String DECREASE_STOCK_LUA = """
+        local stock = tonumber(redis.call("GET", KEYS[1]))
+        local qty = tonumber(ARGV[1])
+        if stock == nil then return -1 end
+        if stock < qty then return -2 end
+        return redis.call("DECRBY", KEYS[1], qty)
+    """;
+
+    public Long decreaseStock(String key, int quantity) {
+        log.debug("[RedisLuaService] key={}, quantity={}", key, quantity);
+        try {
+            return stringRedisTemplate.execute(
+                    new DefaultRedisScript<>(DECREASE_STOCK_LUA, Long.class),
+                    Collections.singletonList(key),
+                    String.valueOf(quantity)
+            );
+        } catch (Exception e) {
+            log.error("[RedisLua 오류] key={}, quantity={}, message={}", key, quantity, e.getMessage(), e);
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
## 요약
메시지 큐에서 주문 메시지를 수신한 후, 상품 재고를 차감하고 주문을 처리하는 로직을 구현했습니다.

## 작업 내용
- `ProductPurchaseProcessingService` 작성
- `ProductPurchaseRepository`를 통한 DB 저장 처리
- `PurchaseCommand`: 메시지 전달용 VO
- `PurchaseProcessingLogRepository`: 처리 로그 저장용 Repository
- `RedisLuaService`: Lua 스크립트를 이용한 원자적 재고 차감 유틸 추가
