### PR TITLE
feat: 특정 단체 챌린지 인증 응답에 조회/좋아요/댓글 수 및 좋아요 여부 반영

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeVerificationReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeVerificationReadService.java
@@ -4,6 +4,8 @@ import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.*;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.*;
 import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.cache.VerificationStatCacheService;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.LikeRepository;
 import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.util.pagination.CursorPaginationHelper;
@@ -14,6 +16,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -23,32 +28,44 @@ public class GroupChallengeVerificationReadService {
 
     private final GroupChallengeRepository groupChallengeRepository;
     private final GroupChallengeVerificationQueryRepository groupChallengeVerificationQueryRepository;
+    private final VerificationStatCacheService verificationStatCacheService;
+    private final LikeRepository likeRepository;
 
     public CursorPaginationResult<GroupChallengeVerificationSummaryDto> getVerifications(
-            Long challengeId, Long cursorId, String cursorTimestamp, int size
+            Long challengeId, Long cursorId, String cursorTimestamp, int size, Long loginMemberId
     ) {
-        try {
-            // 챌린지 존재 여부 선 검증
-            if (!groupChallengeRepository.existsById(challengeId)) {
-                throw new CustomException(ChallengeErrorCode.GROUP_CHALLENGE_NOT_FOUND);
-            }
-
-            List<GroupChallengeVerification> entities =
-                    groupChallengeVerificationQueryRepository.findByChallengeId(challengeId, cursorId, cursorTimestamp, size + 1);
-
-            return CursorPaginationHelper.paginateWithTimestamp(
-                    entities,
-                    size,
-                    GroupChallengeVerificationSummaryDto::from,
-                    GroupChallengeVerificationSummaryDto::id,
-                    GroupChallengeVerificationSummaryDto::createdAt
-            );
-        } catch (CustomException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("[인증 내역 조회 실패] challengeId={}, error={}", challengeId, e.getMessage(), e);
-            throw new CustomException(ChallengeErrorCode.GROUP_CHALLENGE_VERIFICATION_READ_FAILED);
+        if (!groupChallengeRepository.existsById(challengeId)) {
+            throw new CustomException(ChallengeErrorCode.GROUP_CHALLENGE_NOT_FOUND);
         }
+
+        List<GroupChallengeVerification> verifications =
+                groupChallengeVerificationQueryRepository.findByChallengeId(challengeId, cursorId, cursorTimestamp, size + 1);
+
+        List<Long> verificationIds = verifications.stream()
+                .map(GroupChallengeVerification::getId)
+                .toList();
+
+        Map<Long, Map<Object, Object>> redisStats = verificationIds.stream()
+                .collect(Collectors.toMap(
+                        id -> id,
+                        id -> verificationStatCacheService.getStats(id)
+                ));
+
+        Set<Long> likedIds = loginMemberId != null
+                ? likeRepository.findLikedVerificationIdsByMemberId(loginMemberId, verificationIds)
+                : Set.of();
+
+        return CursorPaginationHelper.paginateWithTimestamp(
+                verifications,
+                size,
+                v -> GroupChallengeVerificationSummaryDto.from(
+                        v,
+                        redisStats.get(v.getId()),
+                        likedIds.contains(v.getId())
+                ),
+                GroupChallengeVerificationSummaryDto::id,
+                GroupChallengeVerificationSummaryDto::createdAt
+        );
     }
 
     public GroupChallengeRuleResponseDto getChallengeRules(Long challengeId) {

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeVerificationReadController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeVerificationReadController.java
@@ -20,20 +20,26 @@ public class GroupChallengeVerificationReadController {
     private final GroupChallengeVerificationReadService groupChallengeVerificationReadService;
 
     @GetMapping("/verifications")
-    public ResponseEntity<ApiResponse<CursorPaginationResult<GroupChallengeVerificationSummaryDto>>> getVerifications(
+    public ResponseEntity<ApiResponse<GroupChallengeVerificationListResponseDto>> getVerifications(
             @PathVariable Long challengeId,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(required = false) String cursorTimestamp,
-            @RequestParam(defaultValue = "12") int size
+            @RequestParam(defaultValue = "12") int size,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         if ((cursorId == null) != (cursorTimestamp == null)) {
             throw new CustomException(GlobalErrorCode.INVALID_CURSOR);
         }
 
-        CursorPaginationResult<GroupChallengeVerificationSummaryDto> response =
-                groupChallengeVerificationReadService.getVerifications(challengeId, cursorId, cursorTimestamp, size);
+        Long memberId = userDetails != null ? userDetails.getMemberId() : null;
 
-        return ResponseEntity.ok(ApiResponse.success("단체 챌린지 인증 내역 조회에 성공했습니다.", response));
+        CursorPaginationResult<GroupChallengeVerificationSummaryDto> result =
+                groupChallengeVerificationReadService.getVerifications(challengeId, cursorId, cursorTimestamp, size, memberId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                "단체 챌린지 인증 내역 조회에 성공했습니다.",
+                GroupChallengeVerificationListResponseDto.from(result)
+        ));
     }
 
     @GetMapping("/rules")

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeVerificationListResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeVerificationListResponseDto.java
@@ -1,0 +1,22 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+import ktb.leafresh.backend.global.util.pagination.CursorInfo;
+import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GroupChallengeVerificationListResponseDto(
+        List<GroupChallengeVerificationSummaryDto> verifications,
+        boolean hasNext,
+        CursorInfo cursorInfo
+) {
+    public static GroupChallengeVerificationListResponseDto from(CursorPaginationResult<GroupChallengeVerificationSummaryDto> result) {
+        return new GroupChallengeVerificationListResponseDto(
+                result.items(),
+                result.hasNext(),
+                result.cursorInfo()
+        );
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/GroupChallengeVerificationRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/GroupChallengeVerificationRepository.java
@@ -4,6 +4,7 @@ import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeC
 import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
 import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -126,4 +127,17 @@ public interface GroupChallengeVerificationRepository extends JpaRepository<Grou
     WHERE gcv.participantRecord.id IN :recordIds
     """)
     List<GroupChallengeVerification> findAllByParticipantRecordIds(@Param("recordIds") List<Long> recordIds);
+
+    @Modifying
+    @Query("""
+    UPDATE GroupChallengeVerification v
+    SET v.viewCount = v.viewCount + :view,
+        v.likeCount = v.likeCount + :like,
+        v.commentCount = v.commentCount + :comment
+    WHERE v.id = :id
+    """)
+    void updateCounts(@Param("id") Long id,
+                      @Param("view") int view,
+                      @Param("like") int like,
+                      @Param("comment") int comment);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/LikeRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/LikeRepository.java
@@ -1,0 +1,21 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.verification.domain.entity.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Set;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    @Query("""
+    SELECT l.verification.id
+    FROM Like l
+    WHERE l.member.id = :memberId AND l.verification.id IN :verificationIds
+""")
+    Set<Long> findLikedVerificationIdsByMemberId(@Param("memberId") Long memberId,
+                                                 @Param("verificationIds") List<Long> verificationIds);
+
+}


### PR DESCRIPTION
## 요약
단체 챌린지 인증글 목록 조회 시, Redis에 캐싱된 조회수·좋아요 수·댓글 수를 포함하고 사용자의 좋아요 여부도 함께 반환되도록 응답 구조를 개선했습니다.

## 작업 내용
- 응답 DTO: `GroupChallengeVerificationListResponseDto`, `GroupChallengeVerificationSummaryDto` 확장
- 캐시 병합: Redis 통계 정보 + 좋아요 여부 병합 로직 추가
- 컨트롤러 응답 타입을 커서 기반 응답 DTO로 통일
- 쿼리 추가: 인증글별 통계 업데이트 쿼리 및 좋아요 여부 확인용 쿼리 (`updateCounts`, `findLikedVerificationIdsByMemberId`)
