### PR TITLE
feat: 쿠키에 domain 설정 추가 (.dev-leafresh.app)

### DIFF
--- a/src/main/java/ktb/leafresh/backend/global/security/AuthCookieProvider.java
+++ b/src/main/java/ktb/leafresh/backend/global/security/AuthCookieProvider.java
@@ -15,8 +15,11 @@ public class AuthCookieProvider {
     @Value("${cookie.secure}")
     private boolean secure;
 
-    @Value("${cookie.samesite:Strict}") // 기본은 Strict
+    @Value("${cookie.samesite:Strict}")
     private String sameSite;
+
+    @Value("${cookie.domain}")
+    private String domain;
 
     @PostConstruct
     public void init() {
@@ -27,6 +30,7 @@ public class AuthCookieProvider {
         ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
                 .httpOnly(true)
                 .secure(secure)
+                .domain(domain)
                 .path("/")
                 .sameSite(sameSite)
                 .maxAge(maxAge);
@@ -38,6 +42,7 @@ public class AuthCookieProvider {
         return ResponseCookie.from(name, "")
                 .httpOnly(true)
                 .secure(secure)
+                .domain(domain)
                 .path("/")
                 .sameSite(sameSite)
                 .maxAge(0)


### PR DESCRIPTION
## 작업 내용
- `AuthCookieProvider`에 `@Value("${cookie.domain}")` 추가
- `createCookie`, `clearCookie` 메서드에 `.domain(domain)` 설정
- `application-docker-local.yml` 및 `.env.docker-local`의 `cookie.domain` 반영

## 목적
- SameSite=None 환경에서 cross-origin 쿠키가 정상적으로 브라우저에 저장되지 않는 문제 해결
- 로그인 이후 쿠키가 클라이언트에 정상 전달되지 않아 401 Unauthorized가 발생하던 이슈 해결

## 테스트
- OAuth 로그인 후 브라우저 네트워크 탭에서 `Set-Cookie` 헤더 내 `Domain=.dev-leafresh.app` 확인
- Postman 쿠키 요청 시 200 응답 정상 확인
