### PR TITLE
feat: 일반 상품 주문 생성 API 엔드포인트 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/controller/ProductOrderController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/controller/ProductOrderController.java
@@ -1,0 +1,35 @@
+package ktb.leafresh.backend.domain.store.order.presentation.controller;
+
+import ktb.leafresh.backend.domain.store.order.application.service.ProductOrderCreateService;
+import ktb.leafresh.backend.domain.store.order.presentation.dto.request.ProductOrderCreateRequestDto;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+@Slf4j
+public class ProductOrderController {
+
+    private final ProductOrderCreateService productOrderCreateService;
+
+    @PostMapping("/{productId}")
+    public ResponseEntity<ApiResponse<Void>> createOrder(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long productId,
+            @RequestBody ProductOrderCreateRequestDto request,
+            @RequestHeader("X-Idempotency-Key") String idempotencyKey
+    ) {
+        Long memberId = userDetails.getMemberId();
+        log.info("[주문 요청] memberId={}, productId={}, quantity={}, key={}", memberId, productId, request.quantity(), idempotencyKey);
+
+        productOrderCreateService.create(memberId, productId, request.quantity(), idempotencyKey);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/dto/request/ProductOrderCreateRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/dto/request/ProductOrderCreateRequestDto.java
@@ -1,0 +1,10 @@
+package ktb.leafresh.backend.domain.store.order.presentation.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record ProductOrderCreateRequestDto(
+        @NotNull(message = "수량은 필수입니다.")
+        @Min(value = 1, message = "최소 1개 이상 주문해야 합니다.")
+        Integer quantity
+) {}


### PR DESCRIPTION
## 요약
상품 주문 요청을 처리하는 API 엔드포인트와 DTO, 서비스 진입단을 구현했습니다.

## 작업 내용
- `ProductOrderController` 생성
- `ProductOrderCreateRequestDto` 작성