### PR TITLE
fix: soft delete된 좋아요를 isLiked 판단에서 제외

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/LikeRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/LikeRepository.java
@@ -20,7 +20,9 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     @Query("""
     SELECT l.verification.id
     FROM Like l
-    WHERE l.member.id = :memberId AND l.verification.id IN :verificationIds
+    WHERE l.member.id = :memberId
+    AND l.verification.id IN :verificationIds
+    AND l.deletedAt IS NULL
     """)
     Set<Long> findLikedVerificationIdsByMemberId(@Param("memberId") Long memberId,
                                                  @Param("verificationIds") List<Long> verificationIds);


### PR DESCRIPTION
## 변경 내용
- `LikeRepository.findLikedVerificationIdsByMemberId()` 쿼리에 `deletedAt IS NULL` 조건을 추가했습니다.
- soft delete된 좋아요 레코드가 인증 피드에서 `isLiked: true`로 응답되던 문제를 해결했습니다.

## 주요 이슈
- 좋아요 삭제 후에도 `isLiked`가 true로 반환되는 버그
- 인증 피드에서 isLiked 값의 정확도 문제

## 테스트 시나리오
1. 좋아요 추가
2. 좋아요 삭제 (soft delete 처리)
3. 인증 피드 조회 → `isLiked: false`로 정상 응답됨
