### PR TITLE
feat: 단체 챌린지 인증글 상세 조회 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeVerificationQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeVerificationQueryRepository.java
@@ -3,9 +3,12 @@ package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
 import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface GroupChallengeVerificationQueryRepository {
     List<GroupChallengeVerification> findByChallengeId(Long challengeId, Long cursorId, String cursorTimestamp, int size);
 
     List<GroupChallengeVerification> findByParticipantRecordId(Long participantRecordId);
+
+    Optional<GroupChallengeVerification> findByChallengeIdAndId(Long challengeId, Long verificationId);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeVerificationQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeVerificationQueryRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -44,5 +45,22 @@ public class GroupChallengeVerificationQueryRepositoryImpl implements GroupChall
                 .where(gv.participantRecord.id.eq(participantRecordId), gv.deletedAt.isNull())
                 .orderBy(gv.createdAt.desc())
                 .fetch();
+    }
+
+    @Override
+    public Optional<GroupChallengeVerification> findByChallengeIdAndId(Long challengeId, Long verificationId) {
+        QGroupChallengeVerification v = QGroupChallengeVerification.groupChallengeVerification;
+
+        return Optional.ofNullable(queryFactory
+                .selectFrom(v)
+                .join(v.participantRecord).fetchJoin()
+                .join(v.participantRecord.groupChallenge).fetchJoin()
+                .join(v.participantRecord.member).fetchJoin()
+                .where(
+                        v.id.eq(verificationId),
+                        v.participantRecord.groupChallenge.id.eq(challengeId),
+                        v.deletedAt.isNull()
+                )
+                .fetchOne());
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeVerificationReadController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/controller/GroupChallengeVerificationReadController.java
@@ -4,14 +4,17 @@ import ktb.leafresh.backend.domain.challenge.group.application.service.*;
 import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.*;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
 import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/challenges/group/{challengeId}")
@@ -33,13 +36,22 @@ public class GroupChallengeVerificationReadController {
 
         Long memberId = userDetails != null ? userDetails.getMemberId() : null;
 
-        CursorPaginationResult<GroupChallengeVerificationSummaryDto> result =
-                groupChallengeVerificationReadService.getVerifications(challengeId, cursorId, cursorTimestamp, size, memberId);
+        try {
+            CursorPaginationResult<GroupChallengeVerificationSummaryDto> result =
+                    groupChallengeVerificationReadService.getVerifications(challengeId, cursorId, cursorTimestamp, size, memberId);
 
-        return ResponseEntity.ok(ApiResponse.success(
-                "단체 챌린지 인증 내역 조회에 성공했습니다.",
-                GroupChallengeVerificationListResponseDto.from(result)
-        ));
+            return ResponseEntity.ok(ApiResponse.success(
+                    "특정 단체 챌린지 인증 내역 목록 조회에 성공했습니다.",
+                    GroupChallengeVerificationListResponseDto.from(result)
+            ));
+
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[인증 목록 조회 실패] challengeId={}, cursorId={}, error={}",
+                    challengeId, cursorId, e.getMessage(), e);
+            throw new CustomException(VerificationErrorCode.VERIFICATION_LIST_QUERY_FAILED);
+        }
     }
 
     @GetMapping("/rules")
@@ -53,5 +65,29 @@ public class GroupChallengeVerificationReadController {
 
         GroupChallengeRuleResponseDto response = groupChallengeVerificationReadService.getChallengeRules(challengeId);
         return ResponseEntity.ok(ApiResponse.success("단체 챌린지 인증 규약 정보를 성공적으로 조회했습니다.", response));
+    }
+
+    @GetMapping("/verifications/{verificationId}")
+    public ResponseEntity<ApiResponse<GroupChallengeVerificationDetailResponseDto>> getVerificationDetail(
+            @PathVariable Long challengeId,
+            @PathVariable Long verificationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long memberId = userDetails != null ? userDetails.getMemberId() : null;
+
+        try {
+            GroupChallengeVerificationDetailResponseDto response =
+                    groupChallengeVerificationReadService.getVerificationDetail(challengeId, verificationId, memberId);
+
+            return ResponseEntity.ok(ApiResponse.success("특정 단체 챌린지 인증 상세 정보를 조회했습니다.", response));
+
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[인증 상세 조회 실패] challengeId={}, verificationId={}, error={}",
+                    challengeId, verificationId, e.getMessage(), e);
+
+            throw new CustomException(VerificationErrorCode.VERIFICATION_DETAIL_QUERY_FAILED);
+        }
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeVerificationDetailResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeVerificationDetailResponseDto.java
@@ -1,0 +1,67 @@
+package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
+
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Builder
+public record GroupChallengeVerificationDetailResponseDto(
+        Long id,
+        String nickname,
+        String profileImageUrl,
+        boolean isLiked,
+        String imageUrl,
+        String content,
+        String category,
+        String status,
+        LocalDateTime verifiedAt,
+        Counts counts,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    @Builder
+    public record Counts(
+            int view,
+            int like,
+            int comment
+    ) {}
+
+    public static GroupChallengeVerificationDetailResponseDto from(
+            GroupChallengeVerification v,
+            Map<Object, Object> cachedStats,
+            boolean isLiked
+    ) {
+        var member = v.getParticipantRecord().getMember();
+        var challenge = v.getParticipantRecord().getGroupChallenge();
+
+        return GroupChallengeVerificationDetailResponseDto.builder()
+                .id(v.getId())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getImageUrl())
+                .isLiked(isLiked)
+                .imageUrl(v.getImageUrl())
+                .content(v.getContent())
+                .category(challenge.getCategory().getName())
+                .status(v.getStatus().name())
+                .verifiedAt(v.getVerifiedAt())
+                .counts(new Counts(
+                        parseStat(cachedStats, "viewCount", v.getViewCount()),
+                        parseStat(cachedStats, "likeCount", v.getLikeCount()),
+                        parseStat(cachedStats, "commentCount", v.getCommentCount())
+                ))
+                .createdAt(v.getCreatedAt())
+                .updatedAt(v.getUpdatedAt())
+                .build();
+    }
+
+    private static int parseStat(Map<Object, Object> map, String key, int fallback) {
+        if (map == null || !map.containsKey(key)) return fallback;
+        try {
+            return Integer.parseInt(map.get(key).toString());
+        } catch (Exception e) {
+            return fallback;
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/LikeRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/LikeRepository.java
@@ -14,7 +14,7 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     SELECT l.verification.id
     FROM Like l
     WHERE l.member.id = :memberId AND l.verification.id IN :verificationIds
-""")
+    """)
     Set<Long> findLikedVerificationIdsByMemberId(@Param("memberId") Long memberId,
                                                  @Param("verificationIds") List<Long> verificationIds);
 

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityConfig.java
@@ -80,6 +80,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/challenges/group/{challengeId:\\d+}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/challenges/events").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/challenges/group/{challengeId:\\d+}/verifications").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/challenges/group/{challengeId:\\d+}/verifications/{verificationId:\\d+}").permitAll()
 
                         // 그 외 단체 챌린지 API는 인증 필요
                         .requestMatchers("/api/challenges/group/**").authenticated()

--- a/src/main/java/ktb/leafresh/backend/global/exception/VerificationErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/VerificationErrorCode.java
@@ -31,7 +31,10 @@ public enum VerificationErrorCode implements BaseErrorCode {
     AI_RESPONSE_FAILED(HttpStatus.BAD_REQUEST, "AI 응답 결과가 검열 실패로 판단되었습니다."),
     AI_RESPONSE_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 응답 파싱에 실패했습니다."),
     AI_REQUEST_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "AI 서버 응답이 시간 초과되었습니다."),
-    AI_CONNECTION_FAILED(HttpStatus.BAD_GATEWAY, "AI 서버에 연결할 수 없습니다.");
+    AI_CONNECTION_FAILED(HttpStatus.BAD_GATEWAY, "AI 서버에 연결할 수 없습니다."),
+    VERIFICATION_LIST_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 인증 내역을 조회하지 못했습니다."),
+    VERIFICATION_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 인증입니다."),
+    VERIFICATION_DETAIL_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 인증 상세 정보를 조회하지 못했습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 요약
단체 챌린지 인증글의 상세 정보를 반환하는 API를 구현하였습니다. 응답에는 작성자 정보, 인증 이미지 및 내용, 통계 정보(조회수/댓글수/좋아요 수), 좋아요 여부 등을 포함합니다.

## 작업 내용
- `GroupChallengeVerificationDetailResponseDto`: 상세 응답 DTO 생성
- `GroupChallengeVerificationQueryRepository`: 인증글 단건 조회 메서드 추가
- `GroupChallengeVerificationReadService`: Redis 캐싱된 통계 + 좋아요 여부 병합 처리
- `GroupChallengeVerificationReadController`: `/verifications/{verificationId}` GET API 추가
- `SecurityConfig`: API 경로에 인증 설정 반영
- `VerificationErrorCode`: 인증글 미존재 및 쿼리 실패 예외 추가
