### PR TITLE
feat: 누적 인증 수 Redis 캐싱 및 초기화/증가 처리 로직 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationSubmitService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationSubmitService.java
@@ -17,13 +17,16 @@ import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.MemberErrorCode;
 import ktb.leafresh.backend.global.exception.VerificationErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class PersonalChallengeVerificationSubmitService {
@@ -33,6 +36,10 @@ public class PersonalChallengeVerificationSubmitService {
     private final PersonalChallengeVerificationRepository verificationRepository;
     private final VerificationSubmitValidator validator;
     private final ApplicationEventPublisher eventPublisher;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String TOTAL_VERIFICATION_COUNT_KEY = "leafresh:totalVerifications:count";
+
 
     @Transactional
     public void submit(Long memberId, Long challengeId, PersonalChallengeVerificationRequestDto dto) {
@@ -81,6 +88,13 @@ public class PersonalChallengeVerificationSubmitService {
 
         } catch (Exception e) {
             throw new CustomException(VerificationErrorCode.AI_SERVER_ERROR);
+        }
+
+        try {
+            redisTemplate.opsForValue().increment(TOTAL_VERIFICATION_COUNT_KEY);
+            log.debug("[PersonalChallengeVerificationSubmitService] Redis 인증 수 캐시 1 증가 완료");
+        } catch (Exception e) {
+            log.warn("[PersonalChallengeVerificationSubmitService] Redis 인증 수 캐시 증가 실패", e);
         }
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountQueryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountQueryService.java
@@ -1,0 +1,18 @@
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VerificationCountQueryService {
+
+    private final GroupChallengeVerificationRepository groupRepo;
+    private final PersonalChallengeVerificationRepository personalRepo;
+
+    public int getTotalVerificationCountFromDB() {
+        return groupRepo.countAll() + personalRepo.countAll();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountReadService.java
@@ -1,0 +1,39 @@
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationCountResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VerificationCountReadService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String TOTAL_VERIFICATION_COUNT_KEY = "leafresh:totalVerifications:count";
+
+    public VerificationCountResponseDto getTotalVerificationCount() {
+        try {
+            String cached = redisTemplate.opsForValue().get(TOTAL_VERIFICATION_COUNT_KEY);
+            if (cached != null) {
+                log.debug("[VerificationCountReadService] Redis cache hit: {}", cached);
+                return new VerificationCountResponseDto(Integer.parseInt(cached));
+            }
+
+            log.warn("[VerificationCountReadService] Redis cache miss. Returning 0.");
+            return new VerificationCountResponseDto(0);
+
+        } catch (NumberFormatException e) {
+            log.error("[VerificationCountReadService] Redis 캐시 값 파싱 실패", e);
+            throw new CustomException(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
+        } catch (Exception e) {
+            log.error("[VerificationCountReadService] Redis 조회 중 알 수 없는 에러", e);
+            throw new CustomException(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/GroupChallengeVerificationRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/GroupChallengeVerificationRepository.java
@@ -166,4 +166,7 @@ public interface GroupChallengeVerificationRepository extends JpaRepository<Grou
             "v.id, v.viewCount, v.likeCount, v.commentCount) " +
             "FROM GroupChallengeVerification v WHERE v.id = :id")
     Optional<VerificationStatSnapshot> findStatById(@Param("id") Long id);
+
+    @Query("SELECT COUNT(g) FROM GroupChallengeVerification g")
+    int countAll();
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/PersonalChallengeVerificationRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/PersonalChallengeVerificationRepository.java
@@ -72,4 +72,7 @@ public interface PersonalChallengeVerificationRepository extends JpaRepository<P
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
     );
+
+    @Query("SELECT COUNT(p) FROM PersonalChallengeVerification p")
+    int countAll();
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/VerificationCountController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/VerificationCountController.java
@@ -1,0 +1,36 @@
+package ktb.leafresh.backend.domain.verification.presentation.controller;
+
+import ktb.leafresh.backend.domain.verification.application.service.VerificationCountReadService;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationCountResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import ktb.leafresh.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/challenges/verifications")
+public class VerificationCountController {
+
+    private final VerificationCountReadService verificationCountReadService;
+
+    @GetMapping("/count")
+    public ResponseEntity<ApiResponse<VerificationCountResponseDto>> getTotalVerificationCount() {
+        try {
+            VerificationCountResponseDto result = verificationCountReadService.getTotalVerificationCount();
+            log.info("[VerificationCountController] 누적 인증 수 조회 성공: {}", result.count());
+            return ResponseEntity.ok(ApiResponse.success("누적 사용자 인증 수 조회에 성공했습니다.", result));
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[VerificationCountController] 누적 인증 수 조회 실패", e);
+            throw new CustomException(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/dto/response/VerificationCountResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/dto/response/VerificationCountResponseDto.java
@@ -1,0 +1,3 @@
+package ktb.leafresh.backend.domain.verification.presentation.dto.response;
+
+public record VerificationCountResponseDto(int count) {}

--- a/src/main/java/ktb/leafresh/backend/global/exception/VerificationErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/VerificationErrorCode.java
@@ -38,7 +38,8 @@ public enum VerificationErrorCode implements BaseErrorCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     CANNOT_REPLY_TO_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "삭제된 댓글에는 대댓글을 작성할 수 없습니다."),
     COMMENT_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 댓글 수정에 실패했습니다."),
-    CANNOT_EDIT_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "삭제된 댓글은 수정할 수 없습니다.");
+    CANNOT_EDIT_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "삭제된 댓글은 수정할 수 없습니다."),
+    VERIFICATION_COUNT_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 누적 사용자 인증 수 조회에 실패했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/ktb/leafresh/backend/global/initializer/VerificationCountInitializer.java
+++ b/src/main/java/ktb/leafresh/backend/global/initializer/VerificationCountInitializer.java
@@ -1,0 +1,30 @@
+package ktb.leafresh.backend.global.initializer;
+
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.verification.application.service.VerificationCountQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VerificationCountInitializer {
+
+    private final VerificationCountQueryService queryService;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String TOTAL_VERIFICATION_COUNT_KEY = "leafresh:totalVerifications:count";
+
+    @PostConstruct
+    public void initializeVerificationCountCache() {
+        try {
+            int total = queryService.getTotalVerificationCountFromDB();
+            redisTemplate.opsForValue().set(TOTAL_VERIFICATION_COUNT_KEY, String.valueOf(total));
+            log.info("[VerificationCountInitializer] Redis 누적 인증 수 초기화 완료: {}", total);
+        } catch (Exception e) {
+            log.error("[VerificationCountInitializer] Redis 초기화 실패", e);
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- 누적 사용자 인증 수 조회 성능을 개선하기 위해 Redis 캐싱을 도입했습니다.
- DB 조회 → Redis 초기화 → 인증 발생 시 증가 처리 흐름을 구성했습니다.

## 작업 내용
- `VerificationCountQueryService`: 전체 인증 수를 DB에서 조회하도록 구현 (group + personal 합산)
- `VerificationCountInitializer`: 서버 시작 시 DB에서 조회한 전체 인증 수를 Redis에 캐싱
- `VerificationCountReadService`: Redis에서 인증 수 조회 (조회용 서비스)
- `VerificationCountController`: 인증 수 조회 API에서 `VerificationCountReadService`를 사용하도록 수정
- `GroupChallengeVerificationSubmitService`, `PersonalChallengeVerificationSubmitService`:
  - 인증 제출 성공 시 Redis에서 인증 수 `INCR` 처리
  - Redis 업데이트 실패 시에도 서비스 로직은 영향 없이 진행되도록 예외 캐치 처리
- `VerificationErrorCode`: `VERIFICATION_COUNT_QUERY_FAILED` 추가
- `GroupChallengeVerificationRepository`, `PersonalChallengeVerificationRepository`: `countAll()` 쿼리 추가
