### PR TITLE
feat: 회원 정보 조회 응답에 이메일 필드 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/MemberInfoResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/presentation/dto/response/MemberInfoResponseDto.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 public class MemberInfoResponseDto {
 
     private String nickname;
+    private String email;
     private String profileImageUrl;
     private Long treeLevelId;
     private String treeLevelName;
@@ -20,6 +21,7 @@ public class MemberInfoResponseDto {
     public static MemberInfoResponseDto of(Member member, TreeLevel treeLevel) {
         return MemberInfoResponseDto.builder()
                 .nickname(member.getNickname())
+                .email(member.getEmail())
                 .profileImageUrl(member.getImageUrl())
                 .treeLevelId(treeLevel.getId())
                 .treeLevelName(treeLevel.getName().name())

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/MemberInfoQueryServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/MemberInfoQueryServiceTest.java
@@ -43,6 +43,7 @@ class MemberInfoQueryServiceTest {
 
         // then
         assertThat(result.getNickname()).isEqualTo("테스터");
+        assertThat(result.getEmail()).isEqualTo("test@leafresh.com");
         assertThat(result.getTreeLevelId()).isEqualTo(treeLevel.getId());
     }
 


### PR DESCRIPTION
## 작업 개요
회원 정보 조회 API(`/api/members`) 응답에 이메일(email) 필드를 포함시켰습니다.

## 주요 변경 사항
- `MemberInfoResponseDto`에 `email` 필드 추가
- `MemberInfoResponseDto.of()`에서 `member.getEmail()` 매핑
- 단위 테스트(`MemberInfoQueryServiceTest`)에서 `email` 검증 항목 추가
