### PR TITLE
refactor: 타임딜 상태 계산을 ZonedDateTime 기반 KST 기준으로 변경

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealProductReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealProductReadService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -111,14 +112,18 @@ public class TimedealProductReadService {
                         dto.dealStartTime(),
                         dto.dealEndTime(),
                         dto.productStatus(),
-                        determineTimeDealStatus(nowTime, dto.dealStartTime(), dto.dealEndTime())
+                        determineTimeDealStatus(dto.dealStartTime(), dto.dealEndTime())
                 ))
                 .toList();
 
         return new TimedealProductListResponseDto(updated);
     }
 
-    private String determineTimeDealStatus(LocalDateTime now, LocalDateTime start, LocalDateTime end) {
-        return (start.isBefore(now) && end.isAfter(now)) ? "ONGOING" : "UPCOMING";
+    private String determineTimeDealStatus(LocalDateTime start, LocalDateTime end) {
+        ZonedDateTime nowKST = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        ZonedDateTime startZoned = start.atZone(ZoneId.of("Asia/Seoul"));
+        ZonedDateTime endZoned = end.atZone(ZoneId.of("Asia/Seoul"));
+
+        return (!nowKST.isBefore(startZoned) && nowKST.isBefore(endZoned)) ? "ONGOING" : "UPCOMING";
     }
 }


### PR DESCRIPTION
기존에는 LocalDateTime.now()를 기준으로 타임딜 상태를 판단했으나,
서버 또는 클라이언트의 시간대 설정에 따라 상태 오류가 발생할 수 있어
모든 기준 시각을 `Asia/Seoul` 시간대 기반 `ZonedDateTime`으로 통일했습니다.

### 주요 변경 사항
- `determineTimeDealStatus` 파라미터 변경 및 내부 ZonedDateTime 변환
- now 시점도 KST 기준으로 통일하여 계산 정확성 향상

### 고려한 사항
- 현재 BE 기준 타임존을 명시적으로 설정하는 방향으로 처리했으며,
  추후 프론트 요청 시간대에 따라 동적으로 조정할 여지가 있다면 논의 필요
