### PR TITLE
chore: SQL 로그 출력 설정을 local 환경에만 적용되도록 분리

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,6 +10,12 @@ spring:
       host: ${local_cache_host}
       port: ${local_cache_port}
 
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
 cookie:
   secure: false
   samesite: ${local_cookie_samesite:Strict}
@@ -26,3 +32,13 @@ redis:
   bloom:
     host: ${local_cache_host}
     port: ${local_cache_port}
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: DEBUG
+        type:
+          descriptor:
+            sql:
+              BasicBinder: TRACE

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,8 @@ spring:
   profiles:
     active: ${spring_profiles_active}
 
-    jackson:
-      time-zone: Asia/Seoul
+  jackson:
+    time-zone: Asia/Seoul
 
   security:
     basic:
@@ -16,10 +16,10 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
 
   servlet:
     multipart:
@@ -43,11 +43,11 @@ logging:
       springframework:
         security: DEBUG
       hibernate:
-        SQL: DEBUG
+        SQL: OFF
         type:
           descriptor:
             sql:
-              BasicBinder: TRACE
+              BasicBinder: OFF
     org.springframework.web.servlet.DispatcherServlet: DEBUG
     ktb.leafresh.backend: DEBUG
 


### PR DESCRIPTION
### 변경 내용
- 모든 환경에서 SQL 로그가 출력되지 않도록 application.yml에서 show-sql과 로그 레벨을 OFF로 설정
- local 환경(application-local.yml)에서만 디버깅을 위한 SQL 로그(DEBUG/TRACE) 출력 설정 유지

### 변경 이유
- 운영 및 테스트 서버에서 불필요한 SQL 로그 출력으로 인한 성능 저하 및 보안 위험 방지
- 개발 중에는 local 환경에서만 SQL 쿼리 확인 필요

### 적용 대상
- application.yml
- application-local.yml
