### PR TITLE
feat: 환경별 AI 챗봇 핸들러 분리 적용 (POST / SSE)

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandlerImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandlerImpl.java
@@ -2,6 +2,7 @@ package ktb.leafresh.backend.domain.chatbot.application.handler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -13,6 +14,7 @@ import java.io.IOException;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Profile("docker-local")
 public class ChatbotSseStreamHandlerImpl implements ChatbotSseStreamHandler {
 
     private final WebClient textAiWebClient;

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/client/HttpAiChatbotBaseInfoClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/client/HttpAiChatbotBaseInfoClient.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Component
-@Profile("!local")
+@Profile("bigbang-prod")
 public class HttpAiChatbotBaseInfoClient implements AiChatbotBaseInfoClient {
 
     private final WebClient aiServerWebClient;

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/client/HttpAiChatbotFreeTextClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/infrastructure/client/HttpAiChatbotFreeTextClient.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Component
-@Profile("!local")
+@Profile("bigbang-prod")
 public class HttpAiChatbotFreeTextClient implements AiChatbotFreeTextClient {
 
     private final WebClient aiServerWebClient;


### PR DESCRIPTION
## 주요 변경 사항
- docker-local 환경
  - ChatbotSseStreamHandlerImpl 활성화
  - WebClient를 활용해 SSE 기반 스트리밍 추천 처리
  - Broken pipe, 연결 종료 등의 예외에 대해 completeWithError로 안전하게 처리
- bigbang-prod 환경
  - HttpAiChatbotBaseInfoClient, HttpAiChatbotFreeTextClient 활성화
  - WebClient를 활용한 POST 기반 추천 요청 방식 유지
- 각 핸들러 클래스에 @Profile 지정하여 빈 충돌 방지 및 명확한 실행 흐름 분리

## 기대 효과
- 환경별로 추천 처리 방식(SSE / POST)을 유연하게 분리 가능
- SseEmitter 관련 예외 대응 안정성 확보
- 불필요한 빈 등록 방지로 애플리케이션 실행 실패 이슈 해결