### PR TITLE
fix: 카카오 redirect_uri mismatch 문제 해결

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/auth/application/service/oauth/OAuthLoginService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/application/service/oauth/OAuthLoginService.java
@@ -74,9 +74,9 @@ public class OAuthLoginService {
     }
 
     @Transactional
-    public OAuthTokenResponseDto loginWithKakao(String authorizationCode) {
+    public OAuthTokenResponseDto loginWithKakao(String authorizationCode, String redirectUri) {
         try {
-            OAuthUserInfoDto userInfo = oAuthKakaoService.getUserInfo(authorizationCode);
+            OAuthUserInfoDto userInfo = oAuthKakaoService.getUserInfo(authorizationCode, redirectUri);
             Optional<Member> optionalMember = memberRepository.findByEmail(userInfo.getEmail());
 
             if (optionalMember.isPresent()) {

--- a/src/main/java/ktb/leafresh/backend/domain/auth/infrastructure/client/KakaoTokenClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/infrastructure/client/KakaoTokenClient.java
@@ -34,7 +34,7 @@ public class KakaoTokenClient {
                 clientId, redirectUri, clientSecret);
     }
 
-    public String getAccessToken(String authorizationCode) {
+    public String getAccessToken(String authorizationCode, String redirectUri) {
         var formData = BodyInserters
                 .fromFormData("grant_type", "authorization_code")
                 .with("client_id", clientId)

--- a/src/main/java/ktb/leafresh/backend/domain/auth/infrastructure/client/OAuthKakaoService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/infrastructure/client/OAuthKakaoService.java
@@ -13,9 +13,9 @@ public class OAuthKakaoService {
     private final KakaoTokenClient kakaoTokenClient;
     private final KakaoProfileClient kakaoProfileClient;
 
-    public OAuthUserInfoDto getUserInfo(String authorizationCode) {
+    public OAuthUserInfoDto getUserInfo(String authorizationCode, String redirectUri) {
         try {
-            String accessToken = kakaoTokenClient.getAccessToken(authorizationCode);
+            String accessToken = kakaoTokenClient.getAccessToken(authorizationCode, redirectUri);
             OAuthUserInfoDto kakaoUser = kakaoProfileClient.getUserProfile(accessToken);
 
             // 디폴트 이미지 적용

--- a/src/main/java/ktb/leafresh/backend/domain/auth/presentation/controller/OAuthController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/presentation/controller/OAuthController.java
@@ -73,11 +73,15 @@ public class OAuthController {
     public ResponseEntity<ApiResponse<OAuthLoginResponseDto>> kakaoCallback(
             @PathVariable String provider,
             @RequestParam String code,
+            @RequestParam(required = false) String origin,
             HttpServletResponse response
     ) {
         log.info("인가 코드 수신 - code={}", code);
 
-        OAuthProvider providerEnum = OAuthProvider.from(provider);
+        if (origin == null || origin.isBlank()) {
+            origin = "https://leafresh.app";
+        }
+        String redirectUri = origin + "/member/kakao/callback";
 
         OAuthTokenResponseDto tokenDto = oAuthLoginService.loginWithKakao(code);
         log.info("카카오 로그인 토큰 발급 완료 - accessToken={}, refreshToken={}",


### PR DESCRIPTION
## 요약
카카오 OAuth 로그인 과정에서 인가코드는 발급되나,
AccessToken 요청 시 `redirect_uri` 불일치로 인해 `KOE303` 에러가 발생하는 문제를 해결했습니다.

## 작업 내용
- `/oauth/{provider}/callback` 요청 시 origin을 기반으로 redirectUri 생성
- `OAuthLoginService.loginWithKakao` 메서드 시그니처에 redirectUri 인자 추가
- `OAuthKakaoService`, `KakaoTokenClient`에서도 동일하게 인자 전달 구조로 수정
- WebClient 요청 시 redirectUri를 동적으로 포함하도록 수정

## 참고
- 카카오 개발자 콘솔에 등록된 redirect_uri와 정확히 일치해야 AccessToken 요청이 성공합니다
- 기존의 `@Value`로 고정된 redirectUri 사용 방식은 multi-origin 환경에 맞지 않아 유연하게 변경
