### PR TITLE
refactor: 참여 챌린지 DTO의 createdAt 타입 분리

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeParticipationReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeParticipationReadService.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 
@@ -56,10 +58,10 @@ public class GroupChallengeParticipationReadService {
                         dto.getSuccess(),
                         dto.getTotal(),
                         achievementRecordMap.getOrDefault(dto.getId(), List.of()),
-                        dto.getCreatedAt().toLocalDateTime()
+                        OffsetDateTime.of(dto.getCreatedAt(), ZoneOffset.UTC)
                 ),
                 GroupChallengeParticipationSummaryDto::id,
-                GroupChallengeParticipationSummaryDto::createdAt
+                dto -> dto.createdAt().toLocalDateTime()
         );
 
         return GroupChallengeParticipationListResponseDto.builder()

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/query/GroupChallengeParticipationDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/query/GroupChallengeParticipationDto.java
@@ -16,7 +16,7 @@ public class GroupChallengeParticipationDto {
     private String endDate;
     private Long success;
     private Long total;
-    private OffsetDateTime createdAt;
+    private LocalDateTime createdAt;
 
     public GroupChallengeParticipationDto(
             Long id,
@@ -26,7 +26,7 @@ public class GroupChallengeParticipationDto {
             String endDate,
             Long success,
             Long total,
-            OffsetDateTime createdAt
+            LocalDateTime createdAt
     ) {
         this.id = id;
         this.title = title;

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeParticipationSummaryDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeParticipationSummaryDto.java
@@ -3,7 +3,7 @@ package ktb.leafresh.backend.domain.challenge.group.presentation.dto.response;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Builder
@@ -16,7 +16,7 @@ public record GroupChallengeParticipationSummaryDto(
         AchievementDto achievement,
         List<AchievementRecordDto> achievementRecords,
         @JsonIgnore
-        LocalDateTime createdAt
+        OffsetDateTime createdAt
 ) {
     @Builder
     public record AchievementDto(Long success, Long total) {}
@@ -33,7 +33,7 @@ public record GroupChallengeParticipationSummaryDto(
             Long success,
             Long total,
             List<AchievementRecordDto> achievementRecords,
-            LocalDateTime createdAt
+            OffsetDateTime createdAt
     ) {
         return GroupChallengeParticipationSummaryDto.builder()
                 .id(id)


### PR DESCRIPTION
## 요약
비즈니스 로직에서는 `LocalDateTime`, 프론트엔드 응답 및 커서 기반 페이지네이션에서는 `OffsetDateTime`을 사용하도록 타입을 분리했습니다.

## 작업 내용
- `GroupChallengeParticipationDto`의 `createdAt`을 `LocalDateTime`으로 변경
- `GroupChallengeParticipationSummaryDto`의 `createdAt`을 `OffsetDateTime`으로 변경
- `GroupChallengeParticipationReadService`에서 `OffsetDateTime.of(..., ZoneOffset.UTC)` 변환 처리
- 커서 추출 시 `.toLocalDateTime()` 적용하여 CursorPaginationHelper의 시그니처와 타입 일치

## 이유
- QueryDSL의 constructor projection은 `OffsetDateTime` 매핑 시 런타임 오류 발생 가능성이 있음
- DB의 `TIMESTAMP` 컬럼은 `LocalDateTime`으로 매핑되는 것이 자연스럽고 안정적임
- 응답에는 명시적인 시간대 정보가 포함된 `OffsetDateTime`(UTC) 사용이 적절함
