### PR TITLE
Fix: Chatbot SSE API AI 서버 baseUrl 주입 오류 해결

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationSseService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationSseService.java
@@ -5,6 +5,7 @@ import ktb.leafresh.backend.domain.chatbot.application.handler.ChatbotSseStreamH
 import ktb.leafresh.backend.global.util.sse.SseStreamExecutor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -16,6 +17,8 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class ChatbotRecommendationSseService {
 
+    @Value("${ai-server.base-url}")
+    private String aiServerBaseUrl;
     private final ChatbotSseStreamHandler streamHandler;
     private final SseStreamExecutor sseStreamExecutor;
     private final ObjectMapper objectMapper;
@@ -33,7 +36,8 @@ public class ChatbotRecommendationSseService {
 
     private String buildUriWithParams(String aiUri, Object dto) {
         Map<String, String> map = objectMapper.convertValue(dto, Map.class);
-        UriComponentsBuilder builder = UriComponentsBuilder.fromPath(aiUri);
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromHttpUrl(aiServerBaseUrl + aiUri); // 여기 prefix 추가
         map.forEach(builder::queryParam);
         return builder.toUriString();
     }


### PR DESCRIPTION
## 문제 요약
- ChatbotRecommendationSseService 클래스에서 aiServerBaseUrl 필드가 생성자 주입으로만 선언되어 있어 Spring config로부터 값이 주입되지 않음
- 이로 인해 SSE 요청 시 AI 서버로 전달되는 URI가 null로 시작되어 400 또는 401 에러 발생

## 해결 내역
- aiServerBaseUrl에 @Value("${ai-server.base-url}") 어노테이션을 추가하여 application.yml에서 설정한 값이 주입되도록 수정
