### PR TITLE
feat: 타임딜 상품 주문 생성 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/dto/PurchaseCommand.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/dto/PurchaseCommand.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 public record PurchaseCommand(
         Long memberId,
         Long productId,
+        Long timedealPolicyId,
         Integer quantity,
         String idempotencyKey,
         LocalDateTime requestedAt

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateService.java
@@ -56,7 +56,7 @@ public class ProductOrderCreateService {
         if (result == -2) throw new CustomException(ProductErrorCode.OUT_OF_STOCK);
 
         // 5. 메시지 큐 발행
-        PurchaseCommand command = new PurchaseCommand(memberId, productId, quantity, idempotencyKey, LocalDateTime.now());
+        PurchaseCommand command = new PurchaseCommand(memberId, productId, null, quantity, idempotencyKey, LocalDateTime.now());
         purchaseMessagePublisher.publish(command);
 
         log.info("[주문 큐 발행 완료] memberId={}, productId={}, quantity={}", memberId, productId, quantity);

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductPurchaseProcessingService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductPurchaseProcessingService.java
@@ -5,12 +5,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
 import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
+import ktb.leafresh.backend.domain.store.order.application.service.model.PurchaseProcessContext;
 import ktb.leafresh.backend.domain.store.order.domain.entity.*;
-import ktb.leafresh.backend.domain.store.order.domain.entity.enums.PurchaseProcessingStatus;
 import ktb.leafresh.backend.domain.store.order.domain.entity.enums.PurchaseType;
 import ktb.leafresh.backend.domain.store.order.infrastructure.repository.*;
 import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
 import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.TimedealPolicyRepository;
 import ktb.leafresh.backend.global.exception.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -26,94 +29,55 @@ public class ProductPurchaseProcessingService {
 
     private final MemberRepository memberRepository;
     private final ProductRepository productRepository;
-    private final ProductPurchaseRepository purchaseRepository;
-    private final PurchaseProcessingLogRepository processingLogRepository;
+    private final TimedealPolicyRepository timedealPolicyRepository;
     private final PurchaseFailureLogRepository failureLogRepository;
+    private final PurchaseProcessor purchaseProcessor;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Transactional
     public void process(PurchaseCommand cmd) {
-        log.info("[구매 처리 시작] memberId={}, productId={}, quantity={}",
-                cmd.memberId(), cmd.productId(), cmd.quantity());
-
         try {
-            log.debug("1. 사용자 조회 시작");
             Member member = memberRepository.findById(cmd.memberId())
                     .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
-            log.debug("1. 사용자 조회 완료: {}", member.getNickname());
 
-            log.debug("2. 상품 조회 시작");
             Product product = productRepository.findById(cmd.productId())
                     .orElseThrow(() -> new CustomException(ProductErrorCode.PRODUCT_NOT_FOUND));
-            log.debug("2. 상품 조회 완료: {}", product.getName());
 
-            log.debug("3. 재고 및 포인트 검증 시작");
-            if (product.getStock() < cmd.quantity()) {
-                throw new CustomException(PurchaseErrorCode.INSUFFICIENT_STOCK);
+            Optional<TimedealPolicy> timedealOpt = Optional.empty();
+            if (cmd.timedealPolicyId() != null) {
+                timedealOpt = timedealPolicyRepository.findById(cmd.timedealPolicyId())
+                        .filter(policy -> policy.getDeletedAt() == null);
+            } else {
+                timedealOpt = product.getPurchasableTimedealPolicy(LocalDateTime.now());
             }
 
-            int totalPrice = product.getPrice() * cmd.quantity();
+            int unitPrice = timedealOpt.map(TimedealPolicy::getDiscountedPrice).orElse(product.getPrice());
+            PurchaseType purchaseType = timedealOpt.isPresent() ? PurchaseType.TIMEDEAL : PurchaseType.NORMAL;
 
-            if (member.getCurrentLeafPoints() < totalPrice) {
-                throw new CustomException(PurchaseErrorCode.INSUFFICIENT_POINTS);
-            }
-            log.debug("3. 검증 통과 - 현재 재고: {}, 보유 포인트: {}", product.getStock(), member.getCurrentLeafPoints());
-
-            log.debug("4. 포인트 차감 및 재고 차감 시작");
-            member.updateCurrentLeafPoints(member.getCurrentLeafPoints() - totalPrice);
-            product.updateStock(product.getStock() - cmd.quantity());
-            productRepository.save(product); // 명시적 저장 (dirty checking 이슈 예방)
-            log.debug("4. 차감 완료 - 남은 재고: {}, 남은 포인트: {}", product.getStock(), member.getCurrentLeafPoints());
-
-            log.debug("5. 구매 정보 저장 시작");
-            ProductPurchase purchase = ProductPurchase.builder()
-                    .member(member)
-                    .product(product)
-                    .quantity(cmd.quantity())
-                    .price(product.getPrice())
-                    .type(PurchaseType.NORMAL)
-                    .purchasedAt(LocalDateTime.now())
-                    .build();
-            purchaseRepository.save(purchase);
-            log.debug("5. 구매 정보 저장 완료: purchaseId={}", purchase.getId());
-
-            log.debug("6. 성공 로그 저장 시작");
-            processingLogRepository.save(PurchaseProcessingLog.builder()
-                    .product(product)
-                    .status(PurchaseProcessingStatus.SUCCESS)
-                    .message("구매 성공")
-                    .build());
-            log.debug("6. 성공 로그 저장 완료");
-
-            log.info("[구매 처리 완료] memberId={}, productId={}, price={}, points left={}",
-                    cmd.memberId(), cmd.productId(), totalPrice, member.getCurrentLeafPoints());
+            PurchaseProcessContext context = new PurchaseProcessContext(member, product, cmd.quantity(), unitPrice, purchaseType);
+            purchaseProcessor.process(context);
 
         } catch (Exception e) {
-            log.warn("예외 발생 - 실패 로그 저장 시작");
-
-            String requestBodyJson;
-            try {
-                requestBodyJson = objectMapper.writeValueAsString(cmd);
-            } catch (JsonProcessingException jsonException) {
-                requestBodyJson = String.format("{\"fallback\": \"%s\"}", cmd.toString().replace("\"", "\\\""));
-            }
-
-            failureLogRepository.save(PurchaseFailureLog.builder()
-                    .member(Member.builder().id(cmd.memberId()).build())
-                    .product(Product.builder().id(cmd.productId()).build())
-                    .reason(e.getMessage())
-                    .requestBody(requestBodyJson)
-                    .occurredAt(LocalDateTime.now())
-                    .build());
-
-            processingLogRepository.save(PurchaseProcessingLog.builder()
-                    .product(Product.builder().id(cmd.productId()).build())
-                    .status(PurchaseProcessingStatus.FAILURE)
-                    .message(e.getMessage())
-                    .build());
-
-            log.error("[구매 처리 실패] {}", e.getMessage(), e);
+            saveFailureLog(cmd, e);
             throw e;
         }
+    }
+
+    private void saveFailureLog(PurchaseCommand cmd, Exception e) {
+        String requestBodyJson;
+        try {
+            requestBodyJson = objectMapper.writeValueAsString(cmd);
+        } catch (JsonProcessingException jsonException) {
+            requestBodyJson = String.format("{\"fallback\": \"%s\"}", cmd.toString().replace("\"", "\\\""));
+        }
+
+        failureLogRepository.save(PurchaseFailureLog.builder()
+                .member(Member.builder().id(cmd.memberId()).build())
+                .product(Product.builder().id(cmd.productId()).build())
+                .reason(e.getMessage())
+                .requestBody(requestBodyJson)
+                .occurredAt(LocalDateTime.now())
+                .build());
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/PurchaseProcessor.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/PurchaseProcessor.java
@@ -1,0 +1,70 @@
+package ktb.leafresh.backend.domain.store.order.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.store.order.application.service.model.PurchaseProcessContext;
+import ktb.leafresh.backend.domain.store.order.domain.entity.ProductPurchase;
+import ktb.leafresh.backend.domain.store.order.domain.entity.PurchaseProcessingLog;
+import ktb.leafresh.backend.domain.store.order.domain.entity.enums.PurchaseProcessingStatus;
+import ktb.leafresh.backend.domain.store.order.infrastructure.repository.ProductPurchaseRepository;
+import ktb.leafresh.backend.domain.store.order.infrastructure.repository.PurchaseProcessingLogRepository;
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.PurchaseErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class PurchaseProcessor {
+
+    private final ProductPurchaseRepository purchaseRepository;
+    private final ProductRepository productRepository;
+    private final PurchaseProcessingLogRepository processingLogRepository;
+
+    @Transactional
+    public void process(PurchaseProcessContext context) {
+        Member member = context.member();
+        Product product = context.product();
+
+        int totalPrice = context.totalPrice();
+        int quantity = context.quantity();
+
+        log.debug("[검증] 재고 및 포인트 확인");
+        if (product.getStock() < quantity)
+            throw new CustomException(PurchaseErrorCode.INSUFFICIENT_STOCK);
+
+        if (member.getCurrentLeafPoints() < totalPrice)
+            throw new CustomException(PurchaseErrorCode.INSUFFICIENT_POINTS);
+
+        log.debug("[차감] 포인트 및 재고 차감");
+        member.updateCurrentLeafPoints(member.getCurrentLeafPoints() - totalPrice);
+        product.updateStock(product.getStock() - quantity);
+        productRepository.save(product); // dirty checking 방지
+
+        log.debug("[저장] 구매 정보 저장");
+        ProductPurchase purchase = ProductPurchase.builder()
+                .member(member)
+                .product(product)
+                .quantity(quantity)
+                .price(context.unitPrice())
+                .type(context.purchaseType())
+                .purchasedAt(LocalDateTime.now())
+                .build();
+        purchaseRepository.save(purchase);
+
+        processingLogRepository.save(PurchaseProcessingLog.builder()
+                .product(product)
+                .status(PurchaseProcessingStatus.SUCCESS)
+                .message("구매 성공")
+                .build());
+
+        log.info("[구매 처리 완료] memberId={}, productId={}, price={}, points left={}",
+                member.getId(), product.getId(), totalPrice, member.getCurrentLeafPoints());
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/TimedealOrderCreateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/TimedealOrderCreateService.java
@@ -1,0 +1,76 @@
+package ktb.leafresh.backend.domain.store.order.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
+import ktb.leafresh.backend.domain.store.order.domain.entity.PurchaseIdempotencyKey;
+import ktb.leafresh.backend.domain.store.order.infrastructure.publisher.PurchaseMessagePublisher;
+import ktb.leafresh.backend.domain.store.order.infrastructure.repository.PurchaseIdempotencyKeyRepository;
+import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheKeys;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.TimedealPolicyRepository;
+import ktb.leafresh.backend.global.exception.*;
+import ktb.leafresh.backend.global.util.redis.RedisLuaService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TimedealOrderCreateService {
+
+    private final MemberRepository memberRepository;
+    private final TimedealPolicyRepository timedealPolicyRepository;
+    private final PurchaseIdempotencyKeyRepository idempotencyRepository;
+    private final RedisLuaService redisLuaService;
+    private final PurchaseMessagePublisher purchaseMessagePublisher;
+
+    @Transactional
+    public void create(Long memberId, Long dealId, int quantity, String idempotencyKey) {
+        // 1. 사용자 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 2. Idempotency 키 저장
+        try {
+            idempotencyRepository.save(new PurchaseIdempotencyKey(member, idempotencyKey));
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(PurchaseErrorCode.DUPLICATE_PURCHASE_REQUEST);
+        }
+
+        // 3. 타임딜 정책 조회
+        TimedealPolicy policy = timedealPolicyRepository.findById(dealId)
+                .orElseThrow(() -> new CustomException(TimedealErrorCode.PRODUCT_NOT_FOUND));
+
+        // 4. 구매 가능 시간 검증
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isBefore(policy.getStartTime()) || now.isAfter(policy.getEndTime())) {
+            throw new CustomException(ProductErrorCode.INVALID_STATUS, "현재는 구매할 수 없는 시간입니다.");
+        }
+
+        // 5. 재고 선점 (Redis Lua)
+        String redisKey = ProductCacheKeys.timedealStock(dealId);
+        Long result = redisLuaService.decreaseStock(redisKey, quantity);
+
+        if (result == -1) throw new CustomException(ProductErrorCode.PRODUCT_NOT_FOUND);
+        if (result == -2) throw new CustomException(ProductErrorCode.OUT_OF_STOCK);
+
+        // 6. MQ 발행
+        purchaseMessagePublisher.publish(new PurchaseCommand(
+                memberId,
+                policy.getProduct().getId(), // 실제 상품 ID
+                policy.getId(),
+                quantity,
+                idempotencyKey,
+                now
+        ));
+
+        log.info("[타임딜 주문 큐 발행 완료] memberId={}, policyId={}, productId={}, quantity={}",
+                memberId, dealId, policy.getProduct().getId(), quantity);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/model/PurchaseProcessContext.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/model/PurchaseProcessContext.java
@@ -1,0 +1,17 @@
+package ktb.leafresh.backend.domain.store.order.application.service.model;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.store.order.domain.entity.enums.PurchaseType;
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+
+public record PurchaseProcessContext(
+        Member member,
+        Product product,
+        int quantity,
+        int unitPrice,
+        PurchaseType purchaseType
+) {
+    public int totalPrice() {
+        return unitPrice * quantity;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/controller/ProductOrderController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/presentation/controller/ProductOrderController.java
@@ -1,7 +1,10 @@
 package ktb.leafresh.backend.domain.store.order.presentation.controller;
 
 import ktb.leafresh.backend.domain.store.order.application.service.ProductOrderCreateService;
+import ktb.leafresh.backend.domain.store.order.application.service.TimedealOrderCreateService;
 import ktb.leafresh.backend.domain.store.order.presentation.dto.request.ProductOrderCreateRequestDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -17,19 +20,42 @@ import org.springframework.web.bind.annotation.*;
 public class ProductOrderController {
 
     private final ProductOrderCreateService productOrderCreateService;
+    private final TimedealOrderCreateService timedealOrderCreateService;
 
-    @PostMapping("/{productId}")
+    @PostMapping("/products/{productId}")
     public ResponseEntity<ApiResponse<Void>> createOrder(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long productId,
             @RequestBody ProductOrderCreateRequestDto request,
             @RequestHeader("Idempotency-Key") String idempotencyKey
     ) {
+        if (userDetails == null) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
         Long memberId = userDetails.getMemberId();
-        log.info("[주문 요청] memberId={}, productId={}, quantity={}, key={}", memberId, productId, request.quantity(), idempotencyKey);
+        log.info("[일반 상품 주문 요청] memberId={}, productId={}, quantity={}, key={}", memberId, productId, request.quantity(), idempotencyKey);
 
         productOrderCreateService.create(memberId, productId, request.quantity(), idempotencyKey);
 
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/timedeals/{dealId}")
+    public ResponseEntity<ApiResponse<Void>> createTimedealOrder(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long dealId,
+            @RequestBody ProductOrderCreateRequestDto request,
+            @RequestHeader("Idempotency-Key") String idempotencyKey
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        Long memberId = userDetails.getMemberId();
+        log.info("[타임딜 상품 주문 요청] memberId={}, dealId={}, quantity={}, key={}", memberId, dealId, request.quantity(), idempotencyKey);
+
+        timedealOrderCreateService.create(userDetails.getMemberId(), dealId, request.quantity(), idempotencyKey);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/domain/entity/Product.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/domain/entity/Product.java
@@ -94,4 +94,13 @@ public class Product extends BaseEntity {
                 )
                 .findFirst();
     }
+
+    /**
+     * 현재 시점 기준으로 구매 가능한 타임딜 정책 반환
+     */
+    public Optional<TimedealPolicy> getPurchasableTimedealPolicy(LocalDateTime now) {
+        return timedealPolicies.stream()
+                .filter(policy -> !policy.getStartTime().isAfter(now) && !policy.getEndTime().isBefore(now))
+                .findFirst();
+    }
 }


### PR DESCRIPTION
## 요약
타임딜 상품 주문 기능을 일반 상품 주문과 동일한 구조로 구현하였으며, 메시지 발행 및 처리 과정에서도 일관된 방식으로 개선하였습니다.

## 작업 내용
- `/api/orders/timedeals/{timedealId}` URI 기반 주문 API 엔드포인트 추가
- `TimedealOrderCreateService` 생성 및 타임딜 재고 선점 처리 구현
- 타임딜 정책 유효성(시간, 존재 여부) 검증 로직 추가
- `PurchaseCommand`에 `timedealPolicyId` 필드 추가 및 MQ 메시지 구조 통일
- `ProductPurchaseProcessingService`에서 `timedealPolicyId` 기반 분기 처리
- `PurchaseProcessContext` record 도입으로 프로세스 전달 구조 개선
- `Product` 도메인에 현재 시점 기준 유효한 타임딜 정책 조회 메서드(`getPurchasableTimedealPolicy`) 추가
- 일반 상품 주문 시에도 `timedealPolicyId = null` 명시적으로 전달

## 기타
- 모든 변경 사항은 기존 일반 주문 구조와 동일한 형태로 구성되어 유지보수 일관성을 고려했습니다.
