### PR TITLE
refactor: 그룹 챌린지 참여 현황 통계 쿼리 리팩토링

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeParticipationReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeParticipationReadService.java
@@ -27,7 +27,7 @@ public class GroupChallengeParticipationReadService {
 
     public GroupChallengeParticipationCountResponseDto getParticipationCounts(Long memberId) {
         GroupChallengeParticipationCountSummaryDto summary =
-                groupChallengeParticipationRecordQueryRepository.countParticipationByStatus(memberId, LocalDateTime.now());
+                groupChallengeParticipationRecordQueryRepository.countParticipationByStatus(memberId);
 
         return GroupChallengeParticipationCountResponseDto.from(summary);
     }

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeParticipationRecordQueryRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeParticipationRecordQueryRepository.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface GroupChallengeParticipationRecordQueryRepository {
-    GroupChallengeParticipationCountSummaryDto countParticipationByStatus(Long memberId, LocalDateTime now);
+    GroupChallengeParticipationCountSummaryDto countParticipationByStatus(Long memberId);
 
     List<GroupChallengeParticipationDto> findParticipatedByStatus(
             Long memberId, String status, Long cursorId, String cursorTimestamp, int size);


### PR DESCRIPTION
## 변경 목적
그룹 챌린지 참여 현황 통계(countParticipationByStatus) 메서드의 로직이 서비스 단에서 복잡하게 구성되어 있어, 쿼리 내부로 위임하고 now 파라미터를 제거하여 가독성과 재사용성을 높이기 위함입니다.

## 주요 변경 사항
- `countParticipationByStatus(memberId, now)` → `countParticipationByStatus(memberId)`로 변경
- now 파라미터는 내부에서 `LocalDateTime.now(ZoneOffset.UTC)`로 처리
- 상태별 참여 통계 로직을 `applyStatusFilter()`로 모듈화
- 서비스에서 단순 반복 호출로 참여 상태별 집계 처리

## 기대 효과
- 서비스 로직 간결화
- 쿼리 가독성 및 유지보수성 향상
- 중복 코드 제거 및 명확한 상태 조건 분기 처리
