### PR TITLE
feat: 단체 챌린지 카테고리 응답에 전체(ALL) 카테고리 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCategoryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCategoryService.java
@@ -29,6 +29,12 @@ public class GroupChallengeCategoryService {
                             .build())
                     .collect(Collectors.toList());
 
+            categories.add(0, GroupChallengeCategoryResponseDto.builder()
+                    .category("ALL")
+                    .label("전체")
+                    .imageUrl("https://storage.googleapis.com/leafresh-images/init/all.png")
+                    .build());
+
             if (categories.isEmpty()) {
                 throw new CustomException(ChallengeErrorCode.CHALLENGE_CATEGORY_LIST_EMPTY);
             }
@@ -43,6 +49,7 @@ public class GroupChallengeCategoryService {
 
     private String getLabelFromCategoryName(String name) {
         return switch (name) {
+            case "ALL" -> "전체";
             case "ZERO_WASTE" -> "제로웨이스트";
             case "PLOGGING" -> "플로깅";
             case "CARBON_FOOTPRINT" -> "탄소 발자국";

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/enums/GroupChallengeCategoryName.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/entity/enums/GroupChallengeCategoryName.java
@@ -2,6 +2,7 @@ package ktb.leafresh.backend.domain.challenge.group.domain.entity.enums;
 
 public enum GroupChallengeCategoryName {
 
+    ALL("전체"),
     ZERO_WASTE("제로웨이스트"),
     PLOGGING("플로깅"),
     CARBON_FOOTPRINT("탄소 발자국"),
@@ -24,6 +25,7 @@ public enum GroupChallengeCategoryName {
 
     public static String getImageUrl(String name) {
         return switch (name) {
+            case "ALL" -> "https://storage.googleapis.com/leafresh-images/init/all.png";
             case "ZERO_WASTE" -> "https://storage.googleapis.com/leafresh-images/init/zero_waste.png";
             case "PLOGGING" -> "https://storage.googleapis.com/leafresh-images/init/plogging.png";
             case "CARBON_FOOTPRINT" -> "https://storage.googleapis.com/leafresh-images/init/carbon_footprint.png";


### PR DESCRIPTION
## 작업 내용
- 프론트엔드 요청에 따라 카테고리 목록 조회 API(`/api/challenges/group/categories`) 응답에 전체(ALL) 카테고리 추가
- GroupChallengeCategoryName enum에 `ALL("전체")` 추가
- `getImageUrl()` 및 `getLabelFromCategoryName()` 메서드에 `ALL` 처리 분기 추가
- `GroupChallengeCategoryService.getCategories()` 내에서 수동으로 리스트 최상단에 `ALL` 삽입

## 추가 설명
- '전체' 카테고리는 실제 DB에 저장하지 않고, UI 필터 전용으로만 활용됩니다
- 따라서 DB 조회 쿼리 결과에는 포함되지 않으며, 서비스 단에서 직접 추가합니다

## 관련 요청사항
- 기획서 기준: "전체"가 category 쿼리 없이 UI에 보여야 하며, description 필드 추가 예정
