### PR TITLE
refactor: 챗봇 SSE 핸들러 단일 구현체로 통합 및 기존 Http 핸들러 제거

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandlerImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandlerImpl.java
@@ -1,8 +1,10 @@
 package ktb.leafresh.backend.domain.chatbot.application.handler;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -13,43 +15,42 @@ import java.io.IOException;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @Profile("docker-local")
 public class ChatbotSseStreamHandlerImpl implements ChatbotSseStreamHandler {
 
     private final WebClient textAiWebClient;
 
+    public ChatbotSseStreamHandlerImpl(@Qualifier("textAiWebClient") WebClient textAiWebClient) {
+        this.textAiWebClient = textAiWebClient;
+    }
+
     @Override
     public void streamToEmitter(SseEmitter emitter, String uriWithQueryParams) {
-        try {
-            Flux<ServerSentEvent<String>> eventStream = textAiWebClient.get()
-                    .uri(uriWithQueryParams)
-                    .retrieve()
-                    .bodyToFlux((Class<ServerSentEvent<String>>)(Class<?>)ServerSentEvent.class);
+        Flux<ServerSentEvent<String>> eventStream = textAiWebClient.get()
+                .uri(uriWithQueryParams)
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .retrieve()
+                .bodyToFlux(new ParameterizedTypeReference<>() {});
 
-            eventStream.subscribe(
-                    event -> {
-                        try {
-                            emitter.send(SseEmitter.event()
-                                    .name(event.event())
-                                    .data(event.data()));
-                        } catch (IOException e) {
-                            log.warn("[SSE 전송 실패] {}", e.toString());
-                            emitter.completeWithError(e);
-                        }
-                    },
-                    error -> {
-                        log.warn("[AI SSE 스트림 오류] {}", error.toString());
-                        emitter.completeWithError(error);
-                    },
-                    () -> {
-                        log.info("[AI SSE 스트림 완료]");
-                        emitter.complete();
+        eventStream.subscribe(
+                event -> {
+                    try {
+                        emitter.send(SseEmitter.event()
+                                .name(event.event())
+                                .data(event.data()));
+                    } catch (IOException e) {
+                        log.warn("[SSE 전송 실패] {}", e.getMessage());
+                        emitter.completeWithError(e);
                     }
-            );
-        } catch (Exception e) {
-            log.error("[SSE 스트림 처리 중 예외]", e);
-            emitter.completeWithError(e);
-        }
+                },
+                error -> {
+                    log.error("[SSE 스트림 오류]", error);
+                    emitter.completeWithError(error);
+                },
+                () -> {
+                    log.info("[SSE 스트림 종료]");
+                    emitter.complete();
+                }
+        );
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/HttpChatbotSseStreamHandler.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/HttpChatbotSseStreamHandler.java
@@ -1,55 +1,55 @@
-package ktb.leafresh.backend.domain.chatbot.application.handler;
-
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Profile;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.MediaType;
-import org.springframework.http.codec.ServerSentEvent;
-import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import reactor.core.publisher.Flux;
-
-import java.io.IOException;
-
-@Slf4j
-@Component
-@Profile("!local")
-public class HttpChatbotSseStreamHandler implements ChatbotSseStreamHandler {
-
-    private final WebClient textAiWebClient;
-
-    public HttpChatbotSseStreamHandler(@Qualifier("textAiWebClient") WebClient textAiWebClient) {
-        this.textAiWebClient = textAiWebClient;
-    }
-
-    @Override
-    public void streamToEmitter(SseEmitter emitter, String uriWithQueryParams) {
-        Flux<ServerSentEvent<String>> flux = textAiWebClient.get()
-                .uri(uriWithQueryParams)
-                .accept(MediaType.TEXT_EVENT_STREAM)
-                .retrieve()
-                .bodyToFlux(new ParameterizedTypeReference<>() {});
-
-        flux.doOnNext(event -> {
-                    StringBuilder sb = new StringBuilder();
-                    if (event.event() != null) sb.append("event: ").append(event.event()).append("\n");
-                    if (event.data() != null) sb.append("data: ").append(event.data()).append("\n");
-                    sb.append("\n");
-
-                    try {
-                        emitter.send(sb.toString());
-                    } catch (IOException e) {
-                        log.warn("[SSE 전송 실패] {}", e.getMessage());
-                        emitter.completeWithError(e);
-                    }
-                })
-                .doOnComplete(emitter::complete)
-                .doOnError(e -> {
-                    log.error("[SSE 스트림 오류] {}", e.getMessage());
-                    emitter.completeWithError(e);
-                })
-                .subscribe();
-    }
-}
+//package ktb.leafresh.backend.domain.chatbot.application.handler;
+//
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.beans.factory.annotation.Qualifier;
+//import org.springframework.context.annotation.Profile;
+//import org.springframework.core.ParameterizedTypeReference;
+//import org.springframework.http.MediaType;
+//import org.springframework.http.codec.ServerSentEvent;
+//import org.springframework.stereotype.Component;
+//import org.springframework.web.reactive.function.client.WebClient;
+//import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+//import reactor.core.publisher.Flux;
+//
+//import java.io.IOException;
+//
+//@Slf4j
+//@Component
+//@Profile("!local")
+//public class HttpChatbotSseStreamHandler implements ChatbotSseStreamHandler {
+//
+//    private final WebClient textAiWebClient;
+//
+//    public HttpChatbotSseStreamHandler(@Qualifier("textAiWebClient") WebClient textAiWebClient) {
+//        this.textAiWebClient = textAiWebClient;
+//    }
+//
+//    @Override
+//    public void streamToEmitter(SseEmitter emitter, String uriWithQueryParams) {
+//        Flux<ServerSentEvent<String>> flux = textAiWebClient.get()
+//                .uri(uriWithQueryParams)
+//                .accept(MediaType.TEXT_EVENT_STREAM)
+//                .retrieve()
+//                .bodyToFlux(new ParameterizedTypeReference<>() {});
+//
+//        flux.doOnNext(event -> {
+//                    StringBuilder sb = new StringBuilder();
+//                    if (event.event() != null) sb.append("event: ").append(event.event()).append("\n");
+//                    if (event.data() != null) sb.append("data: ").append(event.data()).append("\n");
+//                    sb.append("\n");
+//
+//                    try {
+//                        emitter.send(sb.toString());
+//                    } catch (IOException e) {
+//                        log.warn("[SSE 전송 실패] {}", e.getMessage());
+//                        emitter.completeWithError(e);
+//                    }
+//                })
+//                .doOnComplete(emitter::complete)
+//                .doOnError(e -> {
+//                    log.error("[SSE 스트림 오류] {}", e.getMessage());
+//                    emitter.completeWithError(e);
+//                })
+//                .subscribe();
+//    }
+//}


### PR DESCRIPTION
기존 SSE 핸들러가 profile에 따라 두 개로 분리되어 있던 구조를 단일화했습니다.

- ChatbotSseStreamHandlerImpl 클래스에 SSE 중계 로직 통합
- event/data 구조를 그대로 유지하여 프론트엔드에서 SSE 수신 가능
- 불필요한 문자열 조립 방식 제거 및 WebClient 요청 정리
- 기존 HttpChatbotSseStreamHandler 완전 제거
