### PR TITLE
fix: 인증 day 및 todayStatus KST 기준으로 계산되도록 수정

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/service/GroupChallengeVerificationHistoryCalculator.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/domain/service/GroupChallengeVerificationHistoryCalculator.java
@@ -8,6 +8,8 @@ import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
@@ -16,20 +18,37 @@ import java.util.stream.Collectors;
 @Component
 public class GroupChallengeVerificationHistoryCalculator {
 
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
     public GroupChallengeVerificationHistoryResponseDto calculate(
             GroupChallenge challenge,
             GroupChallengeParticipantRecord record,
             List<GroupChallengeVerification> verifications
     ) {
-        LocalDate startDate = challenge.getStartDate().toLocalDate();
-        LocalDate endDate = challenge.getEndDate().toLocalDate();
-        LocalDate today = LocalDate.now();
+        // 시작일/종료일을 KST 기준으로 변환
+        LocalDate startDateKST = challenge.getStartDate()
+                .atZone(ZoneOffset.UTC)
+                .withZoneSameInstant(KST)
+                .toLocalDate();
 
-        // 최신 인증이 먼저 보이도록 정렬 + 시작일 기준 day 계산
+        LocalDate endDateKST = challenge.getEndDate()
+                .atZone(ZoneOffset.UTC)
+                .withZoneSameInstant(KST)
+                .toLocalDate();
+
+        LocalDate todayKST = LocalDate.now(KST);
+
+        // 인증 기록 정렬 및 day 계산 (KST 기준)
         List<GroupChallengeVerificationHistoryResponseDto.VerificationDto> verificationDtos = verifications.stream()
-                .sorted(Comparator.comparing(GroupChallengeVerification::getCreatedAt).reversed()) // 최신순
+                .sorted(Comparator.comparing(GroupChallengeVerification::getCreatedAt).reversed())
                 .map(v -> {
-                    int day = (int) ChronoUnit.DAYS.between(startDate, v.getCreatedAt().toLocalDate()) + 1;
+                    LocalDate createdDateKST = v.getCreatedAt()
+                            .atZone(ZoneOffset.UTC)
+                            .withZoneSameInstant(KST)
+                            .toLocalDate();
+
+                    int day = (int) ChronoUnit.DAYS.between(startDateKST, createdDateKST) + 1;
+
                     return GroupChallengeVerificationHistoryResponseDto.VerificationDto.builder()
                             .day(day)
                             .imageUrl(v.getImageUrl())
@@ -38,13 +57,25 @@ public class GroupChallengeVerificationHistoryCalculator {
                 })
                 .collect(Collectors.toList());
 
-        long success = verifications.stream().filter(v -> v.getStatus() == ChallengeStatus.SUCCESS).count();
-        long failure = verifications.stream().filter(v -> v.getStatus() == ChallengeStatus.FAILURE).count();
+        long success = verifications.stream()
+                .filter(v -> v.getStatus() == ChallengeStatus.SUCCESS)
+                .count();
 
-        int remaining = (int) Math.max(0, ChronoUnit.DAYS.between(today, endDate) + 1);
+        long failure = verifications.stream()
+                .filter(v -> v.getStatus() == ChallengeStatus.FAILURE)
+                .count();
 
+        int remaining = (int) Math.max(0, ChronoUnit.DAYS.between(todayKST, endDateKST) + 1);
+
+        // 오늘 인증 여부도 KST 기준으로 판단
         String todayStatus = verifications.stream()
-                .filter(v -> v.getCreatedAt().toLocalDate().isEqual(today))
+                .filter(v -> {
+                    LocalDate createdDateKST = v.getCreatedAt()
+                            .atZone(ZoneOffset.UTC)
+                            .withZoneSameInstant(KST)
+                            .toLocalDate();
+                    return createdDateKST.isEqual(todayKST);
+                })
                 .findFirst()
                 .map(v -> switch (v.getStatus()) {
                     case SUCCESS, FAILURE -> "DONE";


### PR DESCRIPTION
## 문제 요약
- 단체 챌린지를 오늘 생성하고 곧바로 인증했을 때도 day=2로 표시되는 문제가 있었습니다.
- 이는 서버 및 DB가 UTC를 기준으로 작동하면서 인증 시간(createdAt)과 시작일(startDate)의 LocalDate 계산이 UTC 기준으로 잘리는 데서 발생했습니다.

## 주요 변경 사항
- `GroupChallengeVerificationHistoryCalculator`에서 startDate, createdAt, endDate, today를 모두 UTC → KST(LocalDate)로 변환 후 계산
- 인증 day 및 todayStatus 로직이 사용자 입장에서 정확히 반영되도록 개선

## 테스트 필요 사항
- 오늘 시작한 챌린지에 대해 오늘 인증을 등록했을 때 `day=1`, `todayStatus=DONE`으로 나타나는지 확인
- 과거/미래 인증에 대해서도 날짜 계산이 정확히 되는지 확인

##  관련 이슈
- 사용자 피드백 기반 버그 대응
