### PR TITLE
feat: RedisBloomConfig에 외부 설정 주입 적용 및 환경별 호스트 구성

### DIFF
--- a/src/main/java/ktb/leafresh/backend/global/config/RedisBloomConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/RedisBloomConfig.java
@@ -1,14 +1,21 @@
 package ktb.leafresh.backend.global.config;
 
 import io.rebloom.client.Client;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class RedisBloomConfig {
 
+    @Value("${redis.bloom.host}")
+    private String redisBloomHost;
+
+    @Value("${redis.bloom.port}")
+    private int redisBloomPort;
+
     @Bean
     public Client bloomClient() {
-        return new Client("localhost", 6379); // Docker RedisBloom 포트
+        return new Client(redisBloomHost, redisBloomPort);
     }
 }

--- a/src/main/resources/application-docker-local.yml
+++ b/src/main/resources/application-docker-local.yml
@@ -21,3 +21,8 @@ gcp:
     location: classpath:${gcp_credentials_location}
   storage:
     bucket: ${gcp_storage_bucket}
+
+redis:
+  bloom:
+    host: ${docker_local_cache_host}
+    port: ${docker_local_cache_port}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -21,3 +21,8 @@ gcp:
     location: classpath:${gcp_credentials_location}
   storage:
     bucket: ${gcp_storage_bucket}
+
+redis:
+  bloom:
+    host: ${local_cache_host}
+    port: ${local_cache_port}


### PR DESCRIPTION
## 변경 사항
- RedisBloomConfig에 하드코딩된 "localhost:6379"를 제거하고, @Value 주입 방식으로 수정
- application-local.yml, application-docker-local.yml에 redis.bloom.host 및 redis.bloom.port 프로퍼티 추가
- 로컬/도커 환경에 따라 RedisBloom 접근 주소를 `.env`를 통해 쉽게 설정 가능하도록 개선

## 작업 배경
- 운영 환경에서는 RedisBloom이 Docker 컨테이너 내부에서 동작하고 있기 때문에, 내부 IP 연결이 필요함
- 기존에는 localhost로 고정되어 있어 GCE 환경에서 연결 오류 발생
- 이를 `.yml` 외부 설정으로 분리하여, 환경마다 커스텀 가능하게 구성함

## 테스트
- 로컬 환경(local profile)에서 RedisBloom 정상 연결 확인 (`localhost:6379`)
- 향후 서버 배포 시 application-docker-local.yml 기반으로 내부 IP 대응 가능
