### PR TITLE
feat: 댓글 삭제 및 조회 API 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentDeleteService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentDeleteService.java
@@ -1,0 +1,57 @@
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.verification.domain.entity.Comment;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.CommentRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import ktb.leafresh.backend.global.util.redis.VerificationStatRedisLuaService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GroupVerificationCommentDeleteService {
+
+    private final GroupChallengeVerificationRepository verificationRepository;
+    private final CommentRepository commentRepository;
+    private final VerificationStatRedisLuaService verificationStatRedisLuaService;
+
+    @Transactional
+    public void deleteComment(Long challengeId, Long verificationId, Long commentId, Long memberId) {
+        try {
+            log.info("[댓글 삭제 요청] challengeId={}, verificationId={}, commentId={}, memberId={}",
+                    challengeId, verificationId, commentId, memberId);
+
+            GroupChallengeVerification verification = verificationRepository.findByIdAndDeletedAtIsNull(verificationId)
+                    .orElseThrow(() -> new CustomException(VerificationErrorCode.VERIFICATION_DETAIL_NOT_FOUND));
+
+            Comment comment = commentRepository.findById(commentId)
+                    .orElseThrow(() -> new CustomException(VerificationErrorCode.COMMENT_NOT_FOUND));
+
+            if (!comment.getMember().getId().equals(memberId)) {
+                throw new CustomException(GlobalErrorCode.ACCESS_DENIED);
+            }
+
+            if (comment.isDeleted()) {
+                throw new CustomException(VerificationErrorCode.CANNOT_EDIT_DELETED_COMMENT);
+            }
+
+            comment.softDelete();
+            verificationStatRedisLuaService.decreaseVerificationCommentCount(verificationId);
+
+            log.info("[댓글 삭제 완료] commentId={}, memberId={}", commentId, memberId);
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[댓글 삭제 실패] challengeId={}, verificationId={}, commentId={}, memberId={}, error={}",
+                    challengeId, verificationId, commentId, memberId, e.getMessage(), e);
+            throw new CustomException(VerificationErrorCode.COMMENT_UPDATE_FAILED); // 삭제 실패 코드 새로 정의 가능
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentQueryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentQueryService.java
@@ -1,0 +1,36 @@
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.verification.domain.entity.Comment;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.CommentRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.presentation.assembler.CommentHierarchyBuilder;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.CommentSummaryResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroupVerificationCommentQueryService {
+
+    private final GroupChallengeVerificationRepository verificationRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional(readOnly = true)
+    public List<CommentSummaryResponseDto> getComments(Long challengeId, Long verificationId, Long loginMemberId) {
+        GroupChallengeVerification verification = verificationRepository.findByIdAndDeletedAtIsNull(verificationId)
+                .orElseThrow(() -> new CustomException(VerificationErrorCode.VERIFICATION_DETAIL_NOT_FOUND));
+
+        // 인증 ID 기반 댓글 + 작성자 모두 fetch
+        List<Comment> comments = commentRepository.findAllByVerificationIdWithMember(verificationId);
+
+        return CommentHierarchyBuilder.build(comments, loginMemberId);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/CommentRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/CommentRepository.java
@@ -2,6 +2,24 @@ package ktb.leafresh.backend.domain.verification.infrastructure.repository;
 
 import ktb.leafresh.backend.domain.verification.domain.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT c.verification.id, COUNT(c) " +
+            "FROM Comment c " +
+            "WHERE c.deletedAt IS NULL " +
+            "GROUP BY c.verification.id")
+    List<Object[]> findAllCommentCountByVerificationId();
+
+    List<Comment> findByParentCommentAndDeletedAtIsNull(Comment parentComment);
+
+    @Query("SELECT c FROM Comment c " +
+            "JOIN FETCH c.member " +
+            "LEFT JOIN FETCH c.parentComment " +
+            "WHERE c.verification.id = :verificationId")
+    List<Comment> findAllByVerificationIdWithMember(@Param("verificationId") Long verificationId);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupVerificationCommentManageController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupVerificationCommentManageController.java
@@ -2,8 +2,14 @@ package ktb.leafresh.backend.domain.verification.presentation.controller;
 
 import jakarta.validation.Valid;
 import ktb.leafresh.backend.domain.verification.application.service.GroupVerificationCommentCreateService;
+import ktb.leafresh.backend.domain.verification.application.service.GroupVerificationCommentDeleteService;
+import ktb.leafresh.backend.domain.verification.application.service.GroupVerificationCommentQueryService;
+import ktb.leafresh.backend.domain.verification.application.service.GroupVerificationCommentUpdateService;
 import ktb.leafresh.backend.domain.verification.presentation.dto.request.GroupVerificationCommentCreateRequestDto;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.CommentListResponseDto;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.CommentSummaryResponseDto;
 import ktb.leafresh.backend.domain.verification.presentation.dto.response.CommentResponseDto;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.CommentUpdateResponseDto;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.GlobalErrorCode;
 import ktb.leafresh.backend.global.exception.VerificationErrorCode;
@@ -15,6 +21,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +30,31 @@ import org.springframework.web.bind.annotation.*;
 public class GroupVerificationCommentManageController {
 
     private final GroupVerificationCommentCreateService groupVerificationCommentCreateService;
+    private final GroupVerificationCommentUpdateService groupVerificationCommentUpdateService;
+    private final GroupVerificationCommentDeleteService groupVerificationCommentDeleteService;
+    private final GroupVerificationCommentQueryService groupVerificationCommentQueryService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<CommentListResponseDto>> getComments(
+            @PathVariable Long challengeId,
+            @PathVariable Long verificationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long memberId = userDetails != null ? userDetails.getMemberId() : null;
+
+        try {
+            List<CommentSummaryResponseDto> comments = groupVerificationCommentQueryService.getComments(challengeId, verificationId, memberId);
+            CommentListResponseDto responseDto = new CommentListResponseDto(comments);
+
+            return ResponseEntity.ok(ApiResponse.success("댓글 목록을 조회했습니다.", responseDto));
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[댓글 목록 조회 실패] challengeId={}, verificationId={}, memberId={}, error={}",
+                    challengeId, verificationId, memberId, e.getMessage(), e);
+            throw new CustomException(VerificationErrorCode.VERIFICATION_LIST_QUERY_FAILED);
+        }
+    }
 
     @PostMapping
     public ResponseEntity<ApiResponse<CommentResponseDto>> createComment(
@@ -77,6 +110,59 @@ public class GroupVerificationCommentManageController {
             log.error("[대댓글 생성 실패] challengeId={}, verificationId={}, commentId={}, memberId={}, error={}",
                     challengeId, verificationId, commentId, memberId, e.getMessage(), e);
             throw new CustomException(VerificationErrorCode.COMMENT_CREATE_FAILED);
+        }
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<CommentUpdateResponseDto>> updateComment(
+            @PathVariable Long challengeId,
+            @PathVariable Long verificationId,
+            @PathVariable Long commentId,
+            @Valid @RequestBody GroupVerificationCommentCreateRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        Long memberId = userDetails.getMemberId();
+
+        try {
+            CommentUpdateResponseDto response = groupVerificationCommentUpdateService.updateComment(
+                    challengeId, verificationId, commentId, memberId, requestDto
+            );
+            return ResponseEntity.ok(ApiResponse.success("댓글이 수정되었습니다.", response));
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[댓글 수정 실패] challengeId={}, verificationId={}, commentId={}, memberId={}, error={}",
+                    challengeId, verificationId, commentId, memberId, e.getMessage(), e);
+            throw new CustomException(VerificationErrorCode.COMMENT_UPDATE_FAILED);
+        }
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @PathVariable Long challengeId,
+            @PathVariable Long verificationId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        Long memberId = userDetails.getMemberId();
+
+        try {
+            groupVerificationCommentDeleteService.deleteComment(challengeId, verificationId, commentId, memberId);
+            return ResponseEntity.ok(ApiResponse.success("댓글이 삭제되었습니다."));
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[댓글 삭제 실패] challengeId={}, verificationId={}, commentId={}, memberId={}, error={}",
+                    challengeId, verificationId, commentId, memberId, e.getMessage(), e);
+            throw new CustomException(VerificationErrorCode.COMMENT_UPDATE_FAILED);
         }
     }
 }


### PR DESCRIPTION
## 요약
단체 챌린지 인증글에 달린 댓글의 삭제 및 조회 기능을 구현하였습니다.  
댓글의 소프트 삭제 처리와 Redis 내 댓글 수 캐싱 반영까지 포함됩니다.

## 작업 내용
- `CommentRepository`
  - 댓글 수 집계를 위한 `verificationId` 그룹별 카운트 쿼리 추가
  - 대댓글 계층 조회 및 작성자 정보 fetch를 위한 JPQL 추가
- `GroupVerificationCommentDeleteService`
  - 댓글 작성자 본인 여부 확인
  - 이미 삭제된 댓글 여부 확인
  - soft delete 수행 및 Redis 댓글 수 감소 반영
- `GroupVerificationCommentQueryService`
  - 인증글 ID 기반 전체 댓글 조회 및 작성자 정보 포함 fetch
  - 계층 구조(`CommentHierarchyBuilder`)로 변환 후 응답
- `GroupVerificationCommentManageController`
  - 댓글 삭제 API 연결
  - 댓글 목록 조회 API(`GET /api/challenges/group/{challengeId}/verifications/{verificationId}/comments`) 구현
