### PR TITLE
feat: 챌린지 생성 검열용 makeChallengeAiWebClient 분리 및 설정 반영

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/client/HttpAiChallengeValidationClient.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/client/HttpAiChallengeValidationClient.java
@@ -19,7 +19,7 @@ public class HttpAiChallengeValidationClient implements AiChallengeValidationCli
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final WebClient aiServerWebClient;
 
-    public HttpAiChallengeValidationClient(@Qualifier("textAiWebClient") WebClient aiServerWebClient) {
+    public HttpAiChallengeValidationClient(@Qualifier("makeChallengeAiWebClient") WebClient aiServerWebClient) {
         this.aiServerWebClient = aiServerWebClient;
     }
 

--- a/src/main/java/ktb/leafresh/backend/global/config/WebClientConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/WebClientConfig.java
@@ -26,4 +26,11 @@ public class WebClientConfig {
                 .baseUrl(imageAiBaseUrl)
                 .build();
     }
+
+    @Bean(name = "makeChallengeAiWebClient")
+    public WebClient makeChallengeAiWebClient(@Value("${ai-server.make-challenge-base-url}") String makeChallengeBaseUrl) {
+        return WebClient.builder()
+                .baseUrl(makeChallengeBaseUrl)
+                .build();
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,6 +64,7 @@ cookie:
 ai-server:
   text-base-url: ${text_ai_server_base_url}
   image-base-url: ${image_ai_server_base_url}
+  make-challenge-base-url: ${make_challenge_ai_server_base_url}
 
 security:
   allowed-origins:


### PR DESCRIPTION
기존 imageAiWebClient는 인증 이미지 검열과 챌린지 생성 검열을 모두 처리하고 있었지만,
챌린지 검열 서버가 별도로 분리됨에 따라 전용 WebClient를 추가했습니다.

## 작업 내용
- .env.docker-local: `make_challenge_ai_server_base_url` 환경변수 추가
- application.yml: `ai-server.make-challenge-base-url` 항목 추가
- WebClientConfig: `makeChallengeAiWebClient` Bean 등록
- HttpAiChallengeValidationClient: 해당 WebClient로 교체 주입