### PR TITLE
chore: SSE 기반 챗봇 추천 기능 @Profile("unused")로 비활성화 처리

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandler.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandler.java
@@ -9,7 +9,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
  * - ServerSentEvent<String> 형식으로 수신
  * - 받은 SSE 메시지를 포맷 유지한 채 SseEmitter를 통해 FE로 전송
  */
-@Profile("docker-local")
+@Profile("unused")
 public interface ChatbotSseStreamHandler {
     void streamToEmitter(SseEmitter emitter, String uriWithQueryParams);
 }

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandlerImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/handler/ChatbotSseStreamHandlerImpl.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 
 @Slf4j
 @Component
-@Profile("docker-local")
+@Profile("unused")
 public class ChatbotSseStreamHandlerImpl implements ChatbotSseStreamHandler {
 
     private final WebClient textAiWebClient;

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationSseService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/application/service/ChatbotRecommendationSseService.java
@@ -16,7 +16,7 @@ import java.util.Map;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Profile("docker-local")
+@Profile("unused")
 public class ChatbotRecommendationSseService {
 
     @Value("${ai-server.text-base-url}")

--- a/src/main/java/ktb/leafresh/backend/domain/chatbot/presentation/controller/ChatbotRecommendationSseController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/chatbot/presentation/controller/ChatbotRecommendationSseController.java
@@ -15,7 +15,7 @@ import jakarta.servlet.http.HttpServletResponse;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chatbot/recommendation")
-@Profile("docker-local")
+@Profile("unused")
 public class ChatbotRecommendationSseController {
 
     private final ChatbotRecommendationSseService chatbotRecommendationSseService;

--- a/src/main/resources/application-docker-prod.yml
+++ b/src/main/resources/application-docker-prod.yml
@@ -20,7 +20,7 @@ redis:
 
 cookie:
   secure: true
-  samesite: ${docker_prod_cookie_samesite:Strict}
+  samesite: ${docker_prod_cookie_samesite:None}
   domain: ${docker_prod_cookie_domain:.leafresh.app}
 
 gcp:


### PR DESCRIPTION
## 변경 내용
- 기존 `@Profile("docker-local")`로 dev 환경에서만 사용되던 SSE 기반 챗봇 API를 더 이상 사용하지 않음에 따라 `@Profile("unused")`로 변경
- 빈 등록이 되지 않도록 처리하면서도, 코드 자체는 보존하여 추후 필요 시 재활성화 가능

## 추가 설명
- 관련 컨트롤러, 서비스, 핸들러 클래스 전체에 일괄 적용
- 향후 SSE 방식 복구 또는 테스트 시 간편하게 다시 사용할 수 있도록 클래스 및 주석 유지
