### PR TITLE
fix: 인증 상세 조회 시 verifiedAt null 처리

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeVerificationDetailResponseDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/presentation/dto/response/GroupChallengeVerificationDetailResponseDto.java
@@ -47,7 +47,7 @@ public record GroupChallengeVerificationDetailResponseDto(
                 .content(v.getContent())
                 .category(challenge.getCategory().getName())
                 .status(v.getStatus().name())
-                .verifiedAt(v.getVerifiedAt().atOffset(ZoneOffset.UTC))
+                .verifiedAt(v.getVerifiedAt() != null ? v.getVerifiedAt().atOffset(ZoneOffset.UTC) : null)
                 .counts(new Counts(
                         parseStat(cachedStats, "viewCount", v.getViewCount()),
                         parseStat(cachedStats, "likeCount", v.getLikeCount()),


### PR DESCRIPTION
## 요약
인증 상세 조회 API에서 `verifiedAt`이 null일 경우 NPE가 발생하던 문제를 수정했습니다.

## 작업 내용
- `GroupChallengeVerificationDetailResponseDto.from()` 메서드에서 `verifiedAt`을 null-safe 처리
- 향후 nullable 필드에 대해 방어적 코딩 적용
