### PR TITLE
feat: p6spy 및 GCP Pub/Sub 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,9 @@ dependencies {
 
 	// Micrometer Prometheus
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	// p6spy for SQL profiling
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0'
 }
 
 dependencyManagement {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,19 +10,26 @@ spring:
       host: ${local_cache_host}
       port: ${local_cache_port}
 
-redis:
-  redisson:
-    address: redis://${SPRING_DATA_REDIS_HOST}:${SPRING_DATA_REDIS_PORT}
-
-  bloom:
-    host: ${local_cache_host}
-    port: ${local_cache_port}
-
   jpa:
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         format_sql: true
+        generate_statistics: true
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true
+      multiline: true
+      logging: slf4j
+
+redis:
+  redisson:
+    address: redis://${SPRING_DATA_REDIS_HOST}:${SPRING_DATA_REDIS_PORT}
+  bloom:
+    host: ${local_cache_host}
+    port: ${local_cache_port}
 
 cookie:
   secure: false
@@ -35,13 +42,17 @@ gcp:
     location: classpath:${gcp_credentials_location}
   storage:
     bucket: ${gcp_storage_bucket}
+  pubsub:
+    topics:
+      order: ${gcp_pubsub_topic_order}
+      image-verification: ${gcp_pubsub_topic_image_verification}
+    subscriptions:
+      order: ${gcp_pubsub_subscription_order}
+      dlq: $gcp_pubsub_subscription_order_dlq}
 
 logging:
   level:
-    org:
-      hibernate:
-        SQL: DEBUG
-        type:
-          descriptor:
-            sql:
-              BasicBinder: TRACE
+    com.p6spy: DEBUG
+    org.hibernate.stat: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE


### PR DESCRIPTION
## 변경 내용
- SQL 로그 확인을 위한 p6spy 의존성 추가
- application-local.yml에 p6spy 관련 datasource logging 설정 추가
- GCP Pub/Sub topic 및 subscription 관련 환경 변수 설정 추가

## 목적
- 개발 시 SQL 로그 추적을 통해 디버깅 용이성 향상
- GCP Pub/Sub 연동에 필요한 토픽/서브스크립션 설정값 분리 관리

## 기타
- 별도 활성화 profile에 따라 운영 환경에 영향 없음
