### PR TITLE
feat: 카카오 소셜 로그인 state 파라미터 JWT로 암호화 및 복호화 기능 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/global/security/JwtProvider.java
+++ b/src/main/java/ktb/leafresh/backend/global/security/JwtProvider.java
@@ -94,4 +94,26 @@ public class JwtProvider {
         return Jwts.parserBuilder().setSigningKey(key).build()
                 .parseClaimsJws(token).getBody();
     }
+
+    // OAuth 인가 요청 시 state JWT 생성
+    public String generateStateToken(String origin) {
+        return Jwts.builder()
+                .setSubject("oauth_state")
+                .claim("origin", origin)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 3)) // 3분 유효
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    // 콜백 시 state JWT 복호화
+    public String parseStateToken(String stateToken) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(stateToken)
+                .getBody();
+
+        return claims.get("origin", String.class);
+    }
 }


### PR DESCRIPTION
### 작업 개요
- 카카오 소셜 로그인 요청 시 전달되는 `state` 값을 JWT로 암호화하여 CSRF 및 도메인 위변조 대응
- callback 시 해당 `state` JWT를 복호화하여 redirectUri를 재구성

### 주요 변경 사항
- `JwtProvider`에 `generateStateToken(origin)` / `parseStateToken(stateToken)` 메서드 추가
- `OAuthController`의 `/oauth/{provider}`에서 state JWT 발급 및 redirectUrl 생성 로직 수정
- `/oauth/{provider}/callback`에서 state JWT 복호화 및 origin 추출 적용
- API 문서 상 redirectUrl 파라미터 값이 state 포함되도록 변경

### 기타
- 기존 redirectUri fallback 도메인 `https://leafresh.app` 그대로 유지
- 프론트에서는 state 쿼리 파라미터를 그대로 전달만 하면 되므로 별도 복호화 필요 없음
