### PR TITLE
feat: redirectUri 설정 충돌 방지를 위한 구조 개선

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/auth/infrastructure/client/KakaoTokenClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/infrastructure/client/KakaoTokenClient.java
@@ -20,9 +20,6 @@ public class KakaoTokenClient {
     @Value("${kakao.client-id}")
     private String clientId;
 
-    @Value("${kakao.redirect-uri}")
-    private String redirectUri;
-
     @Value("${kakao.client-secret:}")
     private String clientSecret;
 
@@ -30,8 +27,8 @@ public class KakaoTokenClient {
 
     @PostConstruct
     public void logConfig() {
-        log.info("카카오 TokenClient 설정 로드 완료 - clientId={}, redirectUri={}, clientSecret={}",
-                clientId, redirectUri, clientSecret);
+        log.info("카카오 TokenClient 설정 로드 완료 - clientId={}, clientSecret={}",
+                clientId, clientSecret);
     }
 
     public String getAccessToken(String authorizationCode, String redirectUri) {

--- a/src/main/java/ktb/leafresh/backend/domain/auth/presentation/controller/OAuthController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/auth/presentation/controller/OAuthController.java
@@ -66,7 +66,7 @@ public class OAuthController {
     @ApiResponseConstants.SuccessResponses
     @ApiResponseConstants.ClientErrorResponses
     @ApiResponseConstants.ServerErrorResponses
-    @GetMapping("/member/{provider}/callback")
+    @GetMapping("/{provider}/callback")
     public ResponseEntity<ApiResponse<OAuthLoginResponseDto>> kakaoCallback(
             @PathVariable String provider,
             @RequestParam String code,


### PR DESCRIPTION
### 변경 내용
- KakaoTokenClient에서 @Value 주입된 redirectUri 필드 제거
  - 외부 환경변수 의존 없이 loginWithKakao()에서 전달된 redirectUri만 사용하도록 변경
  - redirectUri mismatch(KOE303) 문제 방지
- @PostConstruct 로그 메시지에서 redirectUri 항목 제거
- 기존 `/member/{provider}/callback` → `/{provider}/callback` 으로 엔드포인트 경로 정리

### 변경 이유
- dev 환경(docker-local)에서 `.env`에 등록된 kakao_redirect_uri가 localhost로 되어 있어 배포 시 redirect_uri mismatch(KOE303) 발생
- 실제 사용되는 redirectUri는 OAuthController → OAuthLoginService → KakaoTokenClient로 전달되므로, 고정값 주입 불필요

### 기타
- 실제 Kakao Developers 콘솔에 등록된 redirectUri (`https://leafresh.app/member/kakao/callback`) 기준에 맞춰, 동적 origin 기반 설정을 유지함
