### PR TITLE
refactor: Idempotency-Key 헤더명 및 에러 코드 하드코딩 상수화 리팩토링

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateService.java
@@ -8,10 +8,7 @@ import ktb.leafresh.backend.domain.store.order.infrastructure.repository.Purchas
 import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
 import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
 import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheKeys;
-import ktb.leafresh.backend.global.exception.CustomException;
-import ktb.leafresh.backend.global.exception.GlobalErrorCode;
-import ktb.leafresh.backend.global.exception.ProductErrorCode;
-import ktb.leafresh.backend.global.exception.PurchaseErrorCode;
+import ktb.leafresh.backend.global.exception.*;
 import ktb.leafresh.backend.global.util.redis.RedisLuaService;
 import ktb.leafresh.backend.domain.store.order.infrastructure.publisher.GcpPurchaseMessagePublisher;
 import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
@@ -38,7 +35,7 @@ public class ProductOrderCreateService {
     public void create(Long memberId, Long productId, int quantity, String idempotencyKey) {
         // 1. 사용자 조회
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(GlobalErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         // 2. Idempotency 키 저장
         try {

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/publisher/GcpPurchaseMessagePublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/publisher/GcpPurchaseMessagePublisher.java
@@ -7,7 +7,7 @@ import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
 import ktb.leafresh.backend.global.exception.CustomException;
-import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.exception.PurchaseErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -37,10 +37,10 @@ public class GcpPurchaseMessagePublisher implements PurchaseMessagePublisher {
             log.info("[PubSub 메시지 발행 성공] {}", message);
         } catch (JsonProcessingException e) {
             log.error("[PubSub 직렬화 실패]", e);
-            throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR, "구매 요청 직렬화에 실패했습니다.");
+            throw new CustomException(PurchaseErrorCode.PURCHASE_SERIALIZATION_FAILED);
         } catch (Exception e) {
             log.error("[PubSub 발행 실패]", e);
-            throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR, "구매 요청 발행에 실패했습니다.");
+            throw new CustomException(PurchaseErrorCode.PURCHASE_PUBLISH_FAILED);
         }
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/controller/ProductOrderController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/controller/ProductOrderController.java
@@ -23,7 +23,7 @@ public class ProductOrderController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long productId,
             @RequestBody ProductOrderCreateRequestDto request,
-            @RequestHeader("X-Idempotency-Key") String idempotencyKey
+            @RequestHeader("Idempotency-Key") String idempotencyKey
     ) {
         Long memberId = userDetails.getMemberId();
         log.info("[주문 요청] memberId={}, productId={}, quantity={}, key={}", memberId, productId, request.quantity(), idempotencyKey);

--- a/src/main/java/ktb/leafresh/backend/global/exception/ProductErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/ProductErrorCode.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ProductErrorCode implements BaseErrorCode {
 
-    PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 상품을 찾을 수 없습니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다."),
     INVALID_PRICE(HttpStatus.BAD_REQUEST, "가격은 1 이상이어야 합니다."),
     INVALID_STOCK(HttpStatus.BAD_REQUEST, "재고는 0 이상이어야 합니다."),
     INVALID_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 상품 상태입니다."),

--- a/src/main/java/ktb/leafresh/backend/global/exception/PurchaseErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/PurchaseErrorCode.java
@@ -4,7 +4,11 @@ import org.springframework.http.HttpStatus;
 
 public enum PurchaseErrorCode implements BaseErrorCode {
 
-    DUPLICATE_PURCHASE_REQUEST(HttpStatus.BAD_REQUEST, "중복된 주문 요청입니다.");
+    DUPLICATE_PURCHASE_REQUEST(HttpStatus.CONFLICT, "중복된 주문 요청입니다."),
+    INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
+    INSUFFICIENT_POINTS(HttpStatus.BAD_REQUEST, "보유한 나뭇잎 포인트가 부족합니다."),
+    PURCHASE_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "구매 요청 직렬화에 실패했습니다."),
+    PURCHASE_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "구매 요청 발행에 실패했습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 요약
- 멱등키 관련 헤더명을 X-Idempotency-Key → Idempotency-Key로 변경
- 에러 코드 하드코딩을 상수로 추출하여 관리 방식 개선

## 작업 내용
- 요청 헤더명 변경
- 에러 처리 로직에서 문자열 하드코딩 제거 → ErrorCode 등 상수로 치환
- 코드 일관성 및 유지보수성을 위한 리팩토링 수행