### PR TITLE
refactor: 타임딜 조회 및 일반 상품 재고 캐싱 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.23.4'
 
 	// RedisBloom + Jedis
 	implementation 'com.github.RedisBloom:JRedisBloom:2.1.0'

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealProductReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealProductReadService.java
@@ -27,95 +27,110 @@ public class TimedealProductReadService {
     public TimedealProductListResponseDto findTimedealProducts() {
         log.info("[TimedealProductReadService] 타임딜 목록 조회 요청");
 
-        // 1. 목록 캐시 확인
+        // 1. 목록 캐시 조회
         Object cachedList = redisTemplate.opsForValue().get(ProductCacheKeys.TIMEDEAL_LIST);
-        List<TimedealProductSummaryResponseDto> result;
         if (cachedList != null) {
             log.info("[TimedealProductReadService] 목록 캐시 HIT - key={}", ProductCacheKeys.TIMEDEAL_LIST);
             TimedealProductListResponseDto cachedDto = objectMapper.convertValue(cachedList, TimedealProductListResponseDto.class);
-            result = cachedDto.timeDeals();
-        } else {
-            log.info("[TimedealProductReadService] 목록 캐시 MISS - key={}", ProductCacheKeys.TIMEDEAL_LIST);
+            return refreshTimedealStatus(cachedDto);
+        }
 
-            // 2. ZSET 조회
-            long now = System.currentTimeMillis();
-            long oneWeekLater = LocalDateTime.now().plusDays(7)
-                    .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
-            long twoHoursBeforeNow = LocalDateTime.now().minusHours(2)
-                    .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        // 2. ZSET 범위 조회
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        long from = now.minusHours(2).toInstant().toEpochMilli();
+        long to = now.plusWeeks(1).toInstant().toEpochMilli();
 
-            Set<Object> dealIds = redisTemplate.opsForZSet()
-                    .rangeByScore(ProductCacheKeys.TIMEDEAL_ZSET, twoHoursBeforeNow, oneWeekLater);
+        Set<Object> dealIds = redisTemplate.opsForZSet()
+                .rangeByScore(ProductCacheKeys.TIMEDEAL_ZSET, from, to);
 
-            result = new ArrayList<>();
-            if (dealIds != null && !dealIds.isEmpty()) {
-                List<Long> missedPolicyIds = new ArrayList<>();
+        if (dealIds != null && !dealIds.isEmpty()) {
+            // 3. 단건 캐시 조회 (ZSET 기반)
+            List<TimedealProductSummaryResponseDto> result = new ArrayList<>();
+            List<Long> missedPolicyIds = new ArrayList<>();
 
-                for (Object policyIdObj : dealIds) {
-                    Long policyId = Long.valueOf(policyIdObj.toString());
-                    String key = ProductCacheKeys.timedealSingle(policyId);
-                    Object cachedDto = redisTemplate.opsForValue().get(key);
+            for (Object policyIdObj : dealIds) {
+                Long policyId = Long.valueOf(policyIdObj.toString());
+                String key = ProductCacheKeys.timedealSingle(policyId);
+                Object cachedDto = redisTemplate.opsForValue().get(key);
 
-                    if (cachedDto != null) {
-                        result.add(objectMapper.convertValue(cachedDto, TimedealProductSummaryResponseDto.class));
-                        log.info("[TimedealProductReadService] 단건 캐시 HIT - key={}", key);
-                    } else {
-                        missedPolicyIds.add(policyId);
-                        log.warn("[TimedealProductReadService] 단건 캐시 MISS - key={}", key);
-                    }
-                }
-
-                // 3. Fallback - 벌크 조회 + 병렬 캐싱
-                if (!missedPolicyIds.isEmpty()) {
-                    log.info("[TimedealProductReadService] DB fallback 시작 - size={}", missedPolicyIds.size());
-
-                    List<TimedealProductSummaryResponseDto> fallbackList =
-                            timedealProductQueryService.findAllById(missedPolicyIds);
-
-                    fallbackList.parallelStream().forEach(dto -> {
-                        String fallbackKey = ProductCacheKeys.timedealSingle(dto.dealId());
-                        long ttl = Duration.between(LocalDateTime.now(), dto.dealEndTime()).toSeconds() + 60;
-                        redisTemplate.opsForValue().set(fallbackKey, dto, Duration.ofSeconds(ttl));
-                        log.info("[TimedealProductReadService] DB fallback 캐시 저장 - key={}, TTL={}초", fallbackKey, ttl);
-                    });
-
-                    result.addAll(fallbackList);
+                if (cachedDto != null) {
+                    result.add(objectMapper.convertValue(cachedDto, TimedealProductSummaryResponseDto.class));
+                    log.info("[TimedealProductReadService] 단건 캐시 HIT - key={}", key);
+                } else {
+                    missedPolicyIds.add(policyId);
+                    log.warn("[TimedealProductReadService] 단건 캐시 MISS - key={}", key);
                 }
             }
 
-            // 4. 목록 캐시 저장
+            // 4. DB fallback (단건 캐시 MISS만)
+            if (!missedPolicyIds.isEmpty()) {
+                log.info("[TimedealProductReadService] DB fallback 시작 - size={}", missedPolicyIds.size());
+
+                List<TimedealProductSummaryResponseDto> fallbackList =
+                        timedealProductQueryService.findAllById(missedPolicyIds);
+
+                fallbackList.parallelStream().forEach(dto -> {
+                    String key = ProductCacheKeys.timedealSingle(dto.dealId());
+                    long ttl = Duration.between(OffsetDateTime.now(ZoneOffset.UTC), dto.dealEndTime()).toSeconds() + 60;
+                    redisTemplate.opsForValue().set(key, dto, Duration.ofSeconds(ttl));
+                    log.info("[TimedealProductReadService] DB fallback 캐시 저장 - key={}, TTL={}초", key, ttl);
+                });
+
+                result.addAll(fallbackList);
+            }
+
+            // 5. 목록 캐시 저장 후 반환
             TimedealProductListResponseDto responseDto = new TimedealProductListResponseDto(result);
             redisTemplate.opsForValue().set(
                     ProductCacheKeys.TIMEDEAL_LIST,
                     responseDto,
                     Duration.ofSeconds(60)
             );
-            log.info("[TimedealProductReadService] 목록 캐시 저장 - key={}, TTL=60초", ProductCacheKeys.TIMEDEAL_LIST);
+            log.info("[TimedealProductReadService] 목록 캐시 저장 - TTL=60초");
+
+            return refreshTimedealStatus(responseDto);
         }
 
-        // 5. 상태값 동적 갱신
-        LocalDateTime nowTime = LocalDateTime.now();
-        List<TimedealProductSummaryResponseDto> updated = result.stream()
-                .map(dto -> new TimedealProductSummaryResponseDto(
-                        dto.dealId(),
-                        dto.productId(),
-                        dto.title(),
-                        dto.description(),
-                        dto.defaultPrice(),
-                        dto.discountedPrice(),
-                        dto.discountedPercentage(),
-                        dto.stock(),
-                        dto.imageUrl(),
-                        dto.dealStartTime(),
-                        dto.dealEndTime(),
-                        dto.productStatus(),
-                        determineTimeDealStatus(
-                                dto.dealStartTime(),
-                                dto.dealEndTime()
-                        )
-                ))
-                .toList();
+        // 6. ZSET 비어 있음 → fallback: 열려 있는 타임딜 아예 없는지 확인
+        log.warn("[TimedealProductReadService] ZSET 캐시 없음 → DB fallback for active 타임딜");
 
+        List<TimedealProductSummaryResponseDto> activeDeals = timedealProductQueryService.findUpcomingOrOngoingWithinWeek();
+
+        if (activeDeals.isEmpty()) {
+            log.info("[TimedealProductReadService] 현재 열려 있는 타임딜 없음 - 빈 목록 반환");
+            return new TimedealProductListResponseDto(List.of());
+        }
+
+        // 7. 단건 캐시 + ZSet + 목록 캐시 복구
+        activeDeals.parallelStream().forEach(dto -> {
+            String singleKey = ProductCacheKeys.timedealSingle(dto.dealId());
+            long ttl = Duration.between(OffsetDateTime.now(ZoneOffset.UTC), dto.dealEndTime()).toSeconds() + 60;
+            redisTemplate.opsForValue().set(singleKey, dto, Duration.ofSeconds(ttl));
+            long score = dto.dealStartTime().toInstant().toEpochMilli();
+            redisTemplate.opsForZSet().add(ProductCacheKeys.TIMEDEAL_ZSET, dto.dealId(), score);
+            log.info("[TimedealProductReadService] 캐시 재등록 - key={}, score={}", singleKey, score);
+        });
+
+        TimedealProductListResponseDto rebuiltDto = new TimedealProductListResponseDto(activeDeals);
+        redisTemplate.opsForValue().set(
+                ProductCacheKeys.TIMEDEAL_LIST,
+                rebuiltDto,
+                Duration.ofSeconds(60)
+        );
+        log.info("[TimedealProductReadService] 목록 캐시 재등록 - TTL=60초");
+
+        return refreshTimedealStatus(rebuiltDto);
+    }
+
+    private TimedealProductListResponseDto refreshTimedealStatus(TimedealProductListResponseDto dto) {
+        LocalDateTime nowTime = LocalDateTime.now();
+        List<TimedealProductSummaryResponseDto> updated = dto.timeDeals().stream()
+                .map(d -> new TimedealProductSummaryResponseDto(
+                        d.dealId(), d.productId(), d.title(), d.description(),
+                        d.defaultPrice(), d.discountedPrice(), d.discountedPercentage(),
+                        d.stock(), d.imageUrl(), d.dealStartTime(), d.dealEndTime(),
+                        d.productStatus(), determineTimeDealStatus(d.dealStartTime(), d.dealEndTime())
+                )).toList();
         return new TimedealProductListResponseDto(updated);
     }
 

--- a/src/main/java/ktb/leafresh/backend/global/config/RedisConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/RedisConfig.java
@@ -2,6 +2,10 @@ package ktb.leafresh.backend.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -12,6 +16,17 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
+
+    @Value("${redis.redisson.address}")
+    private String redissonAddress;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(redissonAddress);
+        return Redisson.create(config);
+    }
 
     @Bean
     public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory factory) {

--- a/src/main/resources/application-docker-local.yml
+++ b/src/main/resources/application-docker-local.yml
@@ -10,6 +10,14 @@ spring:
       host: ${docker_local_cache_host}
       port: ${docker_local_cache_port}
 
+redis:
+  redisson:
+    address: redis://${SPRING_DATA_REDIS_HOST}:${SPRING_DATA_REDIS_PORT}
+
+  bloom:
+    host: ${docker_local_cache_host}
+    port: ${docker_local_cache_port}
+
 cookie:
   secure: true
   samesite: ${docker_local_cookie_samesite:none}
@@ -21,8 +29,3 @@ gcp:
     location: classpath:${gcp_credentials_location}
   storage:
     bucket: ${gcp_storage_bucket}
-
-redis:
-  bloom:
-    host: ${docker_local_cache_host}
-    port: ${docker_local_cache_port}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,6 +10,14 @@ spring:
       host: ${local_cache_host}
       port: ${local_cache_port}
 
+redis:
+  redisson:
+    address: redis://${SPRING_DATA_REDIS_HOST}:${SPRING_DATA_REDIS_PORT}
+
+  bloom:
+    host: ${local_cache_host}
+    port: ${local_cache_port}
+
   jpa:
     show-sql: true
     properties:
@@ -27,11 +35,6 @@ gcp:
     location: classpath:${gcp_credentials_location}
   storage:
     bucket: ${gcp_storage_bucket}
-
-redis:
-  bloom:
-    host: ${local_cache_host}
-    port: ${local_cache_port}
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,9 @@ spring:
   profiles:
     active: ${spring_profiles_active}
 
+  jackson:
+    time-zone: UTC
+
   security:
     basic:
       enabled: false

--- a/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateServiceTest.java
@@ -6,6 +6,7 @@ import ktb.leafresh.backend.domain.store.order.domain.entity.PurchaseIdempotency
 import ktb.leafresh.backend.domain.store.order.infrastructure.publisher.PurchaseMessagePublisher;
 import ktb.leafresh.backend.domain.store.order.infrastructure.repository.PurchaseIdempotencyKeyRepository;
 import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
 import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.MemberErrorCode;
@@ -32,6 +33,7 @@ class ProductOrderCreateServiceTest {
     private RedisLuaService redisLuaService;
     private PurchaseMessagePublisher purchaseMessagePublisher;
     private ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository memberRepository;
+    private ProductCacheService productCacheService;
 
     @BeforeEach
     void setUp() {
@@ -40,13 +42,15 @@ class ProductOrderCreateServiceTest {
         redisLuaService = mock(RedisLuaService.class);
         purchaseMessagePublisher = mock(PurchaseMessagePublisher.class);
         memberRepository = mock(ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository.class);
+        productCacheService = mock(ProductCacheService.class);
 
         service = new ProductOrderCreateService(
                 memberRepository,
                 productRepository,
                 idempotencyRepository,
                 redisLuaService,
-                purchaseMessagePublisher
+                purchaseMessagePublisher,
+                productCacheService
         );
     }
 


### PR DESCRIPTION
## 요약
- 타임딜 목록 조회 시 ZSet/단건 캐시가 모두 비어 있는 경우, DB fallback을 통해 캐시 재구축
- 일반 상품 재고 조회 시 Redisson 분산락 기반의 캐시 등록 로직 추가
- ProductOrderCreateService에 fallback 로직 적용하여 캐시 스탬피드 방지
- 관련 의존성/설정 추가 및 테스트 수정 포함

## 작업 내용
- `TimedealProductReadService`
  - ZSet 캐시 범위 조회 후 단건 캐시 확인
  - 단건 캐시 MISS 시 DB에서 조회 후 다시 캐시 등록
  - ZSet 자체도 비어있는 경우 → `findUpcomingOrOngoingWithinWeek()` 호출로 완전 복구
  - 최종적으로 목록 캐시 저장 및 상태 갱신

- `ProductCacheService`
  - `getProductStockWithDistributedLock()` 추가 (Redisson 락 기반 double-check 캐시 등록)
  - 일반 상품 재고 캐시 TTL 추가 설정

- `ProductOrderCreateService`
  - 상품 주문 시 재고 캐시 미존재 대비 fallback 호출 추가
  - 캐시 없는 상태에서의 스탬피드 문제 방지

- `RedisConfig`
  - `redissonClient` 등록을 위한 설정 추가 (`redis.redisson.address` 기반)

- `application-local.yml`, `application-docker-local.yml`
  - redisson address 환경변수 구조 통일
  - 중복된 `redis:` 루트 제거

- 테스트 코드
  - `ProductOrderCreateServiceTest` 생성자 변경 반영
  - `ProductCacheService` mock 추가
