### PR TITLE
feat: 단체 챌린지 인증글 대댓글 생성 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupVerificationCommentManageController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupVerificationCommentManageController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/challenges/group/{challengeId}/verifications/{verificationId}/comments")
-public class GroupVerificationCommentCreateController {
+public class GroupVerificationCommentManageController {
 
     private final GroupVerificationCommentCreateService groupVerificationCommentCreateService;
 
@@ -46,6 +46,36 @@ public class GroupVerificationCommentCreateController {
         } catch (Exception e) {
             log.error("[댓글 생성 실패] challengeId={}, verificationId={}, memberId={}, error={}",
                     challengeId, verificationId, memberId, e.getMessage(), e);
+            throw new CustomException(VerificationErrorCode.COMMENT_CREATE_FAILED);
+        }
+    }
+
+    @PostMapping("/{commentId}/replies")
+    public ResponseEntity<ApiResponse<CommentResponseDto>> createReply(
+            @PathVariable Long challengeId,
+            @PathVariable Long verificationId,
+            @PathVariable Long commentId,
+            @Valid @RequestBody GroupVerificationCommentCreateRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        Long memberId = userDetails.getMemberId();
+
+        try {
+            CommentResponseDto response = groupVerificationCommentCreateService.createReply(
+                    challengeId, verificationId, commentId, memberId, requestDto
+            );
+
+            return ResponseEntity.ok(ApiResponse.success("대댓글이 작성되었습니다.", response));
+
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[대댓글 생성 실패] challengeId={}, verificationId={}, commentId={}, memberId={}, error={}",
+                    challengeId, verificationId, commentId, memberId, e.getMessage(), e);
             throw new CustomException(VerificationErrorCode.COMMENT_CREATE_FAILED);
         }
     }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/dto/request/GroupVerificationCommentCreateRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/dto/request/GroupVerificationCommentCreateRequestDto.java
@@ -3,7 +3,7 @@ package ktb.leafresh.backend.domain.verification.presentation.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record GroupVerificationCommentCreateRequestDto(
-        @NotBlank(message = "댓글 내용은 필수 항목입니다.")
+        @NotBlank(message = "내용은 필수 항목입니다.")
         String content
 ) {
 }

--- a/src/main/java/ktb/leafresh/backend/global/exception/VerificationErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/VerificationErrorCode.java
@@ -34,7 +34,9 @@ public enum VerificationErrorCode implements BaseErrorCode {
     VERIFICATION_LIST_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 인증 내역을 조회하지 못했습니다."),
     VERIFICATION_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 인증입니다."),
     VERIFICATION_DETAIL_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 인증 상세 정보를 조회하지 못했습니다."),
-    COMMENT_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 댓글 작성에 실패했습니다.");
+    COMMENT_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 댓글 작성에 실패했습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    CANNOT_REPLY_TO_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "삭제된 댓글에는 대댓글을 작성할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 요약
단체 챌린지 인증글에 대댓글을 작성할 수 있는 기능을 구현하였습니다. 사용자 인증을 기반으로, 특정 댓글에 대한 자식 댓글(대댓글)을 작성할 수 있습니다.

## 작업 내용
- `/api/challenges/group/{challengeId}/verifications/{verificationId}/comments/{commentId}/replies` POST API 추가
- 대댓글 생성 비즈니스 로직 및 Service, Controller 구현
- 부모 댓글 존재 여부 및 삭제 여부 검증 로직 추가
- 삭제된 부모 댓글에 대댓글 작성 시 에러 반환 (에러 코드 추가)
- `@NotBlank` 메시지 문구 수정
