### PR TITLE
refactor: 누적 나뭇잎·인증 수 캐시 TTL 적용 및 RedissonLock 기반 fallback 처리

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountReadService.java
@@ -5,8 +5,13 @@ import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.VerificationErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -14,8 +19,11 @@ import org.springframework.stereotype.Service;
 public class VerificationCountReadService {
 
     private final StringRedisTemplate redisTemplate;
+    private final VerificationCountQueryService verificationCountQueryService;
+    private final RedissonClient redissonClient;
 
     private static final String TOTAL_VERIFICATION_COUNT_KEY = "leafresh:totalVerifications:count";
+    private static final String LOCK_KEY = "lock:leafresh:totalVerifications:count";
 
     public VerificationCountResponseDto getTotalVerificationCount() {
         try {
@@ -25,11 +33,42 @@ public class VerificationCountReadService {
                 return new VerificationCountResponseDto(Integer.parseInt(cached));
             }
 
-            log.warn("[VerificationCountReadService] Redis cache miss. Returning 0.");
-            return new VerificationCountResponseDto(0);
+            log.warn("[VerificationCountReadService] Redis cache miss. Trying Redisson lock...");
+            RLock lock = redissonClient.getLock(LOCK_KEY);
+            boolean isLocked = lock.tryLock(2, 5, TimeUnit.SECONDS);
+
+            if (isLocked) {
+                try {
+                    String retry = redisTemplate.opsForValue().get(TOTAL_VERIFICATION_COUNT_KEY);
+                    if (retry != null) {
+                        log.debug("[VerificationCountReadService] Redis re-check after lock: {}", retry);
+                        return new VerificationCountResponseDto(Integer.parseInt(retry));
+                    }
+
+                    int total = verificationCountQueryService.getTotalVerificationCountFromDB();
+                    redisTemplate.opsForValue()
+                            .set(TOTAL_VERIFICATION_COUNT_KEY, String.valueOf(total), Duration.ofHours(24));
+                    log.info("[VerificationCountReadService] Redis cache refresh 완료: {}", total);
+
+                    return new VerificationCountResponseDto(total);
+                } finally {
+                    lock.unlock();
+                }
+            } else {
+                log.warn("[VerificationCountReadService] Redisson lock 획득 실패. 대기 후 캐시 재조회");
+                Thread.sleep(200);
+                String fallback = redisTemplate.opsForValue().get(TOTAL_VERIFICATION_COUNT_KEY);
+                if (fallback != null) {
+                    return new VerificationCountResponseDto(Integer.parseInt(fallback));
+                }
+                throw new CustomException(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
+            }
 
         } catch (NumberFormatException e) {
             log.error("[VerificationCountReadService] Redis 캐시 값 파싱 실패", e);
+            throw new CustomException(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new CustomException(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
         } catch (Exception e) {
             log.error("[VerificationCountReadService] Redis 조회 중 알 수 없는 에러", e);

--- a/src/main/java/ktb/leafresh/backend/global/initializer/LeafPointInitializer.java
+++ b/src/main/java/ktb/leafresh/backend/global/initializer/LeafPointInitializer.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -21,7 +23,7 @@ public class LeafPointInitializer {
     public void initializeLeafPointCache() {
         try {
             int sum = memberLeafPointQueryRepository.getTotalLeafPointSum();
-            redisTemplate.opsForValue().set(TOTAL_LEAF_SUM_KEY, String.valueOf(sum));
+            redisTemplate.opsForValue().set(TOTAL_LEAF_SUM_KEY, String.valueOf(sum), Duration.ofHours(24));
             log.info("[LeafPointInitializer] Redis 누적 나뭇잎 합계 초기화 완료: {}", sum);
         } catch (Exception e) {
             log.error("[LeafPointInitializer] Redis 초기화 실패", e);

--- a/src/main/java/ktb/leafresh/backend/global/initializer/VerificationCountInitializer.java
+++ b/src/main/java/ktb/leafresh/backend/global/initializer/VerificationCountInitializer.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -21,7 +23,8 @@ public class VerificationCountInitializer {
     public void initializeVerificationCountCache() {
         try {
             int total = queryService.getTotalVerificationCountFromDB();
-            redisTemplate.opsForValue().set(TOTAL_VERIFICATION_COUNT_KEY, String.valueOf(total));
+            redisTemplate.opsForValue()
+                    .set(TOTAL_VERIFICATION_COUNT_KEY, String.valueOf(total), Duration.ofHours(24));
             log.info("[VerificationCountInitializer] Redis 누적 인증 수 초기화 완료: {}", total);
         } catch (Exception e) {
             log.error("[VerificationCountInitializer] Redis 초기화 실패", e);


### PR DESCRIPTION
## 요약
- Redis 캐시 스탬피드 방지를 위해 Redisson 기반 분산 락 적용
- 누적 나뭇잎 수, 누적 인증 수 캐시 TTL 24시간으로 설정하여 DB 부하 최소화
- 타임딜 구매 성공 시 단건 캐시 자동 갱신 처리

## 작업 내용
- `LeafPointReadService` / `VerificationCountReadService`에 Redisson `tryLock` 적용
  - 락 획득 실패 시 short sleep 후 재시도 방식으로 fail-safe 처리
- TTL 미설정 상태였던 누적 캐시 데이터에 TTL 24시간 추가 적용
- `PurchaseProcessor` 내 타임딜 구매 성공 후 캐시된 상품 요약 정보 갱신 로직 추가

## 기타
- 락 키는 `lock:leafresh:totalLeafPoints:sum`, `lock:leafresh:totalVerifications:count` 형식으로 prefix 일관성 유지
- 향후 공통 분산 캐시 fallback 유틸로 리팩토링 고려 가능
