### PR TITLE
feat: Redisson 분산락 AOP 구현 및 VerificationStat 도메인 적용

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/scheduler/VerificationStatSyncScheduler.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/scheduler/VerificationStatSyncScheduler.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import ktb.leafresh.backend.domain.verification.infrastructure.cache.VerificationCacheKeys;
 import ktb.leafresh.backend.domain.verification.infrastructure.cache.VerificationStatCacheService;
 import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.global.lock.annotation.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -20,14 +21,12 @@ import java.util.Set;
 public class VerificationStatSyncScheduler {
 
     private static final int MAX_BATCH_SIZE = 100;
+    private static final String LOG_PREFIX = "[VerificationStatSyncScheduler]";
 
     private final StringRedisTemplate stringRedisTemplate;
-    private final VerificationStatCacheService verificationStatCacheService;
+    private final VerificationStatCacheService cacheService;
     private final GroupChallengeVerificationRepository verificationRepository;
 
-    /**
-     * 5분마다 Redis → DB로 증가분 누적 동기화
-     */
     @Transactional
     @Scheduled(fixedDelay = 5 * 60 * 1000)
     @SchedulerLock(name = "VerificationStatSyncScheduler", lockAtLeastFor = "1m", lockAtMostFor = "10m")
@@ -36,71 +35,175 @@ public class VerificationStatSyncScheduler {
                 .distinctRandomMembers(VerificationCacheKeys.dirtySetKey(), MAX_BATCH_SIZE);
 
         if (dirtyIds == null || dirtyIds.isEmpty()) {
-            log.debug("[VerificationStatSyncScheduler] 동기화 대상 없음");
+            log.debug("{} 동기화 대상 없음", LOG_PREFIX);
             return;
         }
 
-        log.info("[VerificationStatSyncScheduler] 동기화 시작 - 대상 수: {}", dirtyIds.size());
+        log.info("{} 동기화 시작 - 대상 수: {}", LOG_PREFIX, dirtyIds.size());
 
         for (String idStr : dirtyIds) {
-            Long verificationId;
-            try {
-                verificationId = Long.valueOf(idStr);
-            } catch (NumberFormatException e) {
-                log.warn("[VerificationStatSyncScheduler] 잘못된 ID 형식: {}", idStr);
-                continue;
-            }
-
-            Map<Object, Object> stats;
-            try {
-                stats = verificationStatCacheService.getStats(verificationId);
-            } catch (Exception redisEx) {
-                log.warn("[VerificationStatSyncScheduler] Redis 조회 실패 - verificationId={}, error={}",
-                        verificationId, redisEx.getMessage(), redisEx);
-                continue;
-            }
-
-            if (stats == null || stats.isEmpty()) {
-                verificationStatCacheService.clearStats(verificationId);
-                log.debug("[VerificationStatSyncScheduler] 캐시 없음 - verificationId={}", verificationId);
-                continue;
-            }
-
-            try {
-                var before = verificationRepository.findStatById(verificationId)
-                        .orElseThrow(() -> new IllegalStateException("존재하지 않는 verificationId: " + verificationId));
-
-                int view = Integer.parseInt(stats.getOrDefault("viewCount", "0").toString());
-                int like = Integer.parseInt(stats.getOrDefault("likeCount", "0").toString());
-                int comment = Integer.parseInt(stats.getOrDefault("commentCount", "0").toString());
-
-                int deltaView = view - before.getViewCount();
-                int deltaLike = like - before.getLikeCount();
-                int deltaComment = comment - before.getCommentCount();
-
-                if (deltaView == 0 && deltaLike == 0 && deltaComment == 0) {
-                    verificationStatCacheService.clearStats(verificationId);
-                    continue;
-                }
-
-                verificationRepository.increaseCounts(verificationId, deltaView, deltaLike, deltaComment);
-
-                verificationStatCacheService.clearStats(verificationId);
-
-                log.info(
-                        "[VerificationStatSyncScheduler] 동기화 완료 - verificationId={} | view(+{}): {} → {}, like(+{}): {} → {}, comment(+{}): {} → {}",
-                        verificationId,
-                        view, before.getViewCount(), before.getViewCount() + view,
-                        like, before.getLikeCount(), before.getLikeCount() + like,
-                        comment, before.getCommentCount(), before.getCommentCount() + comment
-                );
-
-            } catch (Exception e) {
-                log.error("[VerificationStatSyncScheduler] 동기화 실패 - verificationId={}, message={}",
-                        verificationId, e.getMessage(), e);
-            }
+            syncStat(idStr);
         }
 
-        log.info("[VerificationStatSyncScheduler] 동기화 종료");
+        log.info("{} 동기화 종료", LOG_PREFIX);
+    }
+
+    @DistributedLock(key = "'syncVerificationStat:' + #idStr")
+    private void syncStat(String idStr) {
+        Long verificationId = extractVerificationId(idStr);
+        if (verificationId == null) return;
+
+        Map<Object, Object> stats = getStatsSafely(verificationId);
+        if (stats == null || stats.isEmpty()) {
+            cacheService.clearStats(verificationId);
+            log.debug("{} 캐시 없음 - verificationId={}", LOG_PREFIX, verificationId);
+            return;
+        }
+
+        try {
+            var before = verificationRepository.findStatById(verificationId)
+                    .orElseThrow(() -> new IllegalStateException("존재하지 않는 verificationId: " + verificationId));
+
+            int view = toInt(stats.get("viewCount"));
+            int like = toInt(stats.get("likeCount"));
+            int comment = toInt(stats.get("commentCount"));
+
+            int deltaView = view - before.getViewCount();
+            int deltaLike = like - before.getLikeCount();
+            int deltaComment = comment - before.getCommentCount();
+
+            if (deltaView == 0 && deltaLike == 0 && deltaComment == 0) {
+                cacheService.clearStats(verificationId);
+                return;
+            }
+
+            verificationRepository.increaseCounts(verificationId, deltaView, deltaLike, deltaComment);
+            cacheService.clearStats(verificationId);
+
+            log.info(
+                    "{} 동기화 완료 - verificationId={} | view(+{}): {}→{}, like(+{}): {}→{}, comment(+{}): {}→{}",
+                    LOG_PREFIX,
+                    verificationId,
+                    deltaView, before.getViewCount(), before.getViewCount() + deltaView,
+                    deltaLike, before.getLikeCount(), before.getLikeCount() + deltaLike,
+                    deltaComment, before.getCommentCount(), before.getCommentCount() + deltaComment
+            );
+
+        } catch (Exception e) {
+            log.error("{} 동기화 실패 - verificationId={}, message={}", LOG_PREFIX, verificationId, e.getMessage(), e);
+        }
+    }
+
+    private Long extractVerificationId(String idStr) {
+        try {
+            return Long.valueOf(idStr);
+        } catch (NumberFormatException e) {
+            log.warn("{} 잘못된 ID 형식: {}", LOG_PREFIX, idStr);
+            return null;
+        }
+    }
+
+    private Map<Object, Object> getStatsSafely(Long verificationId) {
+        try {
+            return cacheService.getStats(verificationId);
+        } catch (Exception e) {
+            log.warn("{} Redis 조회 실패 - verificationId={}, error={}", LOG_PREFIX, verificationId, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private int toInt(Object val) {
+        return Integer.parseInt(val == null ? "0" : val.toString());
     }
 }
+
+//@Slf4j
+//@Component
+//@RequiredArgsConstructor
+//public class VerificationStatSyncScheduler {
+//
+//    private static final int MAX_BATCH_SIZE = 100;
+//
+//    private final StringRedisTemplate stringRedisTemplate;
+//    private final VerificationStatCacheService verificationStatCacheService;
+//    private final GroupChallengeVerificationRepository verificationRepository;
+//
+//    /**
+//     * 5분마다 Redis → DB로 증가분 누적 동기화
+//     */
+//    @Transactional
+//    @Scheduled(fixedDelay = 5 * 60 * 1000)
+//    @SchedulerLock(name = "VerificationStatSyncScheduler", lockAtLeastFor = "1m", lockAtMostFor = "10m")
+//    public void syncVerificationStats() {
+//        Set<String> dirtyIds = stringRedisTemplate.opsForSet()
+//                .distinctRandomMembers(VerificationCacheKeys.dirtySetKey(), MAX_BATCH_SIZE);
+//
+//        if (dirtyIds == null || dirtyIds.isEmpty()) {
+//            log.debug("[VerificationStatSyncScheduler] 동기화 대상 없음");
+//            return;
+//        }
+//
+//        log.info("[VerificationStatSyncScheduler] 동기화 시작 - 대상 수: {}", dirtyIds.size());
+//
+//        for (String idStr : dirtyIds) {
+//            Long verificationId;
+//            try {
+//                verificationId = Long.valueOf(idStr);
+//            } catch (NumberFormatException e) {
+//                log.warn("[VerificationStatSyncScheduler] 잘못된 ID 형식: {}", idStr);
+//                continue;
+//            }
+//
+//            Map<Object, Object> stats;
+//            try {
+//                stats = verificationStatCacheService.getStats(verificationId);
+//            } catch (Exception redisEx) {
+//                log.warn("[VerificationStatSyncScheduler] Redis 조회 실패 - verificationId={}, error={}",
+//                        verificationId, redisEx.getMessage(), redisEx);
+//                continue;
+//            }
+//
+//            if (stats == null || stats.isEmpty()) {
+//                verificationStatCacheService.clearStats(verificationId);
+//                log.debug("[VerificationStatSyncScheduler] 캐시 없음 - verificationId={}", verificationId);
+//                continue;
+//            }
+//
+//            try {
+//                var before = verificationRepository.findStatById(verificationId)
+//                        .orElseThrow(() -> new IllegalStateException("존재하지 않는 verificationId: " + verificationId));
+//
+//                int view = Integer.parseInt(stats.getOrDefault("viewCount", "0").toString());
+//                int like = Integer.parseInt(stats.getOrDefault("likeCount", "0").toString());
+//                int comment = Integer.parseInt(stats.getOrDefault("commentCount", "0").toString());
+//
+//                int deltaView = view - before.getViewCount();
+//                int deltaLike = like - before.getLikeCount();
+//                int deltaComment = comment - before.getCommentCount();
+//
+//                if (deltaView == 0 && deltaLike == 0 && deltaComment == 0) {
+//                    verificationStatCacheService.clearStats(verificationId);
+//                    continue;
+//                }
+//
+//                verificationRepository.increaseCounts(verificationId, deltaView, deltaLike, deltaComment);
+//
+//                verificationStatCacheService.clearStats(verificationId);
+//
+//                log.info(
+//                        "[VerificationStatSyncScheduler] 동기화 완료 - verificationId={} | view(+{}): {} → {}, like(+{}): {} → {}, comment(+{}): {} → {}",
+//                        verificationId,
+//                        view, before.getViewCount(), before.getViewCount() + view,
+//                        like, before.getLikeCount(), before.getLikeCount() + like,
+//                        comment, before.getCommentCount(), before.getCommentCount() + comment
+//                );
+//
+//            } catch (Exception e) {
+//                log.error("[VerificationStatSyncScheduler] 동기화 실패 - verificationId={}, message={}",
+//                        verificationId, e.getMessage(), e);
+//            }
+//        }
+//
+//        log.info("[VerificationStatSyncScheduler] 동기화 종료");
+//    }
+//}

--- a/src/main/java/ktb/leafresh/backend/global/config/RedisConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/RedisConfig.java
@@ -2,10 +2,6 @@ package ktb.leafresh.backend.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.redisson.Redisson;
-import org.redisson.api.RedissonClient;
-import org.redisson.config.Config;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -16,17 +12,6 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
-
-    @Value("${redis.redisson.address}")
-    private String redissonAddress;
-
-    @Bean
-    public RedissonClient redissonClient() {
-        Config config = new Config();
-        config.useSingleServer()
-                .setAddress(redissonAddress);
-        return Redisson.create(config);
-    }
 
     @Bean
     public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory factory) {

--- a/src/main/java/ktb/leafresh/backend/global/config/RedissonConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/RedissonConfig.java
@@ -1,0 +1,24 @@
+package ktb.leafresh.backend.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${redis.redisson.address}")
+    private String redissonAddress;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        RedissonClient redisson = null;
+        Config config = new Config();
+        config.useSingleServer().setAddress(redissonAddress);
+        redisson = Redisson.create(config);
+        return redisson;
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/lock/annotation/DistributedLock.java
+++ b/src/main/java/ktb/leafresh/backend/global/lock/annotation/DistributedLock.java
@@ -1,0 +1,35 @@
+package ktb.leafresh.backend.global.lock.annotation;
+
+import java.lang.annotation.*;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Redisson Distributed Lock annotation
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    /**
+     * 락의 이름
+     */
+    String key();
+
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락을 기다리는 시간 (default - 5s)
+     * 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    long waitTime() default 5L;
+
+
+    /**
+     * 락 임대 시간 (default - 3s)
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 3L;
+}

--- a/src/main/java/ktb/leafresh/backend/global/lock/aop/AopForTransaction.java
+++ b/src/main/java/ktb/leafresh/backend/global/lock/aop/AopForTransaction.java
@@ -1,0 +1,18 @@
+package ktb.leafresh.backend.global.lock.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * AOP에서 트랜잭션 분리를 위한 클래스
+ */
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/lock/aop/DistributedLockAop.java
+++ b/src/main/java/ktb/leafresh/backend/global/lock/aop/DistributedLockAop.java
@@ -1,0 +1,61 @@
+package ktb.leafresh.backend.global.lock.aop;
+
+import ktb.leafresh.backend.global.lock.annotation.DistributedLock;
+import ktb.leafresh.backend.global.lock.util.CustomSpringELParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+/**
+ * @DistributedLock 선언 시 수행되는 Aop class
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAop {
+    private static final String LOCK_PREFIX = "lock:";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(ktb.leafresh.backend.global.lock.annotation.DistributedLock)")
+    public Object lock(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = LOCK_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        RLock rLock = redissonClient.getLock(key);
+
+        boolean isLocked = false;
+        try {
+            isLocked = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            if (!isLocked) {
+                log.warn("[DistributedLockAop] Lock 획득 실패 - key={}", key);
+                return false;
+            }
+
+            return aopForTransaction.proceed(joinPoint);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
+        } finally {
+            if (isLocked && rLock.isHeldByCurrentThread()) {
+                try {
+                    rLock.unlock();
+                    log.debug("[DistributedLockAop] Lock 해제 - key={}", key);
+                } catch (IllegalMonitorStateException e) {
+                    log.info("[DistributedLockAop] 이미 unlock된 lock입니다 - method={}, key={}", method.getName(), key);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/lock/util/CustomSpringELParser.java
+++ b/src/main/java/ktb/leafresh/backend/global/lock/util/CustomSpringELParser.java
@@ -1,0 +1,23 @@
+package ktb.leafresh.backend.global.lock.util;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/**
+ * Spring Expression Language Parser
+ */
+public class CustomSpringELParser {
+    private CustomSpringELParser() {}
+
+    public static String getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, String.class);
+    }
+}


### PR DESCRIPTION
## 작업 개요
VerificationStatSyncScheduler에 Redisson 기반 분산락을 AOP 방식으로 적용하였습니다. 기존의 tryLock → unlock 처리 및 중복 로직을 제거하고, 선언적 분산락 구조로 리팩토링하였습니다.

## 주요 변경 사항
- `@DistributedLock` 어노테이션 정의 및 AOP 적용
- `AopForTransaction` 클래스 추가 (REQUIRES_NEW 트랜잭션 실행용)
- `CustomSpringELParser` 유틸로 SpEL 기반 키 추출 지원
- `RedissonConfig` 클래스 추가하여 RedissonClient 빈 분리
- VerificationStat 서비스의 직접 락 처리 제거 후 AOP 방식으로 일원화

## 기타 참고 사항
- 기존 `ShedLock` 적용된 `VerificationStatSyncScheduler`는 유지하면서, 병렬 처리 구간인 `syncStat`에만 분산락 적용하였습니다.
- 분산락 키는 `"lock:{prefix}"` 형태로 설정되어 있음
