### PR TITLE
fix: 타임딜 목록 조회에서 ZSet 범위 확장 및 상태값 실시간 계산 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealProductReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealProductReadService.java
@@ -31,64 +31,94 @@ public class TimedealProductReadService {
 
         // 1. 목록 캐시 확인
         Object cachedList = redisTemplate.opsForValue().get(ProductCacheKeys.TIMEDEAL_LIST);
+        List<TimedealProductSummaryResponseDto> result;
         if (cachedList != null) {
             log.info("[TimedealProductReadService] 목록 캐시 HIT - key={}", ProductCacheKeys.TIMEDEAL_LIST);
-            return objectMapper.convertValue(cachedList, TimedealProductListResponseDto.class);
-        }
-        log.info("[TimedealProductReadService] 목록 캐시 MISS - key={}", ProductCacheKeys.TIMEDEAL_LIST);
+            TimedealProductListResponseDto cachedDto = objectMapper.convertValue(cachedList, TimedealProductListResponseDto.class);
+            result = cachedDto.timeDeals();
+        } else {
+            log.info("[TimedealProductReadService] 목록 캐시 MISS - key={}", ProductCacheKeys.TIMEDEAL_LIST);
 
-        // 2. ZSET 조회
-        long now = System.currentTimeMillis();
-        long aWeekLater = LocalDateTime.now().plusDays(7)
-                .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
-        Set<Object> dealIds = redisTemplate.opsForZSet()
-                .rangeByScore(ProductCacheKeys.TIMEDEAL_ZSET, now, aWeekLater);
+            // 2. ZSET 조회
+            long now = System.currentTimeMillis();
+            long oneWeekLater = LocalDateTime.now().plusDays(7)
+                    .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            long twoHoursBeforeNow = LocalDateTime.now().minusHours(2)
+                    .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
 
-        List<TimedealProductSummaryResponseDto> result = new ArrayList<>();
-        if (dealIds != null && !dealIds.isEmpty()) {
-            List<Long> missedPolicyIds = new ArrayList<>();
+            Set<Object> dealIds = redisTemplate.opsForZSet()
+                    .rangeByScore(ProductCacheKeys.TIMEDEAL_ZSET, twoHoursBeforeNow, oneWeekLater);
 
-            for (Object policyIdObj : dealIds) {
-                Long policyId = Long.valueOf(policyIdObj.toString());
-                String key = ProductCacheKeys.timedealSingle(policyId);
-                Object cachedDto = redisTemplate.opsForValue().get(key);
+            result = new ArrayList<>();
+            if (dealIds != null && !dealIds.isEmpty()) {
+                List<Long> missedPolicyIds = new ArrayList<>();
 
-                if (cachedDto != null) {
-                    result.add(objectMapper.convertValue(cachedDto, TimedealProductSummaryResponseDto.class));
-                    log.info("[TimedealProductReadService] 단건 캐시 HIT - key={}", key);
-                } else {
-                    missedPolicyIds.add(policyId);
-                    log.warn("[TimedealProductReadService] 단건 캐시 MISS - key={}", key);
+                for (Object policyIdObj : dealIds) {
+                    Long policyId = Long.valueOf(policyIdObj.toString());
+                    String key = ProductCacheKeys.timedealSingle(policyId);
+                    Object cachedDto = redisTemplate.opsForValue().get(key);
+
+                    if (cachedDto != null) {
+                        result.add(objectMapper.convertValue(cachedDto, TimedealProductSummaryResponseDto.class));
+                        log.info("[TimedealProductReadService] 단건 캐시 HIT - key={}", key);
+                    } else {
+                        missedPolicyIds.add(policyId);
+                        log.warn("[TimedealProductReadService] 단건 캐시 MISS - key={}", key);
+                    }
+                }
+
+                // 3. Fallback - 벌크 조회 + 병렬 캐싱
+                if (!missedPolicyIds.isEmpty()) {
+                    log.info("[TimedealProductReadService] DB fallback 시작 - size={}", missedPolicyIds.size());
+
+                    List<TimedealProductSummaryResponseDto> fallbackList =
+                            timedealProductQueryService.findAllById(missedPolicyIds);
+
+                    fallbackList.parallelStream().forEach(dto -> {
+                        String fallbackKey = ProductCacheKeys.timedealSingle(dto.dealId());
+                        long ttl = Duration.between(LocalDateTime.now(), dto.dealEndTime()).toSeconds() + 60;
+                        redisTemplate.opsForValue().set(fallbackKey, dto, Duration.ofSeconds(ttl));
+                        log.info("[TimedealProductReadService] DB fallback 캐시 저장 - key={}, TTL={}초", fallbackKey, ttl);
+                    });
+
+                    result.addAll(fallbackList);
                 }
             }
 
-            // 3. Fallback - 벌크 조회 + 병렬 캐싱
-            if (!missedPolicyIds.isEmpty()) {
-                log.info("[TimedealProductReadService] DB fallback 시작 - size={}", missedPolicyIds.size());
-
-                List<TimedealProductSummaryResponseDto> fallbackList =
-                        timedealProductQueryService.findAllById(missedPolicyIds);
-
-                fallbackList.parallelStream().forEach(dto -> {
-                    String fallbackKey = ProductCacheKeys.timedealSingle(dto.dealId());
-                    long ttl = Duration.between(LocalDateTime.now(), dto.dealEndTime()).toSeconds() + 60;
-                    redisTemplate.opsForValue().set(fallbackKey, dto, Duration.ofSeconds(ttl));
-                    log.info("[TimedealProductReadService] DB fallback 캐시 저장 - key={}, TTL={}초", fallbackKey, ttl);
-                });
-
-                result.addAll(fallbackList);
-            }
+            // 4. 목록 캐시 저장
+            TimedealProductListResponseDto responseDto = new TimedealProductListResponseDto(result);
+            redisTemplate.opsForValue().set(
+                    ProductCacheKeys.TIMEDEAL_LIST,
+                    responseDto,
+                    Duration.ofSeconds(60)
+            );
+            log.info("[TimedealProductReadService] 목록 캐시 저장 - key={}, TTL=60초", ProductCacheKeys.TIMEDEAL_LIST);
         }
 
-        // 4. 목록 캐시 저장
-        TimedealProductListResponseDto responseDto = new TimedealProductListResponseDto(result);
-        redisTemplate.opsForValue().set(
-                ProductCacheKeys.TIMEDEAL_LIST,
-                responseDto,
-                Duration.ofSeconds(60)
-        );
-        log.info("[TimedealProductReadService] 목록 캐시 저장 - key={}, TTL=60초", ProductCacheKeys.TIMEDEAL_LIST);
+        // 5. 상태값 동적 갱신
+        LocalDateTime nowTime = LocalDateTime.now();
+        List<TimedealProductSummaryResponseDto> updated = result.stream()
+                .map(dto -> new TimedealProductSummaryResponseDto(
+                        dto.dealId(),
+                        dto.productId(),
+                        dto.title(),
+                        dto.description(),
+                        dto.defaultPrice(),
+                        dto.discountedPrice(),
+                        dto.discountedPercentage(),
+                        dto.stock(),
+                        dto.imageUrl(),
+                        dto.dealStartTime(),
+                        dto.dealEndTime(),
+                        dto.productStatus(),
+                        determineTimeDealStatus(nowTime, dto.dealStartTime(), dto.dealEndTime())
+                ))
+                .toList();
 
-        return responseDto;
+        return new TimedealProductListResponseDto(updated);
+    }
+
+    private String determineTimeDealStatus(LocalDateTime now, LocalDateTime start, LocalDateTime end) {
+        return (start.isBefore(now) && end.isAfter(now)) ? "ONGOING" : "UPCOMING";
     }
 }


### PR DESCRIPTION
## 개요
타임딜 목록 조회 시 ONGOING 상태의 타임딜이 누락되는 문제를 해결하기 위해
ZSet 범위 조회 기준을 보완하고, 상태값을 동적으로 판단하는 로직을 추가했습니다.

## 변경 사항
- Redis ZSet 조회 시 now → twoHoursBeforeNow 기준으로 확장하여 시작된 타임딜 포함
- Redis 캐시된 TimedealProductSummaryDto의 startTime/endTime을 기반으로
  현재 시각 기준 상태를 ONGOING/UPCOMING으로 동적 재계산
- 기존 캐시 TTL 구조 유지

## 테스트 결과
- DB 상 startTime이 현재 시각과 정확히 같은 타임딜이 정상적으로 목록에 포함됨
- 상태값도 정확히 ONGOING으로 표시되는 것 확인

## 관련 이슈
- 타임딜 노출 시간 임계점(시작 시각 = 현재 시각)에서 목록 누락되는 현상