### PR TITLE
refactor: 피드백 결과 미생성 시 404 에러 → 204 No Content 응답으로 변경

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultQueryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultQueryService.java
@@ -38,17 +38,7 @@ public class FeedbackResultQueryService {
         log.info("[피드백 롱폴링 시작] memberId={}", memberId);
 
         try {
-            FeedbackResponseDto response = feedbackPollingExecutor.poll(() -> getLatestFeedback(member));
-
-            if (response.getContent() == null) {
-                log.info("[피드백 결과 없음] memberId={}", memberId);
-                throw new CustomException(FeedbackErrorCode.FEEDBACK_NOT_READY);
-            }
-
-            return response;
-
-        } catch (CustomException e) {
-            throw e;
+            return feedbackPollingExecutor.poll(() -> getLatestFeedback(member));
         } catch (Exception e) {
             log.error("[피드백 롱폴링 실패] memberId={}, error={}", memberId, e.getMessage(), e);
             throw new CustomException(FeedbackErrorCode.FEEDBACK_SERVER_ERROR);

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/presentation/controller/FeedbackResultController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/presentation/controller/FeedbackResultController.java
@@ -50,7 +50,7 @@ public class FeedbackResultController {
 
         if (response.getContent() == null) {
             log.info("[피드백 결과 없음] memberId={}", memberId);
-            throw new CustomException(FeedbackErrorCode.FEEDBACK_NOT_READY);
+            return ResponseEntity.noContent().build();
         }
 
         log.info("[피드백 결과 반환] memberId={}, content={}", memberId, response.getContent());

--- a/src/test/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultQueryServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultQueryServiceTest.java
@@ -77,7 +77,7 @@ class FeedbackResultQueryServiceTest {
     }
 
     @Test
-    @DisplayName("Redis 캐시에 없고 DB에도 피드백이 없으면 FEEDBACK_NOT_READY 예외를 던진다")
+    @DisplayName("Redis 캐시에 없고 DB에도 피드백이 없으면 null을 포함한 응답을 반환한다")
     void waitForFeedback_notReady() {
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         when(valueOperations.get("feedback:result:1")).thenReturn(null);
@@ -90,8 +90,9 @@ class FeedbackResultQueryServiceTest {
                     return supplier.get();
                 });
 
-        CustomException ex = catchThrowableOfType(() -> service.waitForFeedback(memberId), CustomException.class);
-        assertThat(ex.getErrorCode()).isEqualTo(FeedbackErrorCode.FEEDBACK_NOT_READY);
+        FeedbackResponseDto result = service.waitForFeedback(memberId);
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## 요약
피드백 결과가 아직 생성되지 않았을 경우 기존에는 FEEDBACK_NOT_READY (404 Not Found) 예외를 던졌습니다.
그러나 이 상황은 에러가 아닌 "정상적인 처리 중, 아직 결과 없음" 이므로 HTTP 204 No Content로 응답을 리팩토링했습니다.

## 주요 변경사항
- FeedbackResultQueryService: 더 이상 FEEDBACK_NOT_READY 예외를 던지지 않고 null content를 담은 DTO를 반환
- FeedbackResultController: content가 null이면 ResponseEntity.noContent().build() 반환
- FeedbackResultQueryServiceTest: 기존 예외 검증 테스트 제거 → null content 검증 테스트로 수정