### PR TITLE
refactor: SSE 구조 MVC 방식으로 회귀 및 Virtual Thread 도입

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandler.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandler.java
@@ -1,13 +1,13 @@
-//package ktb.leafresh.backend.domain.chatbot.application.handler;
-//
-//import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-//
-///**
-// * AI 서버로부터 받은 SSE 응답을 그대로 FE로 전달하는 중계 핸들러
-// * - WebClient를 통해 AI 서버로 GET 요청을 보냄
-// * - ServerSentEvent<String> 형식으로 수신
-// * - 받은 SSE 메시지를 포맷 유지한 채 SseEmitter를 통해 FE로 전송
-// */
-//public interface ChatbotSseStreamHandler {
-//    void streamToEmitter(SseEmitter emitter, String uriWithQueryParams);
-//}
+package ktb.leafresh.backend.domain.chatbot.application.handler;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * AI 서버로부터 받은 SSE 응답을 그대로 FE로 전달하는 중계 핸들러
+ * - WebClient를 통해 AI 서버로 GET 요청을 보냄
+ * - ServerSentEvent<String> 형식으로 수신
+ * - 받은 SSE 메시지를 포맷 유지한 채 SseEmitter를 통해 FE로 전송
+ */
+public interface ChatbotSseStreamHandler {
+    void streamToEmitter(SseEmitter emitter, String uriWithQueryParams);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandlerImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandlerImpl.java
@@ -1,77 +1,86 @@
-//package ktb.leafresh.backend.domain.chatbot.application.handler;
-//
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.beans.factory.annotation.Qualifier;
-//import org.springframework.context.annotation.Profile;
-//import org.springframework.core.ParameterizedTypeReference;
-//import org.springframework.http.MediaType;
-//import org.springframework.http.codec.ServerSentEvent;
-//import org.springframework.stereotype.Component;
-//import org.springframework.web.reactive.function.client.WebClient;
-//import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-//import reactor.core.publisher.Flux;
-//
-//import java.io.IOException;
-//
-//@Slf4j
-//@Component
-//@Profile("docker-local")
-//public class ChatbotSseStreamHandlerImpl implements ChatbotSseStreamHandler {
-//
-//    private final WebClient textAiWebClient;
-//
-//    public ChatbotSseStreamHandlerImpl(@Qualifier("textAiWebClient") WebClient textAiWebClient) {
-//        this.textAiWebClient = textAiWebClient;
-//    }
-//
-//    @Override
-//    public void streamToEmitter(SseEmitter emitter, String uriWithQueryParams) {
-//        Flux<ServerSentEvent<String>> eventStream = textAiWebClient.get()
-//                .uri(uriWithQueryParams)
-//                .accept(MediaType.TEXT_EVENT_STREAM)
-//                .retrieve()
-//                .bodyToFlux(new ParameterizedTypeReference<>() {});
-//
-//        eventStream.subscribe(
-//                event -> {
-//                    String rawEventName = event.event();
-//                    String eventName = (rawEventName == null || rawEventName.isBlank()) ? "message" : rawEventName;
-//
-//                    String data = event.data();
-//                    if (data == null) {
-//                        log.warn("[SSE 무효 이벤트 수신] event: {}, data: null", eventName);
-//                        return;
-//                    }
-//
-//                    try {
-//                        if ("close".equalsIgnoreCase(eventName)) {
-//                            log.info("[SSE 종료 이벤트 수신] event: close, data: {}", data);
-//                            emitter.complete();
-//                            return;
-//                        }
-//
-//                        if (data.isBlank()) {
-//                            log.debug("[SSE Keep-Alive 전송] event: {}, data: <빈 문자열>", eventName);
-//                            emitter.send(SseEmitter.event().comment("ping"));
-//                        } else {
-//                            log.info("[SSE 응답 전달] event: {}, data: {}", eventName, data);
-//                            emitter.send(SseEmitter.event()
-//                                    .name(eventName)
-//                                    .data(data, MediaType.APPLICATION_JSON));
-//                        }
-//
-//                    } catch (IOException e) {
-//                        log.warn("[SSE 전송 실패] {}", e.getMessage());
-//                        emitter.completeWithError(e);
-//                    }
-//                },
-//                error -> {
-//                    log.error("[SSE 스트림 오류 발생]", error);
-//                    emitter.completeWithError(error);
-//                },
-//                () -> {
-//                    log.info("[SSE 스트림 종료 콜백 발생] → 무시됨 (event: close로만 종료)");
-//                }
-//        );
-//    }
-//}
+package ktb.leafresh.backend.domain.chatbot.application.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.publisher.Flux;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@Profile("docker-local")
+public class ChatbotSseStreamHandlerImpl implements ChatbotSseStreamHandler {
+
+    private final WebClient textAiWebClient;
+
+    public ChatbotSseStreamHandlerImpl(@Qualifier("textAiWebClient") WebClient textAiWebClient) {
+        this.textAiWebClient = textAiWebClient;
+    }
+
+    @Override
+    public void streamToEmitter(SseEmitter emitter, String uriWithQueryParams) {
+        Flux<ServerSentEvent<String>> eventStream = textAiWebClient.get()
+                .uri(uriWithQueryParams)
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .retrieve()
+                .bodyToFlux(new ParameterizedTypeReference<>() {});
+
+        eventStream.subscribe(
+                event -> {
+                    String rawEventName = event.event();
+                    String eventName = (rawEventName == null || rawEventName.isBlank()) ? "message" : rawEventName;
+
+                    String data = event.data();
+                    if (data == null) {
+                        log.warn("[SSE 무효 이벤트 수신] event: {}, data: null", eventName);
+                        return;
+                    }
+
+                    try {
+                        if ("close".equalsIgnoreCase(eventName)) {
+                            log.info("[SSE 종료 이벤트 수신] event: close, data: {}", data);
+
+                            try {
+                                emitter.send(SseEmitter.event()
+                                        .name("close")
+                                        .data(data, MediaType.APPLICATION_JSON));
+                            } catch (IOException e) {
+                                log.warn("[SSE 종료 이벤트 전송 실패] {}", e.getMessage());
+                            }
+
+                            emitter.complete();
+                            return;
+                        }
+
+                        if (data.isBlank()) {
+                            log.debug("[SSE Keep-Alive 전송] event: {}, data: <빈 문자열>", eventName);
+                            emitter.send(SseEmitter.event().comment("ping"));
+                        } else {
+                            log.info("[SSE 응답 전달] event: {}, data: {}", eventName, data);
+                            emitter.send(SseEmitter.event()
+                                    .name(eventName)
+                                    .data(data, MediaType.APPLICATION_JSON));
+                        }
+
+                    } catch (IOException e) {
+                        log.warn("[SSE 전송 실패] {}", e.getMessage());
+                        emitter.completeWithError(e);
+                    }
+                },
+                error -> {
+                    log.error("[SSE 스트림 오류 발생]", error);
+                    emitter.completeWithError(error);
+                },
+                () -> {
+                    log.info("[SSE 스트림 종료 콜백 발생] → 무시됨 (event: close로만 종료)");
+                }
+        );
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/FakeChatbotSseStreamHandler.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/FakeChatbotSseStreamHandler.java
@@ -1,26 +1,26 @@
-//package ktb.leafresh.backend.domain.chatbot.application.handler;
-//
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.context.annotation.Profile;
-//import org.springframework.stereotype.Component;
-//import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-//
-//import java.io.IOException;
-//
-//@Slf4j
-//@Component
-//@Profile("local")
-//public class FakeChatbotSseStreamHandler implements ChatbotSseStreamHandler {
-//
-//    @Override
-//    public void streamToEmitter(SseEmitter emitter, String uriWithQueryParams) {
-//        try {
-//            emitter.send("event: challenge\ndata: {\"message\":\"fake1\"}\n\n");
-//            emitter.send("event: challenge\ndata: {\"message\":\"fake2\"}\n\n");
-//            emitter.send("event: close\ndata: {\"message\":\"모든 챌린지 추천 완료\"}\n\n");
-//            emitter.complete();
-//        } catch (IOException e) {
-//            emitter.completeWithError(e);
-//        }
-//    }
-//}
+package ktb.leafresh.backend.domain.chatbot.application.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@Profile("local")
+public class FakeChatbotSseStreamHandler implements ChatbotSseStreamHandler {
+
+    @Override
+    public void streamToEmitter(SseEmitter emitter, String uriWithQueryParams) {
+        try {
+            emitter.send("event: challenge\ndata: {\"message\":\"fake1\"}\n\n");
+            emitter.send("event: challenge\ndata: {\"message\":\"fake2\"}\n\n");
+            emitter.send("event: close\ndata: {\"message\":\"모든 챌린지 추천 완료\"}\n\n");
+            emitter.complete();
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationSseService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationSseService.java
@@ -1,20 +1,17 @@
 package ktb.leafresh.backend.domain.chatbot.application.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import ktb.leafresh.backend.domain.chatbot.application.handler.ChatbotSseStreamHandler;
+import ktb.leafresh.backend.global.util.sse.SseStreamExecutor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.MediaType;
-import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Flux;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.util.UriComponentsBuilder;
 
-import java.time.Duration;
 import java.util.Map;
-import java.util.Objects;
 
 @Slf4j
 @Service
@@ -22,55 +19,55 @@ import java.util.Objects;
 @Profile({"docker-local", "docker-prod"})
 public class ChatbotRecommendationSseService {
 
-    @Qualifier("textAiWebClient")
-    private final WebClient textAiWebClient;
-
+    @Value("${ai-server.text-base-url}")
+    private String aiServerBaseUrl;
+    private final ChatbotSseStreamHandler streamHandler;
+    private final SseStreamExecutor sseStreamExecutor;
     private final ObjectMapper objectMapper;
 
-    public Flux<ServerSentEvent<String>> streamFlux(String aiPath, Object dto) {
-        Map<String, String> queryParams = objectMapper.convertValue(dto, Map.class);
+    public SseEmitter stream(String aiUri, Object dto) {
+        SseEmitter emitter = new SseEmitter(300_000L);
 
-        return textAiWebClient.get()
-                .uri(uriBuilder -> {
-                    uriBuilder.path(aiPath);
-                    queryParams.forEach(uriBuilder::queryParam);
-                    return uriBuilder.build();
-                })
-                .accept(MediaType.TEXT_EVENT_STREAM)
-                .retrieve()
-                .bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
-                .timeout(Duration.ofMinutes(5))
-                .onErrorResume(e -> {
-                    log.warn("[AI 응답 타임아웃 또는 오류로 SSE 종료]", e);
-                    return Flux.just(
-                            ServerSentEvent.<String>builder()
-                                    .event("error")
-                                    .data("AI 응답이 지연되어 연결이 종료되었습니다.")
-                                    .build()
-                    );
-                })
-                .map(event -> {
-                    String eventName = event.event();
-                    String data = event.data();
-                    if (data == null) {
-                        log.warn("[SSE 무효 이벤트] event: {}, data: null", eventName);
-                        return null;
-                    }
+        emitter.onCompletion(() -> log.info("[SSE 완료]"));
+        emitter.onTimeout(() -> {
+            log.warn("[SSE 타임아웃]");
+            emitter.complete();
+        });
+        emitter.onError(e -> {
+            log.warn("[SSE 에러 발생]", e);
+        });
 
-                    log.info("[SSE 이벤트 수신] event: {}, data: {}", eventName, data);
+        String uri = buildUriWithParams(aiUri, dto);
 
-                    return ServerSentEvent.<String>builder()
-                            .event(eventName == null ? "message" : eventName)
-                            .data(data)
-                            .build();
-                })
-                .filter(Objects::nonNull)
-                .takeUntil(event -> {
-                    boolean isClose = "close".equalsIgnoreCase(event.event());
-                    if (isClose) {
-                        log.info("[SSE 종료 신호 감지] event: close → Flux 종료 예정");
-                    }
-                    return isClose;
-                });
+        Thread.startVirtualThread(() -> {
+            try {
+                streamHandler.streamToEmitter(emitter, uri);
+            } catch (Exception e) {
+                log.error("[SSE 처리 실패]", e);
+                emitter.completeWithError(e);
+            }
+        });
+
+        return emitter;
+    }
+
+    private String buildUriWithParams(String aiUri, Object dto) {
+        Map<String, String> map = objectMapper.convertValue(dto, Map.class);
+
+        log.debug("[SSE 요청 파라미터] {}", map);
+
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromHttpUrl(aiServerBaseUrl + aiUri);
+
+        map.forEach((key, value) -> {
+            log.debug("[쿼리 파라미터 추가] {}={}", key, value);
+            builder.queryParam(key, value);
+        });
+
+        String uri = builder.toUriString();
+
+        log.info("[AI 요청 URI] {}", uri);
+
+        return uri;
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/presentation/controller/ChatbotRecommendationSseController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/presentation/controller/ChatbotRecommendationSseController.java
@@ -7,10 +7,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
-import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.http.server.reactive.ServerHttpResponse;
-import reactor.core.publisher.Flux;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Slf4j
 @RestController
@@ -22,32 +21,32 @@ public class ChatbotRecommendationSseController {
     private final ChatbotRecommendationSseService chatbotRecommendationSseService;
 
     @GetMapping(value = "/base-info", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<ServerSentEvent<String>> baseInfo(
+    public SseEmitter baseInfo(
             @RequestParam String sessionId,
             @RequestParam String location,
             @RequestParam String workType,
             @RequestParam String category,
-            ServerHttpResponse response
+            HttpServletResponse response
     ) {
-        response.getHeaders().add("Cache-Control", "no-cache");
-        response.getHeaders().add("X-Accel-Buffering", "no");
+        response.setHeader("Cache-Control", "no-cache");
+        response.setHeader("X-Accel-Buffering", "no");
 
-        return chatbotRecommendationSseService.streamFlux(
+        return chatbotRecommendationSseService.stream(
                 "/ai/chatbot/recommendation/base-info",
                 new ChatbotBaseInfoRequestDto(sessionId, location, workType, category)
         );
     }
 
     @GetMapping(value = "/free-text", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<ServerSentEvent<String>> freeText(
+    public SseEmitter freeText(
             @RequestParam String sessionId,
             @RequestParam String message,
-            ServerHttpResponse response
+            HttpServletResponse response
     ) {
-        response.getHeaders().add("Cache-Control", "no-cache");
-        response.getHeaders().add("X-Accel-Buffering", "no");
+        response.setHeader("Cache-Control", "no-cache");
+        response.setHeader("X-Accel-Buffering", "no");
 
-        return chatbotRecommendationSseService.streamFlux(
+        return chatbotRecommendationSseService.stream(
                 "/ai/chatbot/recommendation/free-text",
                 new ChatbotFreeTextRequestDto(sessionId, message)
         );

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/domain/entity/Feedback.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/domain/entity/Feedback.java
@@ -23,7 +23,7 @@ public class Feedback extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Column(name = "week_monday", nullable = false)

--- a/src/main/java/ktb/leafresh/backend/global/util/sse/SseStreamExecutor.java
+++ b/src/main/java/ktb/leafresh/backend/global/util/sse/SseStreamExecutor.java
@@ -1,24 +1,24 @@
-//package ktb.leafresh.backend.global.util.sse;
-//
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.stereotype.Component;
-//import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-//
-//import java.util.concurrent.ExecutorService;
-//import java.util.concurrent.Executors;
-//
-///**
-// * 비동기 실행기
-// */
-//@Slf4j
-//@Component
-//@RequiredArgsConstructor
-//public class SseStreamExecutor {
-//
-//    private final ExecutorService executor = Executors.newCachedThreadPool();
-//
-//    public void execute(SseEmitter emitter, Runnable task) {
-//        executor.execute(task);
-//    }
-//}
+package ktb.leafresh.backend.global.util.sse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * 비동기 실행기
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SseStreamExecutor {
+
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+
+    public void execute(SseEmitter emitter, Runnable task) {
+        executor.execute(task);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,9 +2,6 @@ spring:
   application:
     name: backend
 
-  web:
-    application-type: reactive
-
   profiles:
     active: ${spring_profiles_active}
 


### PR DESCRIPTION
## 주요 변경사항

- 기존 WebFlux 기반 SSE 처리 구조 → Spring MVC 기반 SseEmitter 구조로 회귀
- AI → FE 응답 전송 시 Virtual Thread 적용으로 동시성 확보
- event: close 수신 시 클라이언트에 응답 먼저 전송 후 emitter.complete() 처리하도록 수정
- SseEmitter 응답 헤더 설정 유지 (`Cache-Control`, `X-Accel-Buffering`)
- Feedback.content 컬럼을 TEXT 타입으로 명시 (가독성과 대용량 대응 목적)

## 이유
- WebFlux 사용 시 Security/Servlet 혼합으로 인한 오류 발생
- 현재 프로젝트는 대부분 MVC 기반이므로 구조 일관성 유지 필요
- Virtual Thread 도입으로 블로킹 IO 최소화 및 응답 유실 문제 해결
