### PR TITLE
chore: Jackson 직렬화 시간대를 Asia/Seoul(KST)로 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,9 @@ spring:
   profiles:
     active: ${spring_profiles_active}
 
+    jackson:
+      time-zone: Asia/Seoul
+
   security:
     basic:
       enabled: false


### PR DESCRIPTION
## 변경 사항
- `application.yml`에 `spring.jackson.time-zone: Asia/Seoul` 설정 추가
- Jackson 직렬화 시 응답 시간 기준을 UTC → KST로 통일

## 적용 배경
- 서버/JVM 시간대를 KST로 변경함에 따라 JSON 응답에도 KST 기준 반영 필요
- 기존에는 응답에 포함된 `LocalDateTime`이 UTC 기준으로 직렬화되어 9시간 오차 발생

## 기대 효과
- 클라이언트 화면에서 타임딜 시작/종료 시간이 실제 한국 시간대로 표시됨
- 시간 기준 오해로 인한 사용자 혼란 제거
