### PR TITLE
refactor: 소셜 로그인 허용 origin 목록을 설정 파일로 분리

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/auth/application/service/oauth/OAuthLoginService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/application/service/oauth/OAuthLoginService.java
@@ -10,6 +10,7 @@ import ktb.leafresh.backend.domain.member.application.service.RewardGrantService
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.RefreshTokenRepository;
+import ktb.leafresh.backend.global.config.SecurityProperties;
 import ktb.leafresh.backend.global.exception.GlobalErrorCode;
 import ktb.leafresh.backend.global.exception.MemberErrorCode;
 import ktb.leafresh.backend.global.security.*;
@@ -52,26 +53,15 @@ public class OAuthLoginService {
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final AuthCookieProvider authCookieProvider;
+    private final SecurityProperties securityProperties;
 
-    private static final List<String> ALLOWED_ORIGINS = List.of(
-            "https://local.dev-leafresh.app:3000",
-            "https://dev-leafresh.app",
-            "https://leafresh.app"
-    );
-
-
-//    public String getRedirectUrl() {
-//        return "https://kauth.kakao.com/oauth/authorize" +
-//                "?client_id=" + clientId +
-//                "&redirect_uri=" + redirectUri +
-//                "&response_type=code";
-//    }
     public String getRedirectUrl(String origin) {
         if (origin == null || origin.isBlank()) {
-            origin = "https://leafresh.app"; // fallback
+            origin = "https://leafresh.app";
         }
 
-        if (!ALLOWED_ORIGINS.contains(origin)) {
+        if (!securityProperties.getAllowedOrigins().contains(origin)) {
+            log.warn("허용되지 않은 origin 요청: {}", origin);
             throw new CustomException(GlobalErrorCode.INVALID_ORIGIN);
         }
 

--- a/src/main/java/ktb/leafresh/backend/global/config/SecurityProperties.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/SecurityProperties.java
@@ -1,0 +1,16 @@
+package ktb.leafresh.backend.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "security")
+public class SecurityProperties {
+    private List<String> allowedOrigins;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,3 +61,9 @@ cookie:
 
 ai-server:
   base-url: ${ai_server_base_url}
+
+security:
+  allowed-origins:
+    - https://local.dev-leafresh.app:3000
+    - https://dev-leafresh.app
+    - https://leafresh.app


### PR DESCRIPTION
## 요약
- 소셜 로그인 리다이렉트 시 사용되는 `origin` 값의 화이트리스트 검증 로직에서, 기존 하드코딩된 리스트를 `application.yml` 외부 설정으로 분리하였습니다.

## 작업 내용
- `security.allowed-origins` 항목을 `application.yml`에 추가
- `SecurityProperties` 클래스 생성 및 `@ConfigurationProperties` 바인딩 적용
- `OAuthLoginService` 내 `ALLOWED_ORIGINS` 상수 제거
- `SecurityProperties`를 주입받아 `origin` 검증 처리

## 기타
- 로그에 미허용 origin 요청 경고 로그 추가 (`log.warn`)
- 기존 fallback 도메인인 `https://leafresh.app` 유지
