### PR TITLE
feat: 단체 챌린지 인증글 좋아요 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationLikeService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationLikeService.java
@@ -1,0 +1,78 @@
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.domain.entity.Like;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.LikeRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import ktb.leafresh.backend.global.util.redis.VerificationStatRedisLuaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GroupVerificationLikeService {
+
+    private final GroupChallengeVerificationRepository verificationRepository;
+    private final LikeRepository likeRepository;
+    private final MemberRepository memberRepository;
+    private final VerificationStatRedisLuaService verificationStatRedisLuaService;
+
+    @Transactional
+    public boolean likeVerification(Long verificationId, Long memberId) {
+        GroupChallengeVerification verification = verificationRepository.findByIdAndDeletedAtIsNull(verificationId)
+                .orElseThrow(() -> new CustomException(VerificationErrorCode.VERIFICATION_DETAIL_NOT_FOUND));
+
+        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new CustomException(GlobalErrorCode.UNAUTHORIZED));
+
+        // 1. 삭제되지 않은 좋아요가 이미 있는 경우 → true 반환
+        if (likeRepository.existsByVerificationIdAndMemberIdAndDeletedAtIsNull(verificationId, memberId)) {
+            return true;
+        }
+
+        // 2. soft delete된 좋아요가 있는 경우 → 복구
+        Like like = likeRepository.findByVerificationIdAndMemberId(verificationId, memberId)
+                .orElse(null);
+
+        if (like != null && like.isDeleted()) {
+            like.restoreLike();
+            verificationStatRedisLuaService.increaseVerificationLikeCount(verificationId);
+            return true;
+        }
+
+        likeRepository.save(Like.builder()
+                .verification(verification)
+                .member(member)
+                .build());
+
+        verificationStatRedisLuaService.increaseVerificationLikeCount(verificationId);
+        return true;
+    }
+
+    @Transactional
+    public boolean cancelLike(Long verificationId, Long memberId) {
+        GroupChallengeVerification verification = verificationRepository.findByIdAndDeletedAtIsNull(verificationId)
+                .orElseThrow(() -> new CustomException(VerificationErrorCode.VERIFICATION_DETAIL_NOT_FOUND));
+
+        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new CustomException(GlobalErrorCode.UNAUTHORIZED));
+
+        Like like = likeRepository.findByVerificationIdAndMemberIdAndDeletedAtIsNull(verificationId, memberId)
+                .orElse(null);
+
+        if (like == null) {
+            // 이미 취소된 상태여도 200 반환
+            return false;
+        }
+
+        like.softDelete();
+        verificationStatRedisLuaService.decreaseVerificationLikeCount(verificationId);
+        return false;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/domain/entity/Like.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/domain/entity/Like.java
@@ -6,7 +6,13 @@ import ktb.leafresh.backend.global.common.entity.BaseEntity;
 import lombok.*;
 
 @Entity
-@Table(name = "likes", indexes = @Index(name = "idx_like_deleted", columnList = "deleted_at"))
+@Table(
+        name = "likes",
+        indexes = @Index(name = "idx_like_deleted", columnList = "deleted_at"),
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_verification_member", columnNames = {"verification_id", "member_id"})
+        }
+)
 @Getter
 @Builder
 @AllArgsConstructor
@@ -24,4 +30,8 @@ public class Like extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    public void restoreLike() {
+        super.restore();
+    }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/LikeRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/LikeRepository.java
@@ -6,9 +6,16 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    @Query("SELECT l.verification.id, COUNT(l) " +
+            "FROM Like l " +
+            "WHERE l.deletedAt IS NULL " +
+            "GROUP BY l.verification.id")
+    List<Object[]> findAllLikeCountByVerificationId();
 
     @Query("""
     SELECT l.verification.id
@@ -18,4 +25,10 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     Set<Long> findLikedVerificationIdsByMemberId(@Param("memberId") Long memberId,
                                                  @Param("verificationIds") List<Long> verificationIds);
 
+
+    boolean existsByVerificationIdAndMemberIdAndDeletedAtIsNull(Long verificationId, Long memberId);
+
+    Optional<Like> findByVerificationIdAndMemberIdAndDeletedAtIsNull(Long verificationId, Long memberId);
+
+    Optional<Like> findByVerificationIdAndMemberId(Long verificationId, Long memberId);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupVerificationLikeController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupVerificationLikeController.java
@@ -1,0 +1,65 @@
+package ktb.leafresh.backend.domain.verification.presentation.controller;
+
+import ktb.leafresh.backend.domain.verification.application.service.GroupVerificationLikeService;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import ktb.leafresh.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/challenges/group/{challengeId}/verifications/{verificationId}/likes")
+public class GroupVerificationLikeController {
+
+    private final GroupVerificationLikeService groupVerificationLikeService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> likeVerification(
+            @PathVariable Long challengeId,
+            @PathVariable Long verificationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        Long memberId = userDetails.getMemberId();
+
+        try {
+            boolean isLiked = groupVerificationLikeService.likeVerification(verificationId, memberId);
+            return ResponseEntity.ok(ApiResponse.success("좋아요를 눌렀습니다.", Map.of("isLiked", isLiked)));
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR, "좋아요 작업에 실패했습니다.");
+        }
+    }
+
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> cancelLikeVerification(
+            @PathVariable Long challengeId,
+            @PathVariable Long verificationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        Long memberId = userDetails.getMemberId();
+
+        try {
+            boolean isLiked = groupVerificationLikeService.cancelLike(verificationId, memberId);
+            return ResponseEntity.ok(ApiResponse.success("좋아요를 취소했습니다.", Map.of("isLiked", isLiked)));
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR, "좋아요 작업에 실패했습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 요약
단체 챌린지 인증글에 대해 좋아요를 누를 수 있는 기능을 구현했습니다.  
소프트 삭제된 좋아요 복구, Redis 통계 동기화까지 포함하여 실제 서비스 흐름에 맞게 구현되었습니다.

## 작업 내용
- Like 엔티티에 유니크 제약 조건 및 soft delete 복구 메서드 추가
- 인증글 ID별 좋아요 수 조회, 특정 멤버의 좋아요 조회 등을 위한 쿼리 메서드 추가
- 인증글 좋아요 서비스 로직 구현
  - 이미 좋아요한 경우 true 반환
  - soft delete된 좋아요는 복구 처리
  - Redis에 좋아요 수 증가 처리 포함
- 인증글 좋아요 API 컨트롤러 구현
  - `POST /api/challenges/group/{challengeId}/verifications/{verificationId}/likes`
  - 응답: `{ isLiked: true }`

## 비고
- 중복 좋아요 방지를 위해 memberId + verificationId에 유니크 제약 설정
- 복구 시에는 `restoreLike()` 호출 후 Redis에 좋아요 수 반영
