### PR TITLE
refactor: TimedealProductSummaryResponseDto에 LocalDateTime 입력 대응 생성자 …

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/response/TimedealProductSummaryResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/presentation/dto/response/TimedealProductSummaryResponseDto.java
@@ -1,6 +1,10 @@
 package ktb.leafresh.backend.domain.store.product.presentation.dto.response;
 
+import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
+
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 public record TimedealProductSummaryResponseDto(
         Long dealId,
@@ -16,4 +20,65 @@ public record TimedealProductSummaryResponseDto(
         OffsetDateTime dealEndTime,
         String productStatus,      // ACTIVE or SOLD_OUT
         String timeDealStatus      // ONGOING or UPCOMING
-) {}
+) {
+    public TimedealProductSummaryResponseDto(
+            Long dealId,
+            Long productId,
+            String title,
+            String description,
+            int defaultPrice,
+            int discountedPrice,
+            int discountedPercentage,
+            int stock,
+            String imageUrl,
+            LocalDateTime dealStartTime,
+            LocalDateTime dealEndTime,
+            String productStatus,
+            String timeDealStatus
+    ) {
+        this(
+                dealId,
+                productId,
+                title,
+                description,
+                defaultPrice,
+                discountedPrice,
+                discountedPercentage,
+                stock,
+                imageUrl,
+                dealStartTime.atOffset(ZoneOffset.UTC),
+                dealEndTime.atOffset(ZoneOffset.UTC),
+                productStatus,
+                timeDealStatus
+        );
+    }
+
+    public static TimedealProductSummaryResponseDto from(TimedealPolicy policy) {
+        var product = policy.getProduct();
+        var now = LocalDateTime.now(ZoneOffset.UTC);
+
+        String productStatus = switch (product.getStatus()) {
+            case SOLD_OUT -> "SOLD_OUT";
+            case ACTIVE -> "ACTIVE";
+            default -> "INACTIVE";
+        };
+
+        String timeDealStatus = now.isBefore(policy.getStartTime()) ? "UPCOMING" : "ONGOING";
+
+        return new TimedealProductSummaryResponseDto(
+                policy.getId(),
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getPrice(),
+                policy.getDiscountedPrice(),
+                policy.getDiscountedPercentage(),
+                policy.getStock(),
+                product.getImageUrl(),
+                policy.getStartTime(),
+                policy.getEndTime(),
+                productStatus,
+                timeDealStatus
+        );
+    }
+}


### PR DESCRIPTION
## 요약
- TimedealProductSummaryResponseDto에 LocalDateTime → OffsetDateTime 변환을 위한 생성자 오버로딩 추가
- from(TimedealPolicy) 정적 팩토리 메서드에서 productStatus, timeDealStatus 계산 로직 정리

## 작업 내용
- LocalDateTime 기반 입력을 받을 수 있도록 생성자 추가 (OffsetDateTime으로 변환)
- 정책 시작 시간과 현재 시점을 비교하여 timeDealStatus를 ONGOING 또는 UPCOMING으로 계산
- ProductStatus enum 값을 기반으로 문자열로 변환된 productStatus 지정

## 비고
- 추후 Enum 타입으로 리팩토링 고려
- 현재 UTC 기반 LocalDateTime 기준 계산
