### PR TITLE
fix: SseEmitter 응답 시 Cache-Control 및 X-Accel-Buffering 헤더 설정

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/presentation/controller/ChatbotRecommendationSseController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/presentation/controller/ChatbotRecommendationSseController.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Slf4j
 @RestController
@@ -22,8 +23,12 @@ public class ChatbotRecommendationSseController {
             @RequestParam String sessionId,
             @RequestParam String location,
             @RequestParam String workType,
-            @RequestParam String category
+            @RequestParam String category,
+            HttpServletResponse response
     ) {
+        response.setHeader("Cache-Control", "no-cache");
+        response.setHeader("X-Accel-Buffering", "no");
+
         return chatbotRecommendationSseService.stream(
                 "/ai/chatbot/recommendation/base-info",
                 new ChatbotBaseInfoRequestDto(sessionId, location, workType, category)
@@ -33,8 +38,12 @@ public class ChatbotRecommendationSseController {
     @GetMapping(value = "/free-text", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter freeText(
             @RequestParam String sessionId,
-            @RequestParam String message
+            @RequestParam String message,
+            HttpServletResponse response
     ) {
+        response.setHeader("Cache-Control", "no-cache");
+        response.setHeader("X-Accel-Buffering", "no");
+
         return chatbotRecommendationSseService.stream(
                 "/ai/chatbot/recommendation/free-text",
                 new ChatbotFreeTextRequestDto(sessionId, message)


### PR DESCRIPTION
## 변경사항
- SSE 응답이 nginx 프록시를 거칠 때 실시간 스트리밍이 유지되도록 하기 위해,
  `ChatbotRecommendationSseController`에 `Cache-Control: no-cache` 및 `X-Accel-Buffering: no` 헤더를 명시적으로 추가했습니다.
- HTTP 응답 헤더 설정은 `HttpServletResponse` 객체를 통해 처리했습니다.

## 배경
- nginx에서 기본적으로 response buffering이 활성화되어 있어, SSE의 실시간 스트리밍이 차단될 수 있음
- `X-Accel-Buffering: no` 설정을 통해 nginx의 버퍼링을 비활성화
- `Cache-Control: no-cache`는 브라우저 캐싱 방지 및 실시간 수신 유지를 위해 필요

## 참고
- 적용 대상 URI: `/api/chatbot/recommendation/base-info`, `/free-text`
