### PR TITLE
fix: 참여한 단체 챌린지 not_started 조건 및 remaining 계산 방식 수정

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/service/GroupChallengeVerificationHistoryCalculator.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/service/GroupChallengeVerificationHistoryCalculator.java
@@ -22,6 +22,7 @@ public class GroupChallengeVerificationHistoryCalculator {
             List<GroupChallengeVerification> verifications
     ) {
         LocalDate startDate = challenge.getStartDate().toLocalDate();
+        LocalDate endDate = challenge.getEndDate().toLocalDate();
         LocalDate today = LocalDate.now();
 
         // 최신 인증이 먼저 보이도록 정렬 + 시작일 기준 day 계산
@@ -40,12 +41,7 @@ public class GroupChallengeVerificationHistoryCalculator {
         long success = verifications.stream().filter(v -> v.getStatus() == ChallengeStatus.SUCCESS).count();
         long failure = verifications.stream().filter(v -> v.getStatus() == ChallengeStatus.FAILURE).count();
 
-        LocalDate lastVerificationDate = verifications.stream()
-                .map(v -> v.getCreatedAt().toLocalDate())
-                .max(LocalDate::compareTo)
-                .orElse(startDate);
-
-        long remaining = ChronoUnit.DAYS.between(lastVerificationDate, challenge.getEndDate().toLocalDate());
+        int remaining = (int) Math.max(0, ChronoUnit.DAYS.between(today, endDate) + 1);
 
         String todayStatus = verifications.stream()
                 .filter(v -> v.getCreatedAt().toLocalDate().isEqual(today))
@@ -61,7 +57,7 @@ public class GroupChallengeVerificationHistoryCalculator {
                 .id(challenge.getId())
                 .title(challenge.getTitle())
                 .achievement(new GroupChallengeVerificationHistoryResponseDto.AchievementDto(
-                        (int) success, (int) failure, (int) remaining))
+                        (int) success, (int) failure, remaining))
                 .verifications(verificationDtos)
                 .todayStatus(todayStatus)
                 .build();

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeParticipationRecordQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeParticipationRecordQueryRepositoryImpl.java
@@ -55,10 +55,11 @@ public class GroupChallengeParticipationRecordQueryRepositoryImpl implements Gro
         for (GroupChallengeParticipantRecord r : records) {
             GroupChallenge c = r.getGroupChallenge();
             ParticipantStatus status = r.getStatus();
+            boolean hasNoVerification = r.getVerifications().stream().noneMatch(v -> v.getDeletedAt() == null);
 
             if (status == FINISHED || now.isAfter(c.getEndDate())) {
                 completed++;
-            } else if (now.isBefore(c.getStartDate())) {
+            } else if (hasNoVerification) {
                 notStarted++;
             } else {
                 ongoing++;


### PR DESCRIPTION
## 변경 내용
- `/api/members/challenges/group/participations/count` 에서 not_started 조건을 '참여했으나 인증 이력이 없는 경우'로 수정
- `/participations/{challengeId}/verifications`의 remaining 값을 (endDate - 오늘 + 1)로 계산하며, 음수 방지를 위해 Math.max(0, ...) 적용

## 이유
- 챌린지 시작일이 지난 후에도 인증을 하지 않은 사용자가 not_started로 분류되지 않는 문제 해결
- 인증 마감일이 지났음에도 remaining이 음수로 표기되던 문제 해결

## 영향 범위
- 참여 상태 카운트 API
- 챌린지 인증 내역 조회 API
