### PR TITLE
refactor: GCP Pub/Sub 구독 설정 환경변수화 및 하드코딩 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ out/
 
 ### Google Cloud Storage ###
 leafresh-gcs.json
+leafresh-prod2-wren.json

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/subscriber/PurchaseDlqMessageSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/subscriber/PurchaseDlqMessageSubscriber.java
@@ -16,6 +16,7 @@ import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -26,13 +27,17 @@ import java.time.LocalDateTime;
 @Slf4j
 public class PurchaseDlqMessageSubscriber {
 
+    private final Environment environment;
     private final ObjectMapper objectMapper;
     private final PurchaseFailureLogRepository purchaseFailureLogRepository;
     private final PurchaseProcessingLogRepository purchaseProcessingLogRepository;
 
     @PostConstruct
     public void subscribe() {
-        ProjectSubscriptionName dlqSubscription = ProjectSubscriptionName.of("leafresh2", "leafresh-order-dlq-topic-sub");
+        String projectId = environment.getProperty("gcp.project-id");
+        String subscriptionId = environment.getProperty("gcp.pubsub.subscriptions.dlq");
+
+        ProjectSubscriptionName dlqSubscription = ProjectSubscriptionName.of(projectId, subscriptionId);
 
         MessageReceiver receiver = (message, consumer) -> {
             String rawData = message.getData().toStringUtf8();

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/subscriber/PurchaseMessageSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/subscriber/PurchaseMessageSubscriber.java
@@ -9,6 +9,7 @@ import ktb.leafresh.backend.domain.store.order.application.service.ProductPurcha
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import jakarta.annotation.PostConstruct;
@@ -19,13 +20,16 @@ import jakarta.annotation.PostConstruct;
 @RequiredArgsConstructor
 public class PurchaseMessageSubscriber {
 
+    private final Environment environment;
     private final ProductPurchaseProcessingService processingService;
     private final ObjectMapper objectMapper;
 
     @PostConstruct
     public void subscribe() {
-        ProjectSubscriptionName subscriptionName =
-                ProjectSubscriptionName.of("leafresh2", "leafresh-order-topic-sub");
+        String projectId = environment.getProperty("gcp.project-id");
+        String subscriptionId = environment.getProperty("gcp.pubsub.subscriptions.order");
+
+        ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(projectId, subscriptionId);
 
         MessageReceiver receiver = (message, consumer) -> {
             String rawData = message.getData().toStringUtf8();

--- a/src/main/resources/application-docker-local.yml
+++ b/src/main/resources/application-docker-local.yml
@@ -33,3 +33,6 @@ gcp:
     topics:
       order: ${gcp_pubsub_topic_order}
       image-verification: ${gcp_pubsub_topic_image_verification}
+    subscriptions:
+      order: ${gcp_pubsub_subscription_order}
+      dlq: ${gcp_pubsub_subscription_order_dlq}

--- a/src/main/resources/application-docker-prod.yml
+++ b/src/main/resources/application-docker-prod.yml
@@ -33,3 +33,6 @@ gcp:
     topics:
       order: ${gcp_pubsub_topic_order}
       image-verification: ${gcp_pubsub_topic_image_verification}
+    subscriptions:
+      order: ${gcp_pubsub_subscription_order}
+      dlq: ${gcp_pubsub_subscription_order_dlq}


### PR DESCRIPTION
### 주요 변경사항
- 기존 Pub/Sub 구독 구성을 위한 Subscription ID 하드코딩 제거
- `.env.docker-{env}` 파일에 `gcp_pubsub_subscription_order`, `gcp_pubsub_subscription_order_dlq` 추가
- `application-docker-{env}.yml`에 `gcp.pubsub.subscriptions.order`, `dlq` 설정 추가
- `PurchaseMessageSubscriber`, `PurchaseDlqMessageSubscriber`에 `Environment` 주입 및 설정값 기반 구독 적용

### 목적
운영/개발 환경에 따라 구독 설정을 분리하여 유연한 배포 및 유지보수 지원
