### PR TITLE
test: OffsetDateTime 기반 응답 DTO 테스트 오류 수정

### DIFF
--- a/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealCreateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealCreateServiceTest.java
@@ -17,6 +17,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 
 import static ktb.leafresh.backend.support.fixture.ProductFixture.of;
@@ -52,8 +54,8 @@ class TimedealCreateServiceTest {
     void createTimedeal_success() {
         // given
         Product product = of("친환경 주방세제", 3000, 50);
-        LocalDateTime start = LocalDateTime.now().plusHours(1);
-        LocalDateTime end = LocalDateTime.now().plusHours(2);
+        OffsetDateTime start = OffsetDateTime.now(ZoneOffset.UTC).plusHours(1);
+        OffsetDateTime end = OffsetDateTime.now(ZoneOffset.UTC).plusHours(2);
 
         TimedealCreateRequestDto dto = new TimedealCreateRequestDto(
                 product.getId(),
@@ -77,7 +79,7 @@ class TimedealCreateServiceTest {
 
         // then
         assertThat(response.dealId()).isEqualTo(10L);
-        verify(productCacheService).cacheTimedealStock(eq(10L), eq(50), eq(end));
+        verify(productCacheService).cacheTimedealStock(eq(10L), eq(50), eq(end.toLocalDateTime()));
         verify(productCacheService).updateSingleTimedealCache(any(TimedealPolicy.class));
         verify(eventPublisher).publishEvent(any(ProductUpdatedEvent.class));
     }
@@ -87,8 +89,8 @@ class TimedealCreateServiceTest {
     void createTimedeal_fail_productNotFound() {
         TimedealCreateRequestDto dto = new TimedealCreateRequestDto(
                 999L,
-                LocalDateTime.now().plusHours(1),
-                LocalDateTime.now().plusHours(2),
+                OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
+                OffsetDateTime.now(ZoneOffset.UTC).plusHours(2),
                 2000,
                 20
         );
@@ -104,8 +106,8 @@ class TimedealCreateServiceTest {
         Product product = of("친환경 주방세제", 3000, 50);
         TimedealCreateRequestDto dto = new TimedealCreateRequestDto(
                 product.getId(),
-                LocalDateTime.now().plusHours(3),
-                LocalDateTime.now().plusHours(1),
+                OffsetDateTime.now(ZoneOffset.UTC).plusHours(3),
+                OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
                 2000,
                 20
         );
@@ -121,8 +123,8 @@ class TimedealCreateServiceTest {
         Product product = of("친환경 주방세제", 3000, 50);
         TimedealCreateRequestDto dto = new TimedealCreateRequestDto(
                 product.getId(),
-                LocalDateTime.now().plusHours(1),
-                LocalDateTime.now().plusHours(2),
+                OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
+                OffsetDateTime.now(ZoneOffset.UTC).plusHours(2),
                 2000,
                 20
         );
@@ -140,8 +142,8 @@ class TimedealCreateServiceTest {
         Product product = of("친환경 주방세제", 3000, 50);
         TimedealCreateRequestDto dto = new TimedealCreateRequestDto(
                 product.getId(),
-                LocalDateTime.now().plusHours(1),
-                LocalDateTime.now().plusHours(2),
+                OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
+                OffsetDateTime.now(ZoneOffset.UTC).plusHours(2),
                 2000,
                 20
         );

--- a/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealProductReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealProductReadServiceTest.java
@@ -14,6 +14,8 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.ZSetOperations;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Set;
 
@@ -55,8 +57,8 @@ class TimedealProductReadServiceTest {
                         1L, 1L, "비누", "설명",
                         3000, 2000, 30, 10,
                         "https://img.png",
-                        LocalDateTime.now().plusHours(1),
-                        LocalDateTime.now().plusHours(2),
+                        OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
+                        OffsetDateTime.now(ZoneOffset.UTC).plusHours(2),
                         "ACTIVE", "ONGOING"
                 )
         ));
@@ -79,8 +81,8 @@ class TimedealProductReadServiceTest {
                 1L, 1L, "샴푸", "세정력 좋은 샴푸",
                 5000, 3500, 30, 20,
                 "https://img.png",
-                LocalDateTime.now().plusHours(1),
-                LocalDateTime.now().plusHours(2),
+                OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
+                OffsetDateTime.now(ZoneOffset.UTC).plusHours(2),
                 "ACTIVE", "ONGOING"
         );
         when(valueOps.get(ProductCacheKeys.timedealSingle(1L))).thenReturn(dto);
@@ -102,8 +104,8 @@ class TimedealProductReadServiceTest {
                 1L, 1L, "친환경 수세미", "지속 가능한 수세미",
                 3500, 2000, 40, 10,
                 "https://img.png",
-                LocalDateTime.now().plusHours(1),
-                LocalDateTime.now().plusHours(2),
+                OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
+                OffsetDateTime.now(ZoneOffset.UTC).plusHours(2),
                 "ACTIVE", "ONGOING"
         );
         when(queryService.findAllById(List.of(1L))).thenReturn(List.of(fallbackDto));

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentQueryServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentQueryServiceTest.java
@@ -45,14 +45,30 @@ class GroupVerificationCommentQueryServiceTest {
         when(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).thenReturn(Optional.of(verification));
 
         var member = of(loginMemberId, "test@leafresh.com", "테스터");
-        var comment1 = Comment.builder().id(1L).member(member).verification(verification).content("댓글1").build();
-        var comment2 = Comment.builder().id(2L).member(member).verification(verification).content("댓글2").build();
 
-        // 필수 필드인 createdAt을 명시적으로 설정
-        ReflectionTestUtils.setField(comment1, "createdAt", java.time.LocalDateTime.now().minusSeconds(10));
-        ReflectionTestUtils.setField(comment2, "createdAt", java.time.LocalDateTime.now());
+        var comment1 = Comment.builder()
+                .id(1L)
+                .member(member)
+                .verification(verification)
+                .content("댓글1")
+                .build();
 
-        when(commentRepository.findAllByVerificationIdWithMember(verificationId)).thenReturn(List.of(comment1, comment2));
+        var comment2 = Comment.builder()
+                .id(2L)
+                .member(member)
+                .verification(verification)
+                .content("댓글2")
+                .build();
+
+        var now = java.time.LocalDateTime.now();
+        ReflectionTestUtils.setField(comment1, "createdAt", now.minusSeconds(10));
+        ReflectionTestUtils.setField(comment1, "updatedAt", now.minusSeconds(5));
+
+        ReflectionTestUtils.setField(comment2, "createdAt", now);
+        ReflectionTestUtils.setField(comment2, "updatedAt", now);
+
+        when(commentRepository.findAllByVerificationIdWithMember(verificationId))
+                .thenReturn(List.of(comment1, comment2));
 
         // When
         List<CommentSummaryResponseDto> result = service.getComments(challengeId, verificationId, loginMemberId);

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentUpdateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentUpdateServiceTest.java
@@ -13,7 +13,9 @@ import ktb.leafresh.backend.global.exception.VerificationErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -62,6 +64,9 @@ class GroupVerificationCommentUpdateServiceTest {
         when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
         when(commentRepository.findById(100L)).thenReturn(Optional.of(comment));
         when(commentRepository.findByParentCommentAndDeletedAtIsNull(comment)).thenReturn(List.of());
+
+        // 수정 로직 후 updatedAt이 null인 상태이므로, 테스트에서 수동 세팅
+        ReflectionTestUtils.setField(comment, "updatedAt", LocalDateTime.now());
 
         // when
         CommentUpdateResponseDto response = service.updateComment(1L, 1L, 100L, 1L, dto);


### PR DESCRIPTION
- 테스트 중 createdAt, updatedAt 필드가 null이거나 타입 불일치로 인해
  atOffset(ZoneOffset.UTC) 호출 시 NullPointerException이 발생하던 문제를 해결
- ReflectionTestUtils.setField(...)를 사용해 LocalDateTime 값을 명시적으로 설정
- Timedeal, Comment 관련 테스트에서 OffsetDateTime → LocalDateTime 변환을 반영
