### PR TITLE
fix: 챗봇 SSE 연결 종료 시 예외 처리 로직 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandlerImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandlerImpl.java
@@ -1,0 +1,53 @@
+package ktb.leafresh.backend.domain.chatbot.application.handler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.publisher.Flux;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatbotSseStreamHandlerImpl implements ChatbotSseStreamHandler {
+
+    private final WebClient textAiWebClient;
+
+    @Override
+    public void streamToEmitter(SseEmitter emitter, String uriWithQueryParams) {
+        try {
+            Flux<ServerSentEvent<String>> eventStream = textAiWebClient.get()
+                    .uri(uriWithQueryParams)
+                    .retrieve()
+                    .bodyToFlux((Class<ServerSentEvent<String>>)(Class<?>)ServerSentEvent.class);
+
+            eventStream.subscribe(
+                    event -> {
+                        try {
+                            emitter.send(SseEmitter.event()
+                                    .name(event.event())
+                                    .data(event.data()));
+                        } catch (IOException e) {
+                            log.warn("[SSE 전송 실패] {}", e.toString());
+                            emitter.completeWithError(e);
+                        }
+                    },
+                    error -> {
+                        log.warn("[AI SSE 스트림 오류] {}", error.toString());
+                        emitter.completeWithError(error);
+                    },
+                    () -> {
+                        log.info("[AI SSE 스트림 완료]");
+                        emitter.complete();
+                    }
+            );
+        } catch (Exception e) {
+            log.error("[SSE 스트림 처리 중 예외]", e);
+            emitter.completeWithError(e);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationSseService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationSseService.java
@@ -25,6 +25,16 @@ public class ChatbotRecommendationSseService {
 
     public SseEmitter stream(String aiUri, Object dto) {
         SseEmitter emitter = new SseEmitter(60_000L);
+
+        emitter.onCompletion(() -> log.info("[SSE 완료]"));
+        emitter.onTimeout(() -> {
+            log.warn("[SSE 타임아웃]");
+            emitter.complete();
+        });
+        emitter.onError(e -> {
+            log.warn("[SSE 에러 발생]", e);
+        });
+
         String uri = buildUriWithParams(aiUri, dto);
 
         sseStreamExecutor.execute(emitter, () ->


### PR DESCRIPTION
## 변경 내용
- SseEmitter 생성 시 `.onCompletion`, `.onTimeout`, `.onError` 핸들러 추가
- SSE 응답 전송 중 `Broken pipe` 등의 예외 발생 시 `completeWithError()` 호출하도록 처리
- WebClient `subscribe()` 구독 흐름에서 `onNext`, `onError`, `onComplete` 분기 로직 명확화

## 변경 이유
- 클라이언트(프론트)가 SSE 연결을 끊었을 경우 발생하는 `IOException`, `AsyncRequestNotUsableException` 대응
- 백엔드에서 해당 예외가 발생해도 서버 오류로 확산되지 않도록 방지
- 안정적인 챗봇 SSE 스트리밍을 위한 흐름 보완
