### PR TITLE
feat: 단체 챌린지 인증 이력 조회 메서드 추가 및 createdAt 응답 제거

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeVerificationQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeVerificationQueryRepository.java
@@ -1,8 +1,10 @@
 package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
 
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeParticipationSummaryDto;
 import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface GroupChallengeVerificationQueryRepository {
@@ -11,4 +13,6 @@ public interface GroupChallengeVerificationQueryRepository {
     List<GroupChallengeVerification> findByParticipantRecordId(Long participantRecordId);
 
     Optional<GroupChallengeVerification> findByChallengeIdAndId(Long challengeId, Long verificationId);
+
+    Map<Long, List<GroupChallengeParticipationSummaryDto.AchievementRecordDto>> findVerificationsGroupedByChallenge(List<Long> challengeIds, Long memberId);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeVerificationQueryRepositoryImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeVerificationQueryRepositoryImpl.java
@@ -1,7 +1,10 @@
 package ktb.leafresh.backend.domain.challenge.group.infrastructure.repository;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.QGroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeParticipationSummaryDto;
 import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
 import ktb.leafresh.backend.domain.verification.domain.entity.QGroupChallengeVerification;
 import ktb.leafresh.backend.global.util.pagination.CursorConditionUtils;
@@ -9,8 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Repository
 @RequiredArgsConstructor
@@ -18,6 +20,8 @@ public class GroupChallengeVerificationQueryRepositoryImpl implements GroupChall
 
     private final JPAQueryFactory queryFactory;
     private final QGroupChallengeVerification gv = QGroupChallengeVerification.groupChallengeVerification;
+    private final QGroupChallengeVerification verification = QGroupChallengeVerification.groupChallengeVerification;
+    private final QGroupChallengeParticipantRecord record = QGroupChallengeParticipantRecord.groupChallengeParticipantRecord;
 
     @Override
     public List<GroupChallengeVerification> findByChallengeId(Long challengeId, Long cursorId, String cursorTimestamp, int size) {
@@ -62,5 +66,39 @@ public class GroupChallengeVerificationQueryRepositoryImpl implements GroupChall
                         v.deletedAt.isNull()
                 )
                 .fetchOne());
+    }
+
+    @Override
+    public Map<Long, List<GroupChallengeParticipationSummaryDto.AchievementRecordDto>> findVerificationsGroupedByChallenge(List<Long> challengeIds, Long memberId) {
+
+        List<Tuple> results = queryFactory
+                .select(
+                        record.groupChallenge.id,
+                        verification.status,
+                        verification.createdAt
+                )
+                .from(verification)
+                .join(verification.participantRecord, record)
+                .where(
+                        record.groupChallenge.id.in(challengeIds),
+                        record.member.id.eq(memberId),
+                        verification.deletedAt.isNull()
+                )
+                .orderBy(verification.createdAt.asc())
+                .fetch();
+
+        Map<Long, List<GroupChallengeParticipationSummaryDto.AchievementRecordDto>> map = new HashMap<>();
+        Map<Long, Integer> challengeIdToDayCounter = new HashMap<>();
+
+        for (Tuple tuple : results) {
+            Long challengeId = tuple.get(record.groupChallenge.id);
+            String status = tuple.get(verification.status).name();
+            int day = challengeIdToDayCounter.merge(challengeId, 1, Integer::sum);
+
+            map.computeIfAbsent(challengeId, k -> new ArrayList<>())
+                    .add(new GroupChallengeParticipationSummaryDto.AchievementRecordDto(day, status));
+        }
+
+        return map;
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeParticipationSummaryDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeParticipationSummaryDto.java
@@ -1,8 +1,10 @@
 package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 public record GroupChallengeParticipationSummaryDto(
@@ -12,10 +14,15 @@ public record GroupChallengeParticipationSummaryDto(
         String startDate,
         String endDate,
         AchievementDto achievement,
+        List<AchievementRecordDto> achievementRecords,
+        @JsonIgnore
         LocalDateTime createdAt
 ) {
     @Builder
     public record AchievementDto(Long success, Long total) {}
+
+    @Builder
+    public record AchievementRecordDto(int day, String status) {}
 
     public static GroupChallengeParticipationSummaryDto of(
             Long id,
@@ -25,6 +32,7 @@ public record GroupChallengeParticipationSummaryDto(
             String endDate,
             Long success,
             Long total,
+            List<AchievementRecordDto> achievementRecords,
             LocalDateTime createdAt
     ) {
         return GroupChallengeParticipationSummaryDto.builder()
@@ -34,6 +42,7 @@ public record GroupChallengeParticipationSummaryDto(
                 .startDate(startDate)
                 .endDate(endDate)
                 .achievement(new AchievementDto(success, total))
+                .achievementRecords(achievementRecords)
                 .createdAt(createdAt)
                 .build();
     }

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/presentation/controller/ChatbotRecommendationSseController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/presentation/controller/ChatbotRecommendationSseController.java
@@ -5,6 +5,7 @@ import ktb.leafresh.backend.domain.chatbot.presentation.dto.request.ChatbotBaseI
 import ktb.leafresh.backend.domain.chatbot.presentation.dto.request.ChatbotFreeTextRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -14,6 +15,7 @@ import jakarta.servlet.http.HttpServletResponse;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chatbot/recommendation")
+@Profile({"docker-local", "docker-prod"})
 public class ChatbotRecommendationSseController {
 
     private final ChatbotRecommendationSseService chatbotRecommendationSseService;


### PR DESCRIPTION
## 요약
- 프론트 요청에 따라 참여한 단체 챌린지 목록 응답에서 `createdAt` 필드를 제거했습니다.
- 인증 이력(`achievementRecords`)을 챌린지별로 그룹핑하여 응답에 포함할 수 있도록 새로운 쿼리 메서드를 추가했습니다.

## 작업 내용
- `GroupChallengeParticipationSummaryDto`에서 `createdAt`에 `@JsonIgnore` 적용
  - 커서 기반 페이지네이션에는 사용되지만 응답에서는 제외
- 인증 이력을 챌린지별로 그룹핑하여 `List<AchievementRecordDto>`로 반환하는 메서드 추가
  - `createdAt` 오름차순 정렬 → 가장 오래된 인증이 `day 1`
  - 반복 순서를 기반으로 `day` 값 부여
- `GroupChallengeVerificationQueryRepository`에 시그니처 추가
- `GroupChallengeParticipationReadService`에서 인증 이력 매핑 방식 개선
- 환경 분기용 `@Profile(local/docker)` 추가 (부가 작업)
