### PR TITLE
Fix/profile scope chatbot recommendation

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationService.java
@@ -11,6 +11,7 @@ import ktb.leafresh.backend.domain.chatbot.presentation.dto.request.ChatbotFreeT
 import ktb.leafresh.backend.domain.chatbot.presentation.dto.response.ChatbotRecommendationResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.Optional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Profile("bigbang-prod")
 public class ChatbotRecommendationService {
 
     private final AiChatbotBaseInfoClient aiChatbotBaseInfoClientClient;


### PR DESCRIPTION
## 개요
- `docker-local` 프로파일에서 사용하지 않는 `ChatbotRecommendationService`가 등록되면서,
  해당 서비스가 의존하는 `AiChatbotBaseInfoClient` 구현체가 없어 애플리케이션이 실행 실패하던 문제를 해결했습니다.

## 변경 내용
- `ChatbotRecommendationService`에 `@Profile("bigbang-prod")` 어노테이션 추가
  - 해당 서비스는 POST 기반 챗봇 로직으로, `bigbang-prod` 환경에서만 사용됩니다.

## 기대 효과
- `docker-local` 환경에서 의존성 주입 오류 없이 애플리케이션 정상 기동
- 환경별 Bean 분리가 명확해져 유지보수 용이성 향상
