### PR TITLE
refactor: CORS 허용 origin 설정을 yml에서 읽도록 변경

### DIFF
--- a/src/main/java/ktb/leafresh/backend/global/config/CorsConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/CorsConfig.java
@@ -1,5 +1,7 @@
 package ktb.leafresh.backend.global.config;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -7,13 +9,17 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
 @Configuration
+@EnableConfigurationProperties(SecurityProperties.class)
+@RequiredArgsConstructor
 public class CorsConfig {
+
+    private final SecurityProperties securityProperties;
 
     @Bean
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOriginPattern("*");
+        securityProperties.getAllowedOrigins().forEach(config::addAllowedOriginPattern); // ★ 여기!
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         config.setMaxAge(3600L);


### PR DESCRIPTION
## 변경사항
- CorsConfig에서 하드코딩된 `*` origin 허용 방식 제거
- `security.allowed-origins` 항목을 `SecurityProperties`로 매핑하여 외부 설정 기반 관리
- `@EnableConfigurationProperties`를 통해 바인딩 구성

## 이유
- 운영/개발 환경에 따라 허용 origin을 유연하게 관리하기 위함
- 하드코딩된 와일드카드 설정은 보안상 위험할 수 있어 설정 분리를 통해 명시적으로 관리

## 영향
- application.yml에 정의된 origin 외 요청은 CORS 정책에 의해 차단됨
- 추후 도메인 변경 시 yml만 수정하면 되므로 유지보수성이 향상됨
