### PR TITLE
feat: 소셜 로그인 redirect_uri를 origin 기반으로 동적 생성

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/auth/application/service/oauth/OAuthLoginService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/application/service/oauth/OAuthLoginService.java
@@ -53,10 +53,17 @@ public class OAuthLoginService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final AuthCookieProvider authCookieProvider;
 
-    public String getRedirectUrl() {
+//    public String getRedirectUrl() {
+//        return "https://kauth.kakao.com/oauth/authorize" +
+//                "?client_id=" + clientId +
+//                "&redirect_uri=" + redirectUri +
+//                "&response_type=code";
+//    }
+    public String getRedirectUrl(String origin) {
+        String encodedRedirectUri = origin + "/member/kakao/callback";
         return "https://kauth.kakao.com/oauth/authorize" +
                 "?client_id=" + clientId +
-                "&redirect_uri=" + redirectUri +
+                "&redirect_uri=" + encodedRedirectUri +
                 "&response_type=code";
     }
 

--- a/src/main/java/ktb/leafresh/backend/domain/auth/presentation/controller/OAuthController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/presentation/controller/OAuthController.java
@@ -38,13 +38,29 @@ public class OAuthController {
         return ResponseEntity.ok("<h1>카카오 로그인 성공</h1><p>쿠키 확인은 개발자 도구에서</p>");
     }
 
+//    @Operation(summary = "카카오 로그인 리다이렉트", description = "카카오 인증 페이지로 리다이렉트합니다.")
+//    @ApiResponseConstants.RedirectResponses
+//    @GetMapping("/{provider}")
+//    public ResponseEntity<ApiResponse<OAuthRedirectUrlResponseDto>> redirectToProvider(@PathVariable String provider) {
+//        OAuthProvider providerEnum = OAuthProvider.from(provider);
+//        String redirectUrl = oAuthLoginService.getRedirectUrl();
+//
+//        OAuthRedirectUrlResponseDto responseData = new OAuthRedirectUrlResponseDto(redirectUrl);
+//        return ResponseEntity.ok(ApiResponse.success("소셜 로그인 URL을 반환합니다.", responseData));
+//    }
+
     @Operation(summary = "카카오 로그인 리다이렉트", description = "카카오 인증 페이지로 리다이렉트합니다.")
     @ApiResponseConstants.RedirectResponses
     @GetMapping("/{provider}")
-    public ResponseEntity<ApiResponse<OAuthRedirectUrlResponseDto>> redirectToProvider(@PathVariable String provider) {
-        OAuthProvider providerEnum = OAuthProvider.from(provider);
-        String redirectUrl = oAuthLoginService.getRedirectUrl();
+    public ResponseEntity<ApiResponse<OAuthRedirectUrlResponseDto>> redirectToProvider(
+            @PathVariable String provider,
+            @RequestParam(required = false) String origin
+    ) {
+        if (origin == null || origin.isBlank()) {
+            origin = "https://leafresh.app"; // fallback 도메인
+        }
 
+        String redirectUrl = oAuthLoginService.getRedirectUrl(origin);
         OAuthRedirectUrlResponseDto responseData = new OAuthRedirectUrlResponseDto(redirectUrl);
         return ResponseEntity.ok(ApiResponse.success("소셜 로그인 URL을 반환합니다.", responseData));
     }


### PR DESCRIPTION
## 요약
도메인 환경(local/dev/prod)에 따라 카카오 로그인 redirect_uri를 다르게 반환할 수 있도록 `origin` 쿼리 파라미터 기반 동적 설정 로직을 추가했습니다.

## 작업 내용
- `/oauth/{provider}` API에서 `origin` 파라미터를 받아 환경 식별
- `OAuthLoginService#getRedirectUrl(String origin)` 메서드 추가
- 기존 `redirectUri` 고정 방식 제거 및 origin + "/member/kakao/callback" 형식으로 변환
- origin 누락 시 fallback 도메인 `https://leafresh.app` 적용

## 기타
- 추후 보안을 고려해 허용된 origin만 처리하는 로직 추가 검토 필요
