### PR TITLE
feat: 단체 챌린지 목록에 category 및 description 필드 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCategoryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCategoryService.java
@@ -29,12 +29,6 @@ public class GroupChallengeCategoryService {
                             .build())
                     .collect(Collectors.toList());
 
-            categories.add(0, GroupChallengeCategoryResponseDto.builder()
-                    .category("ALL")
-                    .label("전체")
-                    .imageUrl("https://storage.googleapis.com/leafresh-images/init/all.png")
-                    .build());
-
             if (categories.isEmpty()) {
                 throw new CustomException(ChallengeErrorCode.CHALLENGE_CATEGORY_LIST_EMPTY);
             }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeSummaryResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeSummaryResponseDto.java
@@ -11,6 +11,8 @@ import java.util.List;
 public record GroupChallengeSummaryResponseDto(
         Long id,
         String title,
+        String category,
+        String description,
         String thumbnailUrl,
         int leafReward,
         String startDate,
@@ -25,6 +27,8 @@ public record GroupChallengeSummaryResponseDto(
         return GroupChallengeSummaryResponseDto.builder()
                 .id(entity.getId())
                 .title(entity.getTitle())
+                .category(entity.getCategory().getName())
+                .description(entity.getDescription())
                 .thumbnailUrl(entity.getImageUrl())
                 .leafReward(entity.getLeafReward())
                 .startDate(entity.getStartDate().toLocalDate().toString())


### PR DESCRIPTION
## 변경 내용
- 단체 챌린지 목록 응답 DTO (`GroupChallengeSummaryResponseDto`)에 `category`, `description` 필드 추가
- category: 챌린지에 연결된 GroupChallengeCategory의 name
- description: 챌린지 상세 설명

## 리팩토링
- 기존 GroupChallengeCategory 목록에서 `ALL` 카테고리를 수동 삽입하던 로직 제거
  - DB `sequence_number` 기준으로 정렬되도록 보장

## 목적
- 챌린지 목록 카드에서 카테고리와 설명을 프론트엔드 UI에 바로 바인딩할 수 있도록 하기 위함
