### PR TITLE
feat: GCP Pub/Sub DLQ 구독 설정 및 인증 실패 로깅/재요청 기능 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/Member.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/Member.java
@@ -15,6 +15,7 @@ import ktb.leafresh.backend.domain.auth.domain.entity.OAuth;
 import ktb.leafresh.backend.domain.notification.domain.entity.Notification;
 import ktb.leafresh.backend.domain.store.order.domain.entity.ProductPurchase;
 import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
+import ktb.leafresh.backend.domain.verification.domain.entity.VerificationFailureLog;
 import ktb.leafresh.backend.global.common.entity.BaseEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -81,6 +82,9 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Feedback> feedbacks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<VerificationFailureLog> verificationFailureLogs = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/listener/VerificationEventListener.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/listener/VerificationEventListener.java
@@ -37,7 +37,7 @@ public class VerificationEventListener {
     public void handle(VerificationCreatedEvent event) {
         try {
             log.info("[이벤트 리스너] 인증 정보 저장 커밋 완료. Pub/Sub 전송 시작");
-            imagePublisher.publish(event.requestDto());
+            imagePublisher.publishAsyncWithRetry(event.requestDto());
         } catch (Exception e) {
             log.error("[이벤트 리스너] 인증 요청 실패: {}", e.getMessage(), e);
         }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/domain/entity/VerificationFailureLog.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/domain/entity/VerificationFailureLog.java
@@ -1,0 +1,51 @@
+package ktb.leafresh.backend.domain.verification.domain.entity;
+
+import jakarta.persistence.*;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "verification_failure_logs")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class VerificationFailureLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 실패 발생한 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    // 챌린지 유형 (PERSONAL / GROUP)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "challenge_type", nullable = false)
+    private ChallengeType challengeType;
+
+    // 챌린지 ID
+    @Column(name = "challenge_id", nullable = false)
+    private Long challengeId;
+
+    // 인증 ID (optional: null 허용 가능)
+    @Column(name = "verification_id")
+    private Long verificationId;
+
+    // 실패 사유
+    @Column(columnDefinition = "TEXT")
+    private String reason;
+
+    // 요청 본문 백업 (JSON)
+    @Column(name = "request_body", columnDefinition = "JSON")
+    private String requestBody;
+
+    // 발생 시각
+    @Column(name = "occurred_at", nullable = false)
+    private LocalDateTime occurredAt;
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/publisher/GcpAiVerificationPubSubPublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/publisher/GcpAiVerificationPubSubPublisher.java
@@ -2,15 +2,27 @@ package ktb.leafresh.backend.domain.verification.infrastructure.publisher;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
 import com.google.cloud.pubsub.v1.Publisher;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.verification.domain.entity.VerificationFailureLog;
 import ktb.leafresh.backend.domain.verification.infrastructure.dto.request.AiVerificationRequestDto;
-import ktb.leafresh.backend.global.exception.CustomException;
-import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.VerificationFailureLogRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.Executors;
+
+import java.util.concurrent.*;
 
 @Component
 @Slf4j
@@ -18,30 +30,84 @@ public class GcpAiVerificationPubSubPublisher {
 
     private final Publisher imageVerificationPublisher;
     private final ObjectMapper objectMapper;
+    private final MemberRepository memberRepository;
+    private final VerificationFailureLogRepository failureLogRepository;
+
+    private static final int MAX_RETRY = 3;
+    private static final long INITIAL_BACKOFF_MS = 300;
+
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(4);
 
     public GcpAiVerificationPubSubPublisher(
             @Qualifier("imageVerificationPubSubPublisher") Publisher imageVerificationPublisher,
-            ObjectMapper objectMapper
+            ObjectMapper objectMapper,
+            MemberRepository memberRepository,
+            VerificationFailureLogRepository failureLogRepository
     ) {
         this.imageVerificationPublisher = imageVerificationPublisher;
         this.objectMapper = objectMapper;
+        this.memberRepository = memberRepository;
+        this.failureLogRepository = failureLogRepository;
     }
 
-    public void publish(AiVerificationRequestDto dto) {
+    public void publishAsyncWithRetry(AiVerificationRequestDto dto) {
         try {
             String json = objectMapper.writeValueAsString(dto);
-            PubsubMessage message = PubsubMessage.newBuilder()
-                    .setData(ByteString.copyFromUtf8(json))
-                    .build();
-
-            imageVerificationPublisher.publish(message);
-            log.info("[AI 인증 요청 Pub/Sub 메시지 발행 성공] {}", json);
+            sendWithRetry(json, dto, 1);
         } catch (JsonProcessingException e) {
             log.error("[AI 인증 직렬화 실패]", e);
-            throw new CustomException(VerificationErrorCode.VERIFICATION_SERIALIZATION_FAILED);
+            logFailure(dto, null, "직렬화 실패: " + e.getMessage());
+        }
+    }
+
+    private void sendWithRetry(String json, AiVerificationRequestDto dto, int attempt) {
+        PubsubMessage message = PubsubMessage.newBuilder()
+                .setData(ByteString.copyFromUtf8(json))
+                .build();
+
+        ApiFuture<String> future = imageVerificationPublisher.publish(message);
+
+        ApiFutures.addCallback(future, new ApiFutureCallback<>() {
+            @Override
+            public void onSuccess(String messageId) {
+                log.info("[AI 인증 요청 발행 성공] attempt={}, messageId={}, dto={}", attempt, messageId, json);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                log.warn("[AI 인증 발행 실패] attempt={}, error={}", attempt, t.getMessage());
+
+                if (attempt < MAX_RETRY) {
+                    long backoff = INITIAL_BACKOFF_MS * (1L << (attempt - 1)); // 지수 백오프
+
+                    scheduler.schedule(() -> {
+                        sendWithRetry(json, dto, attempt + 1);
+                    }, backoff, TimeUnit.MILLISECONDS);
+
+                } else {
+                    log.error("[AI 인증 발행 최종 실패] dto={}, error={}", json, t.getMessage());
+                    logFailure(dto, json, "최대 재시도 초과: " + t.getMessage());
+                }
+            }
+        }, MoreExecutors.directExecutor());
+    }
+
+    private void logFailure(AiVerificationRequestDto dto, String json, String reason) {
+        try {
+            Member member = memberRepository.findById(dto.memberId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+            failureLogRepository.save(VerificationFailureLog.builder()
+                    .member(member)
+                    .challengeType(dto.type() != null ? dto.type() : ChallengeType.GROUP)
+                    .challengeId(dto.challengeId())
+                    .verificationId(dto.verificationId())
+                    .reason(reason)
+                    .requestBody(json != null ? json : "{}")
+                    .occurredAt(LocalDateTime.now())
+                    .build());
         } catch (Exception e) {
-            log.error("[AI 인증 Pub/Sub 발행 실패]", e);
-            throw new CustomException(VerificationErrorCode.VERIFICATION_PUBLISH_FAILED);
+            log.warn("[FailureLog 저장 실패] {}", e.getMessage());
         }
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/VerificationFailureLogRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/VerificationFailureLogRepository.java
@@ -1,0 +1,7 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.verification.domain.entity.VerificationFailureLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VerificationFailureLogRepository extends JpaRepository<VerificationFailureLog, Long> {
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/subscriber/GcpVerificationResultDlqMessageSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/subscriber/GcpVerificationResultDlqMessageSubscriber.java
@@ -1,0 +1,73 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.subscriber;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.verification.domain.entity.VerificationFailureLog;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.VerificationFailureLogRepository;
+import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GcpVerificationResultDlqMessageSubscriber {
+
+    private final Environment environment;
+    private final ObjectMapper objectMapper;
+    private final VerificationFailureLogRepository failureLogRepository;
+    private final MemberRepository memberRepository;
+
+    @PostConstruct
+    public void subscribe() {
+        String projectId = environment.getProperty("gcp.project-id");
+        String subscriptionId = environment.getProperty("gcp.pubsub.subscriptions.verification-dlq");
+
+        ProjectSubscriptionName dlqSubscription = ProjectSubscriptionName.of(projectId, subscriptionId);
+
+        MessageReceiver receiver = (message, consumer) -> {
+            String rawData = message.getData().toStringUtf8();
+            log.error("[인증 DLQ 수신] messageId={}, data={}", message.getMessageId(), rawData);
+
+            try {
+                VerificationResultRequestDto dto = objectMapper.readValue(rawData, VerificationResultRequestDto.class);
+
+                Member member = memberRepository.findById(dto.memberId())
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+                failureLogRepository.save(VerificationFailureLog.builder()
+                        .member(member)
+                        .challengeType(dto.type())
+                        .challengeId(dto.challengeId())
+                        .verificationId(dto.verificationId())
+                        .reason("DLQ로 이동된 인증 메시지입니다.")
+                        .requestBody(rawData)
+                        .occurredAt(LocalDateTime.now())
+                        .build());
+            } catch (Exception e) {
+                log.warn("[DLQ 메시지 파싱 실패 → 최소 정보로 로그 저장] {}", e.getMessage(), e);
+
+                failureLogRepository.save(VerificationFailureLog.builder()
+                        .reason("DLQ 메시지 파싱 실패: " + e.getMessage())
+                        .requestBody(rawData)
+                        .occurredAt(LocalDateTime.now())
+                        .build());
+            } finally {
+                consumer.ack(); // DLQ는 무조건 ack (루프 방지)
+            }
+        };
+
+        Subscriber subscriber = Subscriber.newBuilder(dlqSubscription, receiver).build();
+        subscriber.startAsync().awaitRunning();
+        log.info("[인증 DLQ 메시지 구독 시작]");
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/subscriber/GcpVerificationResultSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/subscriber/GcpVerificationResultSubscriber.java
@@ -1,0 +1,88 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.subscriber;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.verification.application.service.VerificationResultProcessor;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.dto.request.AiVerificationRequestDto;
+import ktb.leafresh.backend.domain.verification.infrastructure.publisher.GcpAiVerificationPubSubPublisher;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GcpVerificationResultSubscriber {
+
+    private final Environment environment;
+    private final ObjectMapper objectMapper;
+    private final VerificationResultProcessor verificationResultProcessor;
+    private final GroupChallengeVerificationRepository groupChallengeVerificationRepository;
+    private final GcpAiVerificationPubSubPublisher pubSubPublisher;
+
+    @PostConstruct
+    public void subscribe() {
+        String projectId = environment.getProperty("gcp.project-id");
+        String subscriptionId = environment.getProperty("gcp.pubsub.subscriptions.image-verification-result");
+
+        ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(projectId, subscriptionId);
+
+        MessageReceiver receiver = (message, consumer) -> {
+            String rawData = message.getData().toStringUtf8();
+            log.info("[인증 결과 메시지 수신] messageId={}, data={}", message.getMessageId(), rawData);
+
+            try {
+                VerificationResultRequestDto dto = objectMapper.readValue(rawData, VerificationResultRequestDto.class);
+
+                if (dto.isSuccessResult()) {
+                    verificationResultProcessor.process(dto.verificationId(), dto);
+
+                } else if (dto.isRecoverableHttpError()) {
+                    log.warn("[AI 처리 오류 응답] verificationId={}, httpStatus={}", dto.verificationId(), dto.result());
+
+                    GroupChallengeVerification verification = groupChallengeVerificationRepository
+                            .findById(dto.verificationId())
+                            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 인증 ID"));
+
+                    GroupChallenge challenge = verification.getParticipantRecord().getGroupChallenge();
+
+                    AiVerificationRequestDto retryDto = AiVerificationRequestDto.builder()
+                            .verificationId(dto.verificationId())
+                            .type(dto.type())
+                            .imageUrl(verification.getImageUrl())
+                            .memberId(dto.memberId())
+                            .challengeId(dto.challengeId())
+                            .date(dto.date())
+                            .challengeName(challenge.getTitle())
+                            .challengeInfo(challenge.getDescription())
+                            .build();
+
+                    // 비동기 방식으로 재발행
+                    pubSubPublisher.publishAsyncWithRetry(retryDto);
+                    log.info("[AI 인증 재발행 요청 전송] verificationId={}", dto.verificationId());
+
+                } else {
+                    log.error("[알 수 없는 result 값] result={}", dto.result());
+                }
+
+                consumer.ack();
+
+            } catch (Exception e) {
+                log.error("[인증 결과 메시지 처리 실패] {}", e.getMessage(), e);
+                consumer.nack(); // 실패 시 재시도
+            }
+        };
+
+        Subscriber subscriber = Subscriber.newBuilder(subscriptionName, receiver).build();
+        subscriber.startAsync().awaitRunning();
+        log.info("[인증 결과 메시지 구독 시작]");
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/dto/request/VerificationResultRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/dto/request/VerificationResultRequestDto.java
@@ -15,9 +15,28 @@ public record VerificationResultRequestDto(
         @NotNull(message = "challengeId는 필수입니다.")
         Long challengeId,
 
+        @NotNull(message = "verificationId는 필수입니다.")
+        Long verificationId,
+
         @NotNull(message = "date는 필수입니다.")
         String date,
 
         @NotNull(message = "result는 필수입니다.")
-        Boolean result
-) {}
+        String result
+) {
+        public boolean isSuccessResult() {
+                return "true".equalsIgnoreCase(result) || "false".equalsIgnoreCase(result);
+        }
+
+        public boolean resultAsBoolean() {
+                return Boolean.parseBoolean(result);
+        }
+
+        public boolean isRecoverableHttpError() {
+                return result.matches("4\\d\\d|5\\d\\d");
+        }
+
+        public int resultAsHttpStatus() {
+                return Integer.parseInt(result);
+        }
+}

--- a/src/main/java/ktb/leafresh/backend/global/exception/VerificationErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/VerificationErrorCode.java
@@ -41,7 +41,8 @@ public enum VerificationErrorCode implements BaseErrorCode {
     CANNOT_EDIT_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "삭제된 댓글은 수정할 수 없습니다."),
     VERIFICATION_COUNT_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류로 인해 누적 사용자 인증 수 조회에 실패했습니다."),
     VERIFICATION_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 인증 요청 직렬화에 실패했습니다."),
-    VERIFICATION_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 인증 요청 발행에 실패했습니다.");
+    VERIFICATION_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 인증 요청 발행에 실패했습니다."),
+    AI_RESPONSE_ERROR(HttpStatus.BAD_REQUEST, "AI 응답 값이 true/false가 아닙니다. 오류 코드로 재요청해야 합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/resources/application-docker-local.yml
+++ b/src/main/resources/application-docker-local.yml
@@ -37,3 +37,4 @@ gcp:
       order: ${gcp_pubsub_subscription_order}
       dlq: ${gcp_pubsub_subscription_order_dlq}
       image-verification-result: ${gcp_pubsub_subscription_image_verification_result}
+      verification-dlq: ${gcp_pubsub_subscription_image_verification_result_dlq}

--- a/src/main/resources/application-docker-local.yml
+++ b/src/main/resources/application-docker-local.yml
@@ -36,3 +36,4 @@ gcp:
     subscriptions:
       order: ${gcp_pubsub_subscription_order}
       dlq: ${gcp_pubsub_subscription_order_dlq}
+      image-verification-result: ${gcp_pubsub_subscription_image_verification_result}


### PR DESCRIPTION
## 주요 변경 사항

### 1. GCP Pub/Sub DLQ 처리 구독 설정
- image-verification-result 메시지의 DLQ 구독자(`leafresh-image-verification-dlq-sub`) 설정 추가
- `GcpVerificationResultDlqMessageSubscriber`를 통해 DLQ 메시지 수신 및 처리 로직 구현

### 2. 인증 실패 로깅 기능 추가
- `VerificationFailureLog` 엔티티 및 JPA Repository 구현
- 인증 실패 메시지를 파싱하여 저장하는 로직 추가
- 회원 정보와 연관 관계 설정

### 3. 인증 실패 메시지 재요청 기능 구현
- DLQ 메시지를 저장 후 비동기 방식으로 Pub/Sub 재전송 기능 추가

### 4. 인증 요청/이벤트 발행 구조 개선
- 기존 인증 요청 트리거 방식을 Pub/Sub 직접 발행 방식으로 변경
- 인증 생성 이벤트 리스너 내 인증 요청 로직 개선

### 5. AI 응답 오류 대응 개선
- `AI_RESPONSE_ERROR` 코드 추가 및 처리 로직 개선
- `VerificationResultRequestDto`에 `result` 필드 및 파싱 로직 명확화

## 기타
- 인증 실패 관련 로직 전체 리팩토링 및 Boolean 파싱 처리 명확화
