### PR TITLE
feat: 소셜 로그인 origin 화이트리스트 검증 및 에러 코드 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/auth/application/service/oauth/OAuthLoginService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/application/service/oauth/OAuthLoginService.java
@@ -53,6 +53,13 @@ public class OAuthLoginService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final AuthCookieProvider authCookieProvider;
 
+    private static final List<String> ALLOWED_ORIGINS = List.of(
+            "https://local.dev-leafresh.app",
+            "https://dev-leafresh.app",
+            "https://leafresh.app"
+    );
+
+
 //    public String getRedirectUrl() {
 //        return "https://kauth.kakao.com/oauth/authorize" +
 //                "?client_id=" + clientId +
@@ -60,7 +67,16 @@ public class OAuthLoginService {
 //                "&response_type=code";
 //    }
     public String getRedirectUrl(String origin) {
+        if (origin == null || origin.isBlank()) {
+            origin = "https://leafresh.app"; // fallback
+        }
+
+        if (!ALLOWED_ORIGINS.contains(origin)) {
+            throw new CustomException(GlobalErrorCode.INVALID_ORIGIN);
+        }
+
         String encodedRedirectUri = origin + "/member/kakao/callback";
+
         return "https://kauth.kakao.com/oauth/authorize" +
                 "?client_id=" + clientId +
                 "&redirect_uri=" + encodedRedirectUri +

--- a/src/main/java/ktb/leafresh/backend/global/exception/GlobalErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/GlobalErrorCode.java
@@ -19,8 +19,8 @@ public enum GlobalErrorCode implements BaseErrorCode {
     UNSUPPORTED_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 Content-Type입니다."),
     INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 이미지 URL입니다."),
     VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 기록이 존재하지 않습니다."),
-    SSE_STREAM_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "SSE 스트림이 중단되었습니다.");
-
+    SSE_STREAM_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "SSE 스트림이 중단되었습니다."),
+    INVALID_ORIGIN(HttpStatus.BAD_REQUEST, "접근이 금지되었습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 요약
소셜 로그인 요청 시 전달되는 origin 값이 허용된 도메인인지 검증하여 악의적인 요청을 차단하고, 유효하지 않은 origin에 대해 별도의 에러 코드를 반환하도록 처리했습니다.

## 작업 내용
- `OAuthLoginService#getRedirectUrl()` 내부에 origin 화이트리스트 검증 로직 추가
  - 허용된 도메인 목록: `local.dev-leafresh.app`, `dev-leafresh.app`, `leafresh.app`
- `GlobalErrorCode.INVALID_ORIGIN` 에러 코드 정의 (400 Bad Request)
- origin 누락 시 fallback 도메인(`https://leafresh.app`) 적용 로직 유지

## 테스트
- 허용된 origin → 정상 `redirectUrl` 응답
- 허용되지 않은 origin → 400 응답 + `"허용되지 않은 origin입니다."` 메시지 확인

## 기타
- 도메인 리스트는 추후 `application.yml` 기반 관리로 리팩토링 가능
