### PR TITLE
feat: 텍스트/이미지 AI 서버 URL 분기 처리

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/client/HttpAiChallengeValidationClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/client/HttpAiChallengeValidationClient.java
@@ -6,6 +6,7 @@ import ktb.leafresh.backend.domain.challenge.group.infrastructure.dto.response.A
 import ktb.leafresh.backend.domain.challenge.group.infrastructure.dto.response.AiChallengeValidationResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -13,11 +14,14 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Slf4j
 @Component
 @Profile("!local")
-@RequiredArgsConstructor
 public class HttpAiChallengeValidationClient implements AiChallengeValidationClient {
 
-    private final WebClient aiServerWebClient;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final WebClient aiServerWebClient;
+
+    public HttpAiChallengeValidationClient(@Qualifier("textAiWebClient") WebClient aiServerWebClient) {
+        this.aiServerWebClient = aiServerWebClient;
+    }
 
     @Override
     public AiChallengeValidationResponseDto validateChallenge(AiChallengeValidationRequestDto requestDto) {

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationSseService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationSseService.java
@@ -17,7 +17,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class ChatbotRecommendationSseService {
 
-    @Value("${ai-server.base-url}")
+    @Value("${ai-server.text-base-url}")
     private String aiServerBaseUrl;
     private final ChatbotSseStreamHandler streamHandler;
     private final SseStreamExecutor sseStreamExecutor;

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/client/HttpAiChatbotBaseInfoClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/client/HttpAiChatbotBaseInfoClient.java
@@ -15,9 +15,7 @@ public class HttpAiChatbotBaseInfoClient implements AiChatbotBaseInfoClient {
 
     private final WebClient aiServerWebClient;
 
-    public HttpAiChatbotBaseInfoClient(
-            @Qualifier("aiServerWebClient") WebClient aiServerWebClient
-    ) {
+    public HttpAiChatbotBaseInfoClient(@Qualifier("textAiWebClient") WebClient aiServerWebClient) {
         this.aiServerWebClient = aiServerWebClient;
     }
 

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/client/HttpAiChatbotFreeTextClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/client/HttpAiChatbotFreeTextClient.java
@@ -15,9 +15,7 @@ public class HttpAiChatbotFreeTextClient implements AiChatbotFreeTextClient {
 
     private final WebClient aiServerWebClient;
 
-    public HttpAiChatbotFreeTextClient(
-            @Qualifier("aiServerWebClient") WebClient aiServerWebClient
-    ) {
+    public HttpAiChatbotFreeTextClient(@Qualifier("textAiWebClient") WebClient aiServerWebClient) {
         this.aiServerWebClient = aiServerWebClient;
     }
 

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/client/HttpFeedbackCreationClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/client/HttpFeedbackCreationClient.java
@@ -21,10 +21,10 @@ import java.time.Duration;
 @Profile("!local")
 public class HttpFeedbackCreationClient implements FeedbackCreationClient {
 
-    private final WebClient aiServerWebClient;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final WebClient aiServerWebClient;
 
-    public HttpFeedbackCreationClient(@Qualifier("aiServerWebClient") WebClient aiServerWebClient) {
+    public HttpFeedbackCreationClient(@Qualifier("textAiWebClient") WebClient aiServerWebClient) {
         this.aiServerWebClient = aiServerWebClient;
     }
 

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/HttpAiVerificationClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/client/HttpAiVerificationClient.java
@@ -18,15 +18,13 @@ import java.time.Duration;
 
 @Slf4j
 @Component
-@Profile("!local") // prod
+@Profile("!local")
 public class HttpAiVerificationClient implements AiVerificationClient {
 
-    private final WebClient aiServerWebClient;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final WebClient aiServerWebClient;
 
-    public HttpAiVerificationClient(
-            @Qualifier("aiServerWebClient") WebClient aiServerWebClient
-    ) {
+    public HttpAiVerificationClient(@Qualifier("imageAiWebClient") WebClient aiServerWebClient) {
         this.aiServerWebClient = aiServerWebClient;
     }
 

--- a/src/main/java/ktb/leafresh/backend/global/config/WebClientConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/WebClientConfig.java
@@ -8,17 +8,22 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class WebClientConfig {
 
-    // 기본 WebClient
     @Bean
     public WebClient webClient() {
         return WebClient.builder().build();
     }
 
-    // AI 서버 전용 WebClient
-    @Bean(name = "aiServerWebClient")
-    public WebClient aiServerWebClient(@Value("${ai-server.base-url}") String aiServerBaseUrl) {
+    @Bean(name = "textAiWebClient")
+    public WebClient textAiWebClient(@Value("${ai-server.text-base-url}") String textAiBaseUrl) {
         return WebClient.builder()
-                .baseUrl(aiServerBaseUrl)
+                .baseUrl(textAiBaseUrl)
+                .build();
+    }
+
+    @Bean(name = "imageAiWebClient")
+    public WebClient imageAiWebClient(@Value("${ai-server.image-base-url}") String imageAiBaseUrl) {
+        return WebClient.builder()
+                .baseUrl(imageAiBaseUrl)
                 .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,7 +59,8 @@ cookie:
   secure: true
 
 ai-server:
-  base-url: ${ai_server_base_url}
+  text-base-url: ${text_ai_server_base_url}
+  image-base-url: ${image_ai_server_base_url}
 
 security:
   allowed-origins:


### PR DESCRIPTION
## 주요 변경사항
- 텍스트 기반 기능(챗봇, 피드백, 챌린지 검증)과 이미지 기반 기능(이미지 인증)을 분리된 AI 서버에 전송하도록 수정
- `application.yml`에 `ai-server.text-base-url`, `ai-server.image-base-url` 추가
- WebClientConfig에서 각 용도별 WebClient Bean 분리 등록

## 수정 파일
- application.yml
- WebClientConfig.java
- ChatbotRecommendationSseService.java
- HttpAiChatbotBaseInfoClient.java
- HttpAiChatbotFreeTextClient.java
- HttpFeedbackCreationClient.java
- HttpAiChallengeValidationClient.java
- HttpAiVerificationClient.java

## 비고
- text-base-url: `http://35.216.82.57:8000`
- image-base-url: `http://35.216.16.225:8000`