### PR TITLE
refactor: 분산락 책임을 Facade로 일원화

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/LeafPointReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/LeafPointReadService.java
@@ -4,6 +4,7 @@ import ktb.leafresh.backend.global.exception.LeafPointErrorCode;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberLeafPointQueryRepository;
 import ktb.leafresh.backend.domain.member.presentation.dto.response.TotalLeafPointResponseDto;
 import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.lock.annotation.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
@@ -21,59 +22,30 @@ public class LeafPointReadService {
 
     private final StringRedisTemplate redisTemplate;
     private final MemberLeafPointQueryRepository memberLeafPointQueryRepository;
-    private final RedissonClient redissonClient;
 
     private static final String TOTAL_LEAF_SUM_KEY = "leafresh:totalLeafPoints:sum";
-    private static final String TOTAL_LEAF_SUM_LOCK_KEY = "lock:leafresh:totalLeafPoints:sum";
 
+    @DistributedLock(key = "'leafresh:totalLeafPoints:sum'")
     public TotalLeafPointResponseDto getTotalLeafPoints() {
         try {
+            // 락 획득 후 재확인
             String cached = redisTemplate.opsForValue().get(TOTAL_LEAF_SUM_KEY);
             if (cached != null) {
-                log.debug("[LeafPointReadService] Redis cache hit: {}", cached);
+                log.debug("[LeafPointReadService] Redis cache hit after lock: {}", cached);
                 return new TotalLeafPointResponseDto(Integer.parseInt(cached));
             }
 
-            log.warn("[LeafPointReadService] Redis cache miss. Trying Redisson lock...");
-            RLock lock = redissonClient.getLock(TOTAL_LEAF_SUM_LOCK_KEY);
-            boolean isLocked = lock.tryLock(2, 5, TimeUnit.SECONDS);
-
-            if (isLocked) {
-                try {
-                    String retryCached = redisTemplate.opsForValue().get(TOTAL_LEAF_SUM_KEY);
-                    if (retryCached != null) {
-                        log.debug("[LeafPointReadService] Redis cache filled by other thread: {}", retryCached);
-                        return new TotalLeafPointResponseDto(Integer.parseInt(retryCached));
-                    }
-
-                    int sum = memberLeafPointQueryRepository.getTotalLeafPointSum();
-                    redisTemplate.opsForValue().set(
-                            TOTAL_LEAF_SUM_KEY, String.valueOf(sum), Duration.ofHours(24)
-                    );
-                    log.info("[LeafPointReadService] Redis cache set after DB fallback: {}", sum);
-                    return new TotalLeafPointResponseDto(sum);
-                } finally {
-                    lock.unlock();
-                }
-            } else {
-                log.warn("[LeafPointReadService] Redisson lock 획득 실패. Waiting and retrying Redis...");
-                Thread.sleep(200);
-                String retry = redisTemplate.opsForValue().get(TOTAL_LEAF_SUM_KEY);
-                if (retry != null) {
-                    return new TotalLeafPointResponseDto(Integer.parseInt(retry));
-                } else {
-                    throw new CustomException(LeafPointErrorCode.REDIS_FAILURE);
-                }
-            }
-
+            int sum = memberLeafPointQueryRepository.getTotalLeafPointSum();
+            redisTemplate.opsForValue().set(
+                    TOTAL_LEAF_SUM_KEY,
+                    String.valueOf(sum),
+                    Duration.ofHours(24)
+            );
+            log.info("[LeafPointReadService] Redis cache set after DB fallback: {}", sum);
+            return new TotalLeafPointResponseDto(sum);
         } catch (NumberFormatException e) {
-            log.error("[LeafPointReadService] Redis 캐시 값 변환 실패", e);
-            throw new CustomException(LeafPointErrorCode.REDIS_FAILURE);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
             throw new CustomException(LeafPointErrorCode.REDIS_FAILURE);
         } catch (Exception e) {
-            log.error("[LeafPointReadService] 누적 나뭇잎 수 조회 실패", e);
             throw new CustomException(LeafPointErrorCode.DB_QUERY_FAILED);
         }
     }

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/facade/ProductCacheLockFacade.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/facade/ProductCacheLockFacade.java
@@ -1,0 +1,47 @@
+package ktb.leafresh.backend.domain.store.order.application.facade;
+
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
+import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
+import ktb.leafresh.backend.global.lock.annotation.DistributedLock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ProductCacheLockFacade {
+
+    private final ProductCacheService productCacheService;
+
+    @DistributedLock(key = "#product.id.toString()")
+    public void updateSingleProductCache(Product product) {
+        productCacheService.updateSingleProductCache(product);
+    }
+
+    @DistributedLock(key = "#policy.id.toString()")
+    public void updateSingleTimedealCache(TimedealPolicy policy) {
+        productCacheService.updateSingleTimedealCache(policy);
+    }
+
+    @DistributedLock(key = "#product.id.toString()")
+    public void evictCacheByProduct(Product product) {
+        productCacheService.evictCacheByProduct(product);
+    }
+
+    @DistributedLock(key = "#policy.id.toString()")
+    public void evictTimedealCache(TimedealPolicy policy) {
+        productCacheService.evictTimedealCache(policy);
+    }
+
+    @DistributedLock(key = "#productId.toString()")
+    public void cacheProductStock(Long productId, Integer stock) {
+        productCacheService.cacheProductStock(productId, stock);
+    }
+
+    @DistributedLock(key = "#policyId.toString()")
+    public void cacheTimedealStock(Long policyId, Integer stock, LocalDateTime endTime) {
+        productCacheService.cacheTimedealStock(policyId, stock, endTime);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/TimedealOrderCreateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/TimedealOrderCreateService.java
@@ -10,6 +10,7 @@ import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
 import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheKeys;
 import ktb.leafresh.backend.domain.store.product.infrastructure.repository.TimedealPolicyRepository;
 import ktb.leafresh.backend.global.exception.*;
+import ktb.leafresh.backend.global.lock.annotation.DistributedLock;
 import ktb.leafresh.backend.global.util.redis.RedisLuaService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +31,7 @@ public class TimedealOrderCreateService {
     private final RedisLuaService redisLuaService;
     private final PurchaseMessagePublisher purchaseMessagePublisher;
 
+    @DistributedLock(key = "'timedeal:stock:' + #dealId", waitTime = 0, leaseTime = 3)
     @Transactional
     public void create(Long memberId, Long dealId, int quantity, String idempotencyKey) {
         // 1. 사용자 조회

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/application/listener/ProductEventListener.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/application/listener/ProductEventListener.java
@@ -1,5 +1,6 @@
 package ktb.leafresh.backend.domain.store.product.application.listener;
 
+import ktb.leafresh.backend.domain.store.order.application.facade.ProductCacheLockFacade;
 import ktb.leafresh.backend.domain.store.product.application.event.ProductUpdatedEvent;
 import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
 import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
@@ -14,7 +15,7 @@ import org.springframework.transaction.event.TransactionPhase;
 @RequiredArgsConstructor
 public class ProductEventListener {
 
-    private final ProductCacheService productCacheService;
+    private final ProductCacheLockFacade productCacheLockFacade;
     private final ProductRepository productRepository;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -27,7 +28,7 @@ public class ProductEventListener {
         }
 
         productRepository.findById(productId).ifPresent(product -> {
-            productCacheService.updateSingleProductCache(product);
+            productCacheLockFacade.updateSingleProductCache(product);
             log.info("[ProductEventListener] 개별 상품 캐시 갱신 완료 - productId={}, isTimeDeal={}", productId, event.isTimeDeal());
         });
     }

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/ProductCreateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/application/service/ProductCreateService.java
@@ -1,5 +1,6 @@
 package ktb.leafresh.backend.domain.store.product.application.service;
 
+import ktb.leafresh.backend.domain.store.order.application.facade.ProductCacheLockFacade;
 import ktb.leafresh.backend.domain.store.product.application.event.ProductUpdatedEvent;
 import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
 import ktb.leafresh.backend.domain.store.product.domain.factory.ProductFactory;
@@ -23,7 +24,7 @@ public class ProductCreateService {
     private final ProductRepository productRepository;
     private final ProductFactory productFactory;
     private final ApplicationEventPublisher eventPublisher;
-    private final ProductCacheService productCacheService;
+    private final ProductCacheLockFacade productCacheLockFacade;
 
     @Transactional
     public ProductCreateResponseDto createProduct(ProductCreateRequestDto dto) {
@@ -32,7 +33,7 @@ public class ProductCreateService {
             Product product = productFactory.create(dto);
             productRepository.save(product);
 
-            productCacheService.cacheProductStock(product.getId(), product.getStock());
+            productCacheLockFacade.cacheProductStock(product.getId(), product.getStock());
 
             eventPublisher.publishEvent(new ProductUpdatedEvent(product.getId(), false));
 

--- a/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/ProductCacheService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/product/infrastructure/cache/ProductCacheService.java
@@ -6,16 +6,12 @@ import ktb.leafresh.backend.domain.store.product.infrastructure.cache.dto.Produc
 import ktb.leafresh.backend.domain.store.product.infrastructure.cache.dto.TimedealProductSummaryCacheDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 @Slf4j
 @Service
@@ -23,10 +19,6 @@ import java.util.function.Supplier;
 public class ProductCacheService {
 
     private final RedisTemplate<String, Object> redisTemplate;
-    private final RedissonClient redissonClient;
-
-    private static final long LOCK_WAIT_TIME = 100; // ms
-    private static final long LOCK_LEASE_TIME = 3;   // sec
 
     /**
      * 일반 상품 캐시 등록
@@ -117,54 +109,6 @@ public class ProductCacheService {
         Duration ttl = Duration.ofHours(24);
         redisTemplate.opsForValue().set(key, stock, ttl);
         log.info("[ProductCacheService] 일반 상품 재고 캐시 저장 - key={}, stock={}, TTL={}초", key, stock, ttl.getSeconds());
-    }
-
-    /**
-     * 캐시 MISS 시 Redisson Lock 기반 DB fallback
-     */
-    public Integer getProductStockWithDistributedLock(Long productId, Supplier<Integer> dbSupplier) {
-        String key = ProductCacheKeys.productStock(productId);
-        Object cached = redisTemplate.opsForValue().get(key);
-        if (cached != null) {
-            log.info("[ProductCacheService] 캐시 HIT - key={}, stock={}", key, cached);
-            return (Integer) cached;
-        }
-
-        String lockKey = "lock:stock:product:" + productId;
-        RLock lock = redissonClient.getLock(lockKey);
-        boolean acquired = false;
-
-        try {
-            acquired = lock.tryLock(LOCK_WAIT_TIME, LOCK_LEASE_TIME, TimeUnit.MILLISECONDS);
-            if (acquired) {
-                cached = redisTemplate.opsForValue().get(key);
-                if (cached != null) {
-                    log.info("[ProductCacheService] 캐시 HIT (락 이후 재확인) - key={}", key);
-                    return (Integer) cached;
-                }
-
-                Integer stock = dbSupplier.get();
-                cacheProductStock(productId, stock);
-                log.info("[ProductCacheService] DB fallback 및 캐싱 완료 - key={}, stock={}", key, stock);
-                return stock;
-            } else {
-                Thread.sleep(LOCK_LEASE_TIME * 1000); // 잠깐 대기 후 재시도
-                cached = redisTemplate.opsForValue().get(key);
-                if (cached != null) {
-                    log.info("[ProductCacheService] 캐시 HIT (락 실패 후 재시도) - key={}", key);
-                    return (Integer) cached;
-                }
-                log.warn("[ProductCacheService] 캐시 없음 (락 실패 + 재시도 실패) - key={}", key);
-                return null;
-            }
-        } catch (Exception e) {
-            log.error("[ProductCacheService] 재고 조회 예외 - productId={}", productId, e);
-            return null;
-        } finally {
-            if (acquired && lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
     }
 
     /**

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountReadService.java
@@ -3,6 +3,7 @@ package ktb.leafresh.backend.domain.verification.application.service;
 import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationCountResponseDto;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import ktb.leafresh.backend.global.lock.annotation.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
@@ -20,10 +21,8 @@ public class VerificationCountReadService {
 
     private final StringRedisTemplate redisTemplate;
     private final VerificationCountQueryService verificationCountQueryService;
-    private final RedissonClient redissonClient;
 
     private static final String TOTAL_VERIFICATION_COUNT_KEY = "leafresh:totalVerifications:count";
-    private static final String LOCK_KEY = "lock:leafresh:totalVerifications:count";
 
     public VerificationCountResponseDto getTotalVerificationCount() {
         try {
@@ -33,46 +32,29 @@ public class VerificationCountReadService {
                 return new VerificationCountResponseDto(Integer.parseInt(cached));
             }
 
-            log.warn("[VerificationCountReadService] Redis cache miss. Trying Redisson lock...");
-            RLock lock = redissonClient.getLock(LOCK_KEY);
-            boolean isLocked = lock.tryLock(2, 5, TimeUnit.SECONDS);
-
-            if (isLocked) {
-                try {
-                    String retry = redisTemplate.opsForValue().get(TOTAL_VERIFICATION_COUNT_KEY);
-                    if (retry != null) {
-                        log.debug("[VerificationCountReadService] Redis re-check after lock: {}", retry);
-                        return new VerificationCountResponseDto(Integer.parseInt(retry));
-                    }
-
-                    int total = verificationCountQueryService.getTotalVerificationCountFromDB();
-                    redisTemplate.opsForValue()
-                            .set(TOTAL_VERIFICATION_COUNT_KEY, String.valueOf(total), Duration.ofHours(24));
-                    log.info("[VerificationCountReadService] Redis cache refresh 완료: {}", total);
-
-                    return new VerificationCountResponseDto(total);
-                } finally {
-                    lock.unlock();
-                }
-            } else {
-                log.warn("[VerificationCountReadService] Redisson lock 획득 실패. 대기 후 캐시 재조회");
-                Thread.sleep(200);
-                String fallback = redisTemplate.opsForValue().get(TOTAL_VERIFICATION_COUNT_KEY);
-                if (fallback != null) {
-                    return new VerificationCountResponseDto(Integer.parseInt(fallback));
-                }
-                throw new CustomException(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
-            }
-
+            log.warn("[VerificationCountReadService] Redis cache miss. 진입 → lock 메서드 실행");
+            return getTotalVerificationCountWithLock();
         } catch (NumberFormatException e) {
-            log.error("[VerificationCountReadService] Redis 캐시 값 파싱 실패", e);
-            throw new CustomException(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+            log.error("[VerificationCountReadService] Redis 캐시 파싱 실패", e);
             throw new CustomException(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
         } catch (Exception e) {
-            log.error("[VerificationCountReadService] Redis 조회 중 알 수 없는 에러", e);
+            log.error("[VerificationCountReadService] 알 수 없는 예외", e);
             throw new CustomException(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
         }
+    }
+
+    @DistributedLock(key = "'totalVerifications'")
+    public VerificationCountResponseDto getTotalVerificationCountWithLock() {
+        String cached = redisTemplate.opsForValue().get(TOTAL_VERIFICATION_COUNT_KEY);
+        if (cached != null) {
+            log.debug("[VerificationCountReadService] Lock 이후 캐시 재조회 성공: {}", cached);
+            return new VerificationCountResponseDto(Integer.parseInt(cached));
+        }
+
+        int total = verificationCountQueryService.getTotalVerificationCountFromDB();
+        redisTemplate.opsForValue().set(TOTAL_VERIFICATION_COUNT_KEY, String.valueOf(total), Duration.ofHours(24));
+        log.info("[VerificationCountReadService] 캐시 재적재 완료: {}", total);
+
+        return new VerificationCountResponseDto(total);
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/scheduler/VerificationStatSyncScheduler.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/scheduler/VerificationStatSyncScheduler.java
@@ -4,7 +4,6 @@ import jakarta.transaction.Transactional;
 import ktb.leafresh.backend.domain.verification.infrastructure.cache.VerificationCacheKeys;
 import ktb.leafresh.backend.domain.verification.infrastructure.cache.VerificationStatCacheService;
 import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
-import ktb.leafresh.backend.global.lock.annotation.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -21,12 +20,14 @@ import java.util.Set;
 public class VerificationStatSyncScheduler {
 
     private static final int MAX_BATCH_SIZE = 100;
-    private static final String LOG_PREFIX = "[VerificationStatSyncScheduler]";
 
     private final StringRedisTemplate stringRedisTemplate;
-    private final VerificationStatCacheService cacheService;
+    private final VerificationStatCacheService verificationStatCacheService;
     private final GroupChallengeVerificationRepository verificationRepository;
 
+    /**
+     * 5분마다 Redis → DB로 증가분 누적 동기화
+     */
     @Transactional
     @Scheduled(fixedDelay = 5 * 60 * 1000)
     @SchedulerLock(name = "VerificationStatSyncScheduler", lockAtLeastFor = "1m", lockAtMostFor = "10m")
@@ -35,175 +36,71 @@ public class VerificationStatSyncScheduler {
                 .distinctRandomMembers(VerificationCacheKeys.dirtySetKey(), MAX_BATCH_SIZE);
 
         if (dirtyIds == null || dirtyIds.isEmpty()) {
-            log.debug("{} 동기화 대상 없음", LOG_PREFIX);
+            log.debug("[VerificationStatSyncScheduler] 동기화 대상 없음");
             return;
         }
 
-        log.info("{} 동기화 시작 - 대상 수: {}", LOG_PREFIX, dirtyIds.size());
+        log.info("[VerificationStatSyncScheduler] 동기화 시작 - 대상 수: {}", dirtyIds.size());
 
         for (String idStr : dirtyIds) {
-            syncStat(idStr);
-        }
-
-        log.info("{} 동기화 종료", LOG_PREFIX);
-    }
-
-    @DistributedLock(key = "'syncVerificationStat:' + #idStr")
-    private void syncStat(String idStr) {
-        Long verificationId = extractVerificationId(idStr);
-        if (verificationId == null) return;
-
-        Map<Object, Object> stats = getStatsSafely(verificationId);
-        if (stats == null || stats.isEmpty()) {
-            cacheService.clearStats(verificationId);
-            log.debug("{} 캐시 없음 - verificationId={}", LOG_PREFIX, verificationId);
-            return;
-        }
-
-        try {
-            var before = verificationRepository.findStatById(verificationId)
-                    .orElseThrow(() -> new IllegalStateException("존재하지 않는 verificationId: " + verificationId));
-
-            int view = toInt(stats.get("viewCount"));
-            int like = toInt(stats.get("likeCount"));
-            int comment = toInt(stats.get("commentCount"));
-
-            int deltaView = view - before.getViewCount();
-            int deltaLike = like - before.getLikeCount();
-            int deltaComment = comment - before.getCommentCount();
-
-            if (deltaView == 0 && deltaLike == 0 && deltaComment == 0) {
-                cacheService.clearStats(verificationId);
-                return;
+            Long verificationId;
+            try {
+                verificationId = Long.valueOf(idStr);
+            } catch (NumberFormatException e) {
+                log.warn("[VerificationStatSyncScheduler] 잘못된 ID 형식: {}", idStr);
+                continue;
             }
 
-            verificationRepository.increaseCounts(verificationId, deltaView, deltaLike, deltaComment);
-            cacheService.clearStats(verificationId);
+            Map<Object, Object> stats;
+            try {
+                stats = verificationStatCacheService.getStats(verificationId);
+            } catch (Exception redisEx) {
+                log.warn("[VerificationStatSyncScheduler] Redis 조회 실패 - verificationId={}, error={}",
+                        verificationId, redisEx.getMessage(), redisEx);
+                continue;
+            }
 
-            log.info(
-                    "{} 동기화 완료 - verificationId={} | view(+{}): {}→{}, like(+{}): {}→{}, comment(+{}): {}→{}",
-                    LOG_PREFIX,
-                    verificationId,
-                    deltaView, before.getViewCount(), before.getViewCount() + deltaView,
-                    deltaLike, before.getLikeCount(), before.getLikeCount() + deltaLike,
-                    deltaComment, before.getCommentCount(), before.getCommentCount() + deltaComment
-            );
+            if (stats == null || stats.isEmpty()) {
+                verificationStatCacheService.clearStats(verificationId);
+                log.debug("[VerificationStatSyncScheduler] 캐시 없음 - verificationId={}", verificationId);
+                continue;
+            }
 
-        } catch (Exception e) {
-            log.error("{} 동기화 실패 - verificationId={}, message={}", LOG_PREFIX, verificationId, e.getMessage(), e);
+            try {
+                var before = verificationRepository.findStatById(verificationId)
+                        .orElseThrow(() -> new IllegalStateException("존재하지 않는 verificationId: " + verificationId));
+
+                int view = Integer.parseInt(stats.getOrDefault("viewCount", "0").toString());
+                int like = Integer.parseInt(stats.getOrDefault("likeCount", "0").toString());
+                int comment = Integer.parseInt(stats.getOrDefault("commentCount", "0").toString());
+
+                int deltaView = view - before.getViewCount();
+                int deltaLike = like - before.getLikeCount();
+                int deltaComment = comment - before.getCommentCount();
+
+                if (deltaView == 0 && deltaLike == 0 && deltaComment == 0) {
+                    verificationStatCacheService.clearStats(verificationId);
+                    continue;
+                }
+
+                verificationRepository.increaseCounts(verificationId, deltaView, deltaLike, deltaComment);
+
+                verificationStatCacheService.clearStats(verificationId);
+
+                log.info(
+                        "[VerificationStatSyncScheduler] 동기화 완료 - verificationId={} | view(+{}): {} → {}, like(+{}): {} → {}, comment(+{}): {} → {}",
+                        verificationId,
+                        view, before.getViewCount(), before.getViewCount() + view,
+                        like, before.getLikeCount(), before.getLikeCount() + like,
+                        comment, before.getCommentCount(), before.getCommentCount() + comment
+                );
+
+            } catch (Exception e) {
+                log.error("[VerificationStatSyncScheduler] 동기화 실패 - verificationId={}, message={}",
+                        verificationId, e.getMessage(), e);
+            }
         }
-    }
 
-    private Long extractVerificationId(String idStr) {
-        try {
-            return Long.valueOf(idStr);
-        } catch (NumberFormatException e) {
-            log.warn("{} 잘못된 ID 형식: {}", LOG_PREFIX, idStr);
-            return null;
-        }
-    }
-
-    private Map<Object, Object> getStatsSafely(Long verificationId) {
-        try {
-            return cacheService.getStats(verificationId);
-        } catch (Exception e) {
-            log.warn("{} Redis 조회 실패 - verificationId={}, error={}", LOG_PREFIX, verificationId, e.getMessage(), e);
-            return null;
-        }
-    }
-
-    private int toInt(Object val) {
-        return Integer.parseInt(val == null ? "0" : val.toString());
+        log.info("[VerificationStatSyncScheduler] 동기화 종료");
     }
 }
-
-//@Slf4j
-//@Component
-//@RequiredArgsConstructor
-//public class VerificationStatSyncScheduler {
-//
-//    private static final int MAX_BATCH_SIZE = 100;
-//
-//    private final StringRedisTemplate stringRedisTemplate;
-//    private final VerificationStatCacheService verificationStatCacheService;
-//    private final GroupChallengeVerificationRepository verificationRepository;
-//
-//    /**
-//     * 5분마다 Redis → DB로 증가분 누적 동기화
-//     */
-//    @Transactional
-//    @Scheduled(fixedDelay = 5 * 60 * 1000)
-//    @SchedulerLock(name = "VerificationStatSyncScheduler", lockAtLeastFor = "1m", lockAtMostFor = "10m")
-//    public void syncVerificationStats() {
-//        Set<String> dirtyIds = stringRedisTemplate.opsForSet()
-//                .distinctRandomMembers(VerificationCacheKeys.dirtySetKey(), MAX_BATCH_SIZE);
-//
-//        if (dirtyIds == null || dirtyIds.isEmpty()) {
-//            log.debug("[VerificationStatSyncScheduler] 동기화 대상 없음");
-//            return;
-//        }
-//
-//        log.info("[VerificationStatSyncScheduler] 동기화 시작 - 대상 수: {}", dirtyIds.size());
-//
-//        for (String idStr : dirtyIds) {
-//            Long verificationId;
-//            try {
-//                verificationId = Long.valueOf(idStr);
-//            } catch (NumberFormatException e) {
-//                log.warn("[VerificationStatSyncScheduler] 잘못된 ID 형식: {}", idStr);
-//                continue;
-//            }
-//
-//            Map<Object, Object> stats;
-//            try {
-//                stats = verificationStatCacheService.getStats(verificationId);
-//            } catch (Exception redisEx) {
-//                log.warn("[VerificationStatSyncScheduler] Redis 조회 실패 - verificationId={}, error={}",
-//                        verificationId, redisEx.getMessage(), redisEx);
-//                continue;
-//            }
-//
-//            if (stats == null || stats.isEmpty()) {
-//                verificationStatCacheService.clearStats(verificationId);
-//                log.debug("[VerificationStatSyncScheduler] 캐시 없음 - verificationId={}", verificationId);
-//                continue;
-//            }
-//
-//            try {
-//                var before = verificationRepository.findStatById(verificationId)
-//                        .orElseThrow(() -> new IllegalStateException("존재하지 않는 verificationId: " + verificationId));
-//
-//                int view = Integer.parseInt(stats.getOrDefault("viewCount", "0").toString());
-//                int like = Integer.parseInt(stats.getOrDefault("likeCount", "0").toString());
-//                int comment = Integer.parseInt(stats.getOrDefault("commentCount", "0").toString());
-//
-//                int deltaView = view - before.getViewCount();
-//                int deltaLike = like - before.getLikeCount();
-//                int deltaComment = comment - before.getCommentCount();
-//
-//                if (deltaView == 0 && deltaLike == 0 && deltaComment == 0) {
-//                    verificationStatCacheService.clearStats(verificationId);
-//                    continue;
-//                }
-//
-//                verificationRepository.increaseCounts(verificationId, deltaView, deltaLike, deltaComment);
-//
-//                verificationStatCacheService.clearStats(verificationId);
-//
-//                log.info(
-//                        "[VerificationStatSyncScheduler] 동기화 완료 - verificationId={} | view(+{}): {} → {}, like(+{}): {} → {}, comment(+{}): {} → {}",
-//                        verificationId,
-//                        view, before.getViewCount(), before.getViewCount() + view,
-//                        like, before.getLikeCount(), before.getLikeCount() + like,
-//                        comment, before.getCommentCount(), before.getCommentCount() + comment
-//                );
-//
-//            } catch (Exception e) {
-//                log.error("[VerificationStatSyncScheduler] 동기화 실패 - verificationId={}, message={}",
-//                        verificationId, e.getMessage(), e);
-//            }
-//        }
-//
-//        log.info("[VerificationStatSyncScheduler] 동기화 종료");
-//    }
-//}

--- a/src/main/java/ktb/leafresh/backend/global/exception/GlobalErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/GlobalErrorCode.java
@@ -20,7 +20,8 @@ public enum GlobalErrorCode implements BaseErrorCode {
     INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 이미지 URL입니다."),
     VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 기록이 존재하지 않습니다."),
     SSE_STREAM_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "SSE 스트림이 중단되었습니다."),
-    INVALID_ORIGIN(HttpStatus.BAD_REQUEST, "접근이 금지되었습니다.");
+    INVALID_ORIGIN(HttpStatus.BAD_REQUEST, "접근이 금지되었습니다."),
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "동시 요청이 너무 많습니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/ktb/leafresh/backend/global/initializer/ProductStockCacheInitializer.java
+++ b/src/main/java/ktb/leafresh/backend/global/initializer/ProductStockCacheInitializer.java
@@ -1,6 +1,7 @@
 package ktb.leafresh.backend.global.initializer;
 
 import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.store.order.application.facade.ProductCacheLockFacade;
 import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
 import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
 import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
@@ -16,7 +17,7 @@ import java.util.List;
 public class ProductStockCacheInitializer {
 
     private final ProductRepository productRepository;
-    private final ProductCacheService productCacheService;
+    private final ProductCacheLockFacade productCacheLockFacade;
 
     /**
      * 서비스 시작 시 모든 상품 재고를 Redis에 캐싱
@@ -28,7 +29,7 @@ public class ProductStockCacheInitializer {
         int successCount = 0;
         for (Product product : products) {
             try {
-                productCacheService.cacheProductStock(product.getId(), product.getStock());
+                productCacheLockFacade.cacheProductStock(product.getId(), product.getStock());
                 successCount++;
             } catch (Exception e) {
                 log.error("[ProductStockCacheInitializer] 캐시 등록 실패 - productId={}", product.getId(), e);

--- a/src/main/java/ktb/leafresh/backend/global/initializer/TimedealStockCacheInitializer.java
+++ b/src/main/java/ktb/leafresh/backend/global/initializer/TimedealStockCacheInitializer.java
@@ -1,6 +1,7 @@
 package ktb.leafresh.backend.global.initializer;
 
 import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.store.order.application.facade.ProductCacheLockFacade;
 import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
 import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
 import ktb.leafresh.backend.domain.store.product.infrastructure.repository.TimedealPolicyRepository;
@@ -17,7 +18,7 @@ import java.util.List;
 public class TimedealStockCacheInitializer {
 
     private final TimedealPolicyRepository timedealPolicyRepository;
-    private final ProductCacheService productCacheService;
+    private final ProductCacheLockFacade productCacheLockFacade;
 
     @PostConstruct
     public void initTimedealStockCache() {
@@ -26,12 +27,12 @@ public class TimedealStockCacheInitializer {
         int successCount = 0;
         for (TimedealPolicy policy : validPolicies) {
             try {
-                productCacheService.cacheTimedealStock(
+                productCacheLockFacade.cacheTimedealStock(
                         policy.getId(),
                         policy.getStock(),
                         policy.getEndTime()
                 );
-                productCacheService.updateSingleTimedealCache(policy);
+                productCacheLockFacade.updateSingleTimedealCache(policy);
                 successCount++;
             } catch (Exception e) {
                 log.error("[TimedealStockCacheInitializer] 캐시 등록 실패 - timedealId={}", policy.getId(), e);

--- a/src/main/java/ktb/leafresh/backend/global/lock/aop/DistributedLockAop.java
+++ b/src/main/java/ktb/leafresh/backend/global/lock/aop/DistributedLockAop.java
@@ -1,5 +1,7 @@
 package ktb.leafresh.backend.global.lock.aop;
 
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
 import ktb.leafresh.backend.global.lock.annotation.DistributedLock;
 import ktb.leafresh.backend.global.lock.util.CustomSpringELParser;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +42,7 @@ public class DistributedLockAop {
             isLocked = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
             if (!isLocked) {
                 log.warn("[DistributedLockAop] Lock 획득 실패 - key={}", key);
-                return false;
+                throw new CustomException(GlobalErrorCode.TOO_MANY_REQUESTS);
             }
 
             return aopForTransaction.proceed(joinPoint);

--- a/src/test/java/ktb/leafresh/backend/domain/member/application/service/LeafPointReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/member/application/service/LeafPointReadServiceTest.java
@@ -7,8 +7,7 @@ import ktb.leafresh.backend.global.exception.LeafPointErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
+import org.mockito.ArgumentCaptor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
@@ -20,42 +19,30 @@ import static org.mockito.Mockito.*;
 class LeafPointReadServiceTest {
 
     private StringRedisTemplate redisTemplate;
+    private ValueOperations<String, String> valueOps;
     private MemberLeafPointQueryRepository queryRepository;
-    private RedissonClient redissonClient;
     private LeafPointReadService service;
 
-    private ValueOperations<String, String> valueOperations;
-    private RLock mockLock;
-
     private static final String REDIS_KEY = "leafresh:totalLeafPoints:sum";
-    private static final String LOCK_KEY = "lock:leafresh:totalLeafPoints:sum";
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         redisTemplate = mock(StringRedisTemplate.class);
+        valueOps = mock(ValueOperations.class);
         queryRepository = mock(MemberLeafPointQueryRepository.class);
-        redissonClient = mock(RedissonClient.class);
-        valueOperations = mock(ValueOperations.class);
-        mockLock = mock(RLock.class);
 
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        when(redissonClient.getLock(LOCK_KEY)).thenReturn(mockLock);
-        when(mockLock.tryLock(anyLong(), anyLong(), any())).thenReturn(true);
-
-        service = new LeafPointReadService(redisTemplate, queryRepository, redissonClient);
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        service = new LeafPointReadService(redisTemplate, queryRepository);
     }
 
     @Test
-    @DisplayName("Redis 캐시에 값이 있으면 캐시에서 반환한다")
-    void getTotalLeafPoints_cacheHit() {
-        // given
-        when(valueOperations.get(REDIS_KEY)).thenReturn("12345");
+    @DisplayName("Redis에 값이 있으면 그대로 반환한다")
+    void cacheHit() {
+        when(valueOps.get(REDIS_KEY)).thenReturn("1000");
 
-        // when
         TotalLeafPointResponseDto result = service.getTotalLeafPoints();
 
-        // then
-        assertThat(result.count()).isEqualTo(12345);
+        assertThat(result.count()).isEqualTo(1000);
         verify(queryRepository, never()).getTotalLeafPointSum();
     }
 
@@ -63,37 +50,63 @@ class LeafPointReadServiceTest {
     @DisplayName("Redis 캐시에 없으면 DB 조회 후 캐싱한다")
     void getTotalLeafPoints_cacheMiss() {
         // given
-        when(valueOperations.get(REDIS_KEY)).thenReturn(null);
+        when(valueOps.get(REDIS_KEY)).thenReturn(null).thenReturn(null);
         when(queryRepository.getTotalLeafPointSum()).thenReturn(9876);
+
+        ArgumentCaptor<Duration> durationCaptor = ArgumentCaptor.forClass(Duration.class);
 
         // when
         TotalLeafPointResponseDto result = service.getTotalLeafPoints();
 
         // then
         assertThat(result.count()).isEqualTo(9876);
-        verify(valueOperations).set(REDIS_KEY, "9876", Duration.ofHours(24));
+
+        verify(valueOps).set(eq(REDIS_KEY), eq("9876"), durationCaptor.capture());
+        assertThat(durationCaptor.getValue()).isEqualTo(Duration.ofHours(24));
     }
 
     @Test
-    @DisplayName("Redis 값이 숫자 변환 불가일 경우 예외 발생")
-    void getTotalLeafPoints_redisFormatError() {
-        // given
-        when(valueOperations.get(REDIS_KEY)).thenReturn("not-a-number");
+    @DisplayName("Redis에 값이 없으면 DB 조회 후 바로 캐싱한다")
+    void cacheMiss_thenGoToDbImmediately() {
+        when(valueOps.get(REDIS_KEY)).thenReturn(null);
+        when(queryRepository.getTotalLeafPointSum()).thenReturn(5555);
 
-        // when
+        TotalLeafPointResponseDto result = service.getTotalLeafPoints();
+
+        assertThat(result.count()).isEqualTo(5555);
+        verify(queryRepository).getTotalLeafPointSum();
+    }
+
+    @Test
+    @DisplayName("Redis 값이 숫자로 변환 불가능하면 예외 발생")
+    void redisFormatError() {
+        when(valueOps.get(REDIS_KEY)).thenReturn("not-a-number");
+
         CustomException ex = catchThrowableOfType(
                 () -> service.getTotalLeafPoints(),
                 CustomException.class
         );
 
-        // then
         assertThat(ex.getErrorCode()).isEqualTo(LeafPointErrorCode.REDIS_FAILURE);
     }
 
     @Test
+    @DisplayName("Redis 조회 중 예외가 발생하면 DB_QUERY_FAILED로 감싼 예외 반환")
+    void redisExceptionThrown() {
+        when(valueOps.get(REDIS_KEY)).thenThrow(new RuntimeException("Redis down"));
+
+        CustomException ex = catchThrowableOfType(
+                () -> service.getTotalLeafPoints(),
+                CustomException.class
+        );
+
+        assertThat(ex.getErrorCode()).isEqualTo(LeafPointErrorCode.DB_QUERY_FAILED);
+    }
+
+    @Test
     @DisplayName("DB 조회 중 예외 발생 시 CustomException 반환")
-    void getTotalLeafPoints_dbError() {
-        when(valueOperations.get(REDIS_KEY)).thenReturn(null);
+    void dbExceptionThrown() {
+        when(valueOps.get(REDIS_KEY)).thenReturn(null).thenReturn(null);
         when(queryRepository.getTotalLeafPointSum()).thenThrow(new RuntimeException("DB 장애"));
 
         CustomException ex = catchThrowableOfType(

--- a/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateServiceTest.java
@@ -2,6 +2,7 @@ package ktb.leafresh.backend.domain.store.order.application.service;
 
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
+import ktb.leafresh.backend.domain.store.order.application.facade.ProductCacheLockFacade;
 import ktb.leafresh.backend.domain.store.order.domain.entity.PurchaseIdempotencyKey;
 import ktb.leafresh.backend.domain.store.order.infrastructure.publisher.PurchaseMessagePublisher;
 import ktb.leafresh.backend.domain.store.order.infrastructure.repository.PurchaseIdempotencyKeyRepository;
@@ -33,7 +34,7 @@ class ProductOrderCreateServiceTest {
     private RedisLuaService redisLuaService;
     private PurchaseMessagePublisher purchaseMessagePublisher;
     private ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository memberRepository;
-    private ProductCacheService productCacheService;
+    private ProductCacheLockFacade productCacheLockFacade;
 
     @BeforeEach
     void setUp() {
@@ -42,7 +43,7 @@ class ProductOrderCreateServiceTest {
         redisLuaService = mock(RedisLuaService.class);
         purchaseMessagePublisher = mock(PurchaseMessagePublisher.class);
         memberRepository = mock(ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository.class);
-        productCacheService = mock(ProductCacheService.class);
+        productCacheLockFacade = mock(ProductCacheLockFacade.class);
 
         service = new ProductOrderCreateService(
                 memberRepository,
@@ -50,7 +51,7 @@ class ProductOrderCreateServiceTest {
                 idempotencyRepository,
                 redisLuaService,
                 purchaseMessagePublisher,
-                productCacheService
+                productCacheLockFacade
         );
     }
 

--- a/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/ProductUpdateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/ProductUpdateServiceTest.java
@@ -1,9 +1,9 @@
 package ktb.leafresh.backend.domain.store.product.application.service;
 
+import ktb.leafresh.backend.domain.store.order.application.facade.ProductCacheLockFacade;
 import ktb.leafresh.backend.domain.store.product.application.event.ProductUpdatedEvent;
 import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
 import ktb.leafresh.backend.domain.store.product.domain.entity.enums.ProductStatus;
-import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
 import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
 import ktb.leafresh.backend.domain.store.product.presentation.dto.request.ProductUpdateRequestDto;
 import ktb.leafresh.backend.global.exception.CustomException;
@@ -23,16 +23,16 @@ import static org.mockito.Mockito.*;
 class ProductUpdateServiceTest {
 
     private ProductRepository productRepository;
-    private ProductCacheService productCacheService;
+    private ProductCacheLockFacade productCacheLockFacade;
     private ApplicationEventPublisher eventPublisher;
     private ProductUpdateService productUpdateService;
 
     @BeforeEach
     void setUp() {
         productRepository = mock(ProductRepository.class);
-        productCacheService = mock(ProductCacheService.class);
+        productCacheLockFacade = mock(ProductCacheLockFacade.class);
         eventPublisher = mock(ApplicationEventPublisher.class);
-        productUpdateService = new ProductUpdateService(productRepository, productCacheService, eventPublisher);
+        productUpdateService = new ProductUpdateService(productRepository, productCacheLockFacade, eventPublisher);
     }
 
     @Test
@@ -57,8 +57,8 @@ class ProductUpdateServiceTest {
         assertThat(product.getStock()).isEqualTo(15);
         assertThat(product.getStatus()).isEqualTo(ProductStatus.INACTIVE);
 
-        verify(productCacheService).cacheProductStock(1L, 15);
-        verify(productCacheService).evictCacheByProduct(product);
+        verify(productCacheLockFacade).cacheProductStock(1L, 15);
+        verify(productCacheLockFacade).evictCacheByProduct(product);
 
         ArgumentCaptor<ProductUpdatedEvent> eventCaptor = ArgumentCaptor.forClass(ProductUpdatedEvent.class);
         verify(eventPublisher).publishEvent(eventCaptor.capture());

--- a/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealUpdateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealUpdateServiceTest.java
@@ -1,53 +1,51 @@
 package ktb.leafresh.backend.domain.store.product.application.service;
 
+import ktb.leafresh.backend.domain.store.order.application.facade.ProductCacheLockFacade;
 import ktb.leafresh.backend.domain.store.product.application.event.ProductUpdatedEvent;
 import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
 import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
-import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheService;
 import ktb.leafresh.backend.domain.store.product.infrastructure.repository.TimedealPolicyRepository;
 import ktb.leafresh.backend.domain.store.product.presentation.dto.request.TimedealUpdateRequestDto;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.TimedealErrorCode;
+import ktb.leafresh.backend.support.fixture.ProductFixture;
+import ktb.leafresh.backend.support.fixture.TimedealPolicyFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
 
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
 
-import static ktb.leafresh.backend.support.fixture.ProductFixture.of;
-import ktb.leafresh.backend.support.fixture.TimedealPolicyFixture;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class TimedealUpdateServiceTest {
 
     private TimedealPolicyRepository policyRepository;
-    private ProductCacheService productCacheService;
+    private ProductCacheLockFacade productCacheLockFacade;
     private ApplicationEventPublisher eventPublisher;
-
     private TimedealUpdateService service;
 
     @BeforeEach
     void setUp() {
         policyRepository = mock(TimedealPolicyRepository.class);
-        productCacheService = mock(ProductCacheService.class);
+        productCacheLockFacade = mock(ProductCacheLockFacade.class);
         eventPublisher = mock(ApplicationEventPublisher.class);
 
-        service = new TimedealUpdateService(policyRepository, productCacheService, eventPublisher);
+        service = new TimedealUpdateService(policyRepository, productCacheLockFacade, eventPublisher);
     }
 
     @Test
     @DisplayName("타임딜 수정 성공 - 재고, 시간 변경 포함")
     void updateTimedeal_success() {
-        Product product = of("주방세제", 3000, 100);
+        Product product = ProductFixture.of("주방세제", 3000, 100);
         TimedealPolicy policy = TimedealPolicyFixture.of(product);
 
-        OffsetDateTime newStart = policy.getStartTime().atOffset(ZoneOffset.UTC);
-        OffsetDateTime newEnd = policy.getEndTime().atOffset(ZoneOffset.UTC);
+        OffsetDateTime newStart = policy.getStartTime().atOffset(ZoneOffset.UTC).plusHours(1);
+        OffsetDateTime newEnd = policy.getEndTime().atOffset(ZoneOffset.UTC).plusHours(1);
 
         when(policyRepository.findById(1L)).thenReturn(Optional.of(policy));
         when(policyRepository.existsByProductIdAndTimeOverlapExceptSelf(any(), any(), any(), any())).thenReturn(false);
@@ -64,9 +62,9 @@ class TimedealUpdateServiceTest {
         assertThat(policy.getStartTime()).isEqualTo(newStart.toLocalDateTime());
         assertThat(policy.getEndTime()).isEqualTo(newEnd.toLocalDateTime());
 
-        verify(productCacheService).cacheTimedealStock(eq(policy.getId()), eq(20), eq(newEnd.toLocalDateTime()));
-        verify(productCacheService).evictTimedealCache(eq(policy));
-        verify(productCacheService).updateSingleTimedealCache(eq(policy));
+        verify(productCacheLockFacade).cacheTimedealStock(eq(policy.getId()), eq(20), eq(newEnd.toLocalDateTime()));
+        verify(productCacheLockFacade).evictTimedealCache(eq(policy));
+        verify(productCacheLockFacade).updateSingleTimedealCache(eq(policy));
         verify(eventPublisher).publishEvent(any(ProductUpdatedEvent.class));
     }
 
@@ -84,13 +82,15 @@ class TimedealUpdateServiceTest {
     @Test
     @DisplayName("타임딜 수정 실패 - 시간 유효성 오류")
     void updateTimedeal_fail_invalidTime() {
-        Product product = of("주방세제", 3000, 100);
+        Product product = ProductFixture.of("주방세제", 3000, 100);
         TimedealPolicy policy = TimedealPolicyFixture.of(product);
 
         when(policyRepository.findById(1L)).thenReturn(Optional.of(policy));
 
         TimedealUpdateRequestDto dto = new TimedealUpdateRequestDto(
-                OffsetDateTime.now(ZoneOffset.UTC).plusHours(2), OffsetDateTime.now(ZoneOffset.UTC).minusHours(1), null, null, 10
+                OffsetDateTime.now(ZoneOffset.UTC).plusHours(2),
+                OffsetDateTime.now(ZoneOffset.UTC).minusHours(1),
+                null, null, 10
         );
 
         CustomException exception = catchThrowableOfType(() -> service.update(1L, dto), CustomException.class);
@@ -100,11 +100,11 @@ class TimedealUpdateServiceTest {
     @Test
     @DisplayName("타임딜 수정 실패 - 시간 중복")
     void updateTimedeal_fail_overlapTime() {
-        Product product = of("주방세제", 3000, 100);
+        Product product = ProductFixture.of("주방세제", 3000, 100);
         TimedealPolicy policy = TimedealPolicyFixture.of(product);
 
-        OffsetDateTime newStart = policy.getStartTime().atOffset(ZoneOffset.UTC);
-        OffsetDateTime newEnd = policy.getEndTime().atOffset(ZoneOffset.UTC);
+        OffsetDateTime newStart = policy.getStartTime().atOffset(ZoneOffset.UTC).plusHours(1);
+        OffsetDateTime newEnd = policy.getEndTime().atOffset(ZoneOffset.UTC).plusHours(1);
 
         when(policyRepository.findById(1L)).thenReturn(Optional.of(policy));
         when(policyRepository.existsByProductIdAndTimeOverlapExceptSelf(any(), any(), any(), any()))
@@ -121,7 +121,7 @@ class TimedealUpdateServiceTest {
     @Test
     @DisplayName("타임딜 수정 실패 - 유효하지 않은 할인율, 가격, 재고")
     void updateTimedeal_fail_invalidDiscountAndStock() {
-        Product product = of("주방세제", 3000, 100);
+        Product product = ProductFixture.of("주방세제", 3000, 100);
         TimedealPolicy policy = TimedealPolicyFixture.of(product);
 
         when(policyRepository.findById(1L)).thenReturn(Optional.of(policy));

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountReadServiceTest.java
@@ -6,12 +6,10 @@ import ktb.leafresh.backend.global.exception.VerificationErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
@@ -22,85 +20,67 @@ class VerificationCountReadServiceTest {
     private StringRedisTemplate redisTemplate;
     private ValueOperations<String, String> valueOps;
     private VerificationCountQueryService queryService;
-    private RedissonClient redissonClient;
-    private RLock mockLock;
 
     private VerificationCountReadService service;
 
     private static final String KEY = "leafresh:totalVerifications:count";
-    private static final String LOCK_KEY = "lock:leafresh:totalVerifications:count";
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         redisTemplate = mock(StringRedisTemplate.class);
         valueOps = mock(ValueOperations.class);
         queryService = mock(VerificationCountQueryService.class);
-        redissonClient = mock(RedissonClient.class);
-        mockLock = mock(RLock.class);
 
         when(redisTemplate.opsForValue()).thenReturn(valueOps);
-        when(redissonClient.getLock(LOCK_KEY)).thenReturn(mockLock);
-        when(mockLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
 
-        service = new VerificationCountReadService(redisTemplate, queryService, redissonClient);
+        service = new VerificationCountReadService(redisTemplate, queryService);
     }
 
     @Test
     @DisplayName("Redis 캐시에 값이 존재하면 해당 값을 반환한다")
     void getTotalVerificationCount_success_cacheHit() {
-        // given
         when(valueOps.get(KEY)).thenReturn("42");
 
-        // when
         VerificationCountResponseDto result = service.getTotalVerificationCount();
 
-        // then
         assertThat(result.count()).isEqualTo(42);
         verify(queryService, never()).getTotalVerificationCountFromDB();
     }
 
     @Test
-    @DisplayName("Redis 캐시에 없고 락 획득 후 DB에서 조회하여 캐싱한다")
+    @DisplayName("Redis 캐시에 없고 DB에서 조회하여 캐싱한다")
     void getTotalVerificationCount_cacheMiss_dbFallback() {
-        // given
-        when(valueOps.get(KEY)).thenReturn(null);
+        when(valueOps.get(KEY)).thenReturn(null).thenReturn(null);
         when(queryService.getTotalVerificationCountFromDB()).thenReturn(99);
 
-        // when
         VerificationCountResponseDto result = service.getTotalVerificationCount();
 
-        // then
         assertThat(result.count()).isEqualTo(99);
         verify(queryService).getTotalVerificationCountFromDB();
-        verify(valueOps).set(eq(KEY), eq("99"), any());
+        verify(valueOps).set(eq(KEY), eq("99"), eq(Duration.ofHours(24)));
     }
 
     @Test
-    @DisplayName("Redis 캐시에 값이 없으면 0을 반환한다")
-    void getTotalVerificationCount_success_cacheMiss() {
-        // given
-        when(valueOps.get(KEY)).thenReturn(null);
+    @DisplayName("Redis 캐시에 없고 락 도중 다른 인스턴스가 캐싱하면 그대로 반환")
+    void getTotalVerificationCount_cacheMiss_but_cacheRestoredInLock() {
+        when(valueOps.get(KEY)).thenReturn(null).thenReturn("55");
 
-        // when
         VerificationCountResponseDto result = service.getTotalVerificationCount();
 
-        // then
-        assertThat(result.count()).isEqualTo(0);
+        assertThat(result.count()).isEqualTo(55);
+        verify(queryService, never()).getTotalVerificationCountFromDB();
     }
 
     @Test
     @DisplayName("Redis 값이 숫자가 아니면 예외를 던진다")
     void getTotalVerificationCount_fail_invalidFormat() {
-        // given
         when(valueOps.get(KEY)).thenReturn("not-a-number");
 
-        // when
         CustomException exception = catchThrowableOfType(
                 () -> service.getTotalVerificationCount(),
                 CustomException.class
         );
 
-        // then
         assertThat(exception).isNotNull();
         assertThat(exception.getErrorCode()).isEqualTo(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
     }
@@ -108,29 +88,14 @@ class VerificationCountReadServiceTest {
     @Test
     @DisplayName("Redis 조회 중 예외가 발생하면 예외를 던진다")
     void getTotalVerificationCount_fail_redisError() {
-        // given
         when(valueOps.get(KEY)).thenThrow(new RuntimeException("Redis error"));
 
-        // when
         CustomException exception = catchThrowableOfType(
                 () -> service.getTotalVerificationCount(),
                 CustomException.class
         );
 
-        // then
         assertThat(exception).isNotNull();
         assertThat(exception.getErrorCode()).isEqualTo(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
-    }
-
-    @Test
-    @DisplayName("락 획득 실패 시 fallback으로 Redis 재조회 후 반환")
-    void getTotalVerificationCount_lockFail_fallbackRedis() throws Exception {
-        when(mockLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(false);
-        when(valueOps.get(KEY)).thenReturn(null).thenReturn("55");
-
-        VerificationCountResponseDto result = service.getTotalVerificationCount();
-
-        assertThat(result.count()).isEqualTo(55);
-        verify(queryService, never()).getTotalVerificationCountFromDB();
     }
 }


### PR DESCRIPTION
## 주요 변경 사항

- 분산락의 책임을 서비스 레이어에서 제거하고, `ProductCacheLockFacade`로 일원화했습니다.
- 기존 `@DistributedLock`이 서비스 메서드에 직접 걸려 있던 구조를 제거하고, 모든 락 로직을 파사드 내부로 이동시켰습니다.
- 대표적으로 `ProductOrderCreateService`, `TimedealCreateService`, `TimedealUpdateService` 등이 파사드를 사용하도록 변경되었습니다.
- `ProductCacheService` 내부의 `getProductStockWithDistributedLock()` 메서드는 제거하고, 단순 캐싱 메서드로 대체했습니다.
- 관련된 테스트 코드도 모두 `ProductCacheLockFacade` mock을 활용하는 방식으로 수정했습니다.

## 기대 효과

- 분산락 처리 위치가 명확해지고, SRP 원칙을 준수합니다.
- 락 중복 및 의도치 않은 이중락 방지
- 테스트, 유지보수, 로깅 모두에서 책임 구분이 뚜렷해집니다.

## 테스트 범위

- 주문 생성: `ProductOrderCreateServiceTest`
- 타임딜 생성/수정: `TimedealCreateServiceTest`, `TimedealUpdateServiceTest`
- 기타 캐시 관련 테스트: `ProductCreateServiceTest`, `ProductUpdateServiceTest`