### PR TITLE
feat: Prometheus metrics endpoint 활성화 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,9 @@ dependencies {
 	// ShedLock
 	implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
 	implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.10.0'
+
+	// Micrometer Prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 dependencyManagement {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,15 @@ spring:
       max-file-size: 10MB
       max-request-size: 50MB
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,info,prometheus"
+  endpoint:
+    prometheus:
+      access: unrestricted
+
 springdoc:
   api-docs:
     enabled: true


### PR DESCRIPTION
## 작업 내용
- Prometheus를 통한 메트릭 수집을 위해 actuator에 prometheus endpoint 추가
- application.yml:
  - `management.endpoints.web.exposure.include`에 prometheus 포함
  - `management.endpoint.prometheus.access`를 `unrestricted`로 설정하여 인증 없이 접근 가능
- build.gradle:
  - `io.micrometer:micrometer-registry-prometheus` 의존성 추가

## 참고
- Spring Boot 3.4.5 기준 설정 방식
- `access: public`은 유효하지 않으며, `unrestricted` 사용
