### PR TITLE
feat: 인증 통계 Redis 캐싱 및 ShedLock 기반 동기화 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,10 @@ dependencies {
 	implementation 'io.grpc:grpc-auth:1.62.2'
 	implementation 'io.grpc:grpc-protobuf:1.62.2'
 	implementation 'io.grpc:grpc-stub:1.62.2'
+
+	// ShedLock
+	implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.10.0'
 }
 
 dependencyManagement {

--- a/src/main/java/ktb/leafresh/backend/BackendApplication.java
+++ b/src/main/java/ktb/leafresh/backend/BackendApplication.java
@@ -1,11 +1,13 @@
 package ktb.leafresh.backend;
 
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
 @EnableScheduling
 @SpringBootApplication
 public class BackendApplication {
@@ -13,5 +15,4 @@ public class BackendApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(BackendApplication.class, args);
 	}
-
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/cache/VerificationCacheKeys.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/cache/VerificationCacheKeys.java
@@ -1,0 +1,12 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.cache;
+
+public class VerificationCacheKeys {
+
+    public static String stat(Long verificationId) {
+        return "verification:stat:" + verificationId;
+    }
+
+    public static String dirtySetKey() {
+        return "verification:stat:dirty";
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/cache/VerificationStatCacheService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/cache/VerificationStatCacheService.java
@@ -1,0 +1,64 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.cache;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VerificationStatCacheService {
+
+    private static final Duration TTL = Duration.ofDays(1);
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void increaseViewCount(Long verificationId) {
+        increaseStat(verificationId, "viewCount", 1);
+    }
+
+    public void increaseLikeCount(Long verificationId) {
+        increaseStat(verificationId, "likeCount", 1);
+    }
+
+    public void decreaseLikeCount(Long verificationId) {
+        increaseStat(verificationId, "likeCount", -1);
+    }
+
+    public void increaseCommentCount(Long verificationId) {
+        increaseStat(verificationId, "commentCount", 1);
+    }
+
+    public void decreaseCommentCount(Long verificationId) {
+        increaseStat(verificationId, "commentCount", -1);
+    }
+
+    private void increaseStat(Long verificationId, String field, int delta) {
+        String key = VerificationCacheKeys.stat(verificationId);
+        stringRedisTemplate.opsForHash().increment(key, field, delta);
+        stringRedisTemplate.opsForSet().add(VerificationCacheKeys.dirtySetKey(), verificationId.toString());
+
+        // TTL 설정: 매 이벤트마다 갱신 (캐시 자동 정리)
+        stringRedisTemplate.expire(key, TTL);
+
+        log.debug("[VerificationStatCache] {}:{} += {}", key, field, delta);
+    }
+
+    public Map<Object, Object> getStats(Long verificationId) {
+        String key = VerificationCacheKeys.stat(verificationId);
+        return stringRedisTemplate.opsForHash().entries(key);
+    }
+
+    public void clearStats(Long verificationId) {
+        String key = VerificationCacheKeys.stat(verificationId);
+        stringRedisTemplate.delete(key);
+        stringRedisTemplate.opsForSet().remove(VerificationCacheKeys.dirtySetKey(), verificationId.toString());
+        log.info("[VerificationStatCache] 캐시 삭제 - key={}", key);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/scheduler/VerificationStatSyncScheduler.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/scheduler/VerificationStatSyncScheduler.java
@@ -1,0 +1,89 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.scheduler;
+
+import jakarta.transaction.Transactional;
+import ktb.leafresh.backend.domain.verification.infrastructure.cache.VerificationCacheKeys;
+import ktb.leafresh.backend.domain.verification.infrastructure.cache.VerificationStatCacheService;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VerificationStatSyncScheduler {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final VerificationStatCacheService verificationStatCacheService;
+    private final GroupChallengeVerificationRepository verificationRepository;
+
+    /**
+     * 5분마다 Redis → DB로 누적 카운트 동기화
+     */
+    @Transactional
+    @Scheduled(fixedDelay = 5 * 60 * 1000)
+    @SchedulerLock(name = "VerificationStatSyncScheduler", lockAtLeastFor = "1m", lockAtMostFor = "10m")
+    public void syncVerificationStats() {
+        Set<String> dirtyIds = stringRedisTemplate.opsForSet().members(VerificationCacheKeys.dirtySetKey());
+
+        if (dirtyIds == null || dirtyIds.isEmpty()) {
+            log.debug("[VerificationStatSyncScheduler] 동기화 대상 없음");
+            return;
+        }
+
+        log.info("[VerificationStatSyncScheduler] 동기화 시작 - 대상 수: {}", dirtyIds.size());
+
+        for (String idStr : dirtyIds) {
+            Long verificationId;
+            try {
+                verificationId = Long.valueOf(idStr);
+            } catch (NumberFormatException e) {
+                log.warn("[VerificationStatSyncScheduler] 잘못된 ID 형식: {}", idStr);
+                continue;
+            }
+
+            Map<Object, Object> stats;
+            try {
+                stats = verificationStatCacheService.getStats(verificationId);
+            } catch (Exception redisEx) {
+                log.warn("[VerificationStatSyncScheduler] Redis 장애로 캐시 조회 실패 - verificationId={}, err={}",
+                        verificationId, redisEx.getMessage(), redisEx);
+                continue;
+            }
+
+            if (stats == null || stats.isEmpty()) {
+                verificationStatCacheService.clearStats(verificationId);
+                continue;
+            }
+
+            try {
+                int view = Integer.parseInt(stats.getOrDefault("viewCount", "0").toString());
+                int like = Integer.parseInt(stats.getOrDefault("likeCount", "0").toString());
+                int comment = Integer.parseInt(stats.getOrDefault("commentCount", "0").toString());
+
+                if (view == 0 && like == 0 && comment == 0) {
+                    verificationStatCacheService.clearStats(verificationId);
+                    continue;
+                }
+
+                verificationRepository.updateCounts(verificationId, view, like, comment);
+                verificationStatCacheService.clearStats(verificationId);
+
+                log.info("[VerificationStatSyncScheduler] 동기화 완료 - verificationId={}, +views={}, +likes={}, +comments={}",
+                        verificationId, view, like, comment);
+
+            } catch (Exception e) {
+                log.error("[VerificationStatSyncScheduler] 동기화 실패 - verificationId={}, message={}",
+                        verificationId, e.getMessage(), e);
+            }
+        }
+
+        log.info("[VerificationStatSyncScheduler] 동기화 종료");
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/config/ShedLockConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/ShedLockConfig.java
@@ -1,0 +1,16 @@
+package ktb.leafresh.backend.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+@Configuration
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(RedisConnectionFactory redisConnectionFactory) {
+        return new RedisLockProvider(redisConnectionFactory, "shedlock:"); // prefix 선택적
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/util/redis/VerificationStatRedisLuaService.java
+++ b/src/main/java/ktb/leafresh/backend/global/util/redis/VerificationStatRedisLuaService.java
@@ -1,0 +1,51 @@
+package ktb.leafresh.backend.global.util.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class VerificationStatRedisLuaService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private static final String INCREASE_VIEW_COUNT_LUA = """
+        local hashKey = KEYS[1]
+        local dirtySetKey = KEYS[2]
+        local verificationId = ARGV[1]
+        local ttlSeconds = tonumber(ARGV[2])
+
+        -- 뷰 카운트 증가
+        redis.call("HINCRBY", hashKey, "viewCount", 1)
+
+        -- dirty set에 등록
+        redis.call("SADD", dirtySetKey, verificationId)
+
+        -- TTL 설정 (매번 갱신)
+        redis.call("EXPIRE", hashKey, ttlSeconds)
+
+        return 1
+    """;
+
+    public void increaseVerificationViewCount(Long verificationId) {
+        String statKey = "verification:stat:" + verificationId;
+        String dirtySetKey = "verification:stat:dirty";
+
+        try {
+            stringRedisTemplate.execute(
+                    new DefaultRedisScript<>(INCREASE_VIEW_COUNT_LUA, Long.class),
+                    Arrays.asList(statKey, dirtySetKey),
+                    verificationId.toString(), String.valueOf(60 * 60 * 24) // 24시간 TTL
+            );
+            log.debug("[Lua] 조회수 증가 완료 - verificationId={}", verificationId);
+        } catch (Exception e) {
+            log.warn("[Lua] 조회수 증가 실패 - verificationId={}, err={}", verificationId, e.getMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION
## 요약
인증글의 좋아요/댓글/뷰 수를 Redis에 임시로 캐싱하고, 일정 주기로 DB에 동기화하는 구조를 구현하였습니다. 중복 스케줄 실행 방지를 위해 ShedLock을 도입하고 Redis 기반 락 설정을 추가했습니다.

## 작업 내용
- `ShedLock` 의존성 추가 및 `RedisLockProvider` 설정 (`ShedLockConfig`)
- 인증 통계 캐싱 키 유틸 클래스 (`VerificationCacheKeys`)
- 좋아요 및 댓글 수 증감용 Redis Hash 캐싱 로직 (`VerificationStatCacheService`)
- Lua 스크립트를 활용한 뷰 수 증가 및 TTL 설정 처리 (`VerificationStatRedisLuaService`)
- ShedLock을 이용한 통계 DB 동기화 스케줄러 구현 (`VerificationStatSyncScheduler`)
- `@EnableSchedulerLock` 및 관련 어노테이션 추가 (`BackendApplication`)
