### PR TITLE
refactor: 챌린지 인증 결과 조회 시 pollingExecutor 제거 및 동기 방식으로 변경

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultQueryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultQueryService.java
@@ -16,14 +16,26 @@ import java.time.LocalDateTime;
 public class GroupChallengeVerificationResultQueryService {
 
     private final GroupChallengeVerificationRepository verificationRepository;
-    private final ChallengeVerificationPollingExecutor pollingExecutor;
+//    private final ChallengeVerificationPollingExecutor pollingExecutor;
+
+//    @Transactional(readOnly = true)
+//    public ChallengeStatus waitForResult(Long memberId, Long challengeId) {
+//        return pollingExecutor.poll(() -> getLatestStatus(memberId, challengeId));
+//    }
+//
+//    private ChallengeStatus getLatestStatus(Long memberId, Long challengeId) {
+//        LocalDateTime start = LocalDate.now().atStartOfDay();
+//        LocalDateTime end = LocalDate.now().atTime(23, 59, 59);
+//
+//        return verificationRepository
+//                .findTopByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_IdAndCreatedAtBetween(
+//                        memberId, challengeId, start, end)
+//                .map(GroupChallengeVerification::getStatus)
+//                .orElse(ChallengeStatus.NOT_SUBMITTED);
+//    }
 
     @Transactional(readOnly = true)
-    public ChallengeStatus waitForResult(Long memberId, Long challengeId) {
-        return pollingExecutor.poll(() -> getLatestStatus(memberId, challengeId));
-    }
-
-    private ChallengeStatus getLatestStatus(Long memberId, Long challengeId) {
+    public ChallengeStatus getLatestStatus(Long memberId, Long challengeId) {
         LocalDateTime start = LocalDate.now().atStartOfDay();
         LocalDateTime end = LocalDate.now().atTime(23, 59, 59);
 

--- a/src/main/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultQueryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultQueryService.java
@@ -16,14 +16,26 @@ import java.time.LocalDateTime;
 public class PersonalChallengeVerificationResultQueryService {
 
     private final PersonalChallengeVerificationRepository verificationRepository;
-    private final ChallengeVerificationPollingExecutor pollingExecutor;
+//    private final ChallengeVerificationPollingExecutor pollingExecutor;
+
+//    @Transactional(readOnly = true)
+//    public ChallengeStatus waitForResult(Long memberId, Long challengeId) {
+//        return pollingExecutor.poll(() -> getLatestStatus(memberId, challengeId));
+//    }
+//
+//    private ChallengeStatus getLatestStatus(Long memberId, Long challengeId) {
+//        LocalDateTime start = LocalDate.now().atStartOfDay();
+//        LocalDateTime end = LocalDate.now().atTime(23, 59, 59);
+//
+//        return verificationRepository
+//                .findTopByMemberIdAndPersonalChallengeIdAndCreatedAtBetween(
+//                        memberId, challengeId, start, end)
+//                .map(PersonalChallengeVerification::getStatus)
+//                .orElse(ChallengeStatus.NOT_SUBMITTED);
+//    }
 
     @Transactional(readOnly = true)
-    public ChallengeStatus waitForResult(Long memberId, Long challengeId) {
-        return pollingExecutor.poll(() -> getLatestStatus(memberId, challengeId));
-    }
-
-    private ChallengeStatus getLatestStatus(Long memberId, Long challengeId) {
+    public ChallengeStatus getLatestStatus(Long memberId, Long challengeId) {
         LocalDateTime start = LocalDate.now().atStartOfDay();
         LocalDateTime end = LocalDate.now().atTime(23, 59, 59);
 

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupChallengeVerificationSubmitController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/GroupChallengeVerificationSubmitController.java
@@ -59,7 +59,7 @@ public class GroupChallengeVerificationSubmitController {
         }
 
         Long memberId = userDetails.getMemberId();
-        ChallengeStatus status = resultQueryService.waitForResult(memberId, challengeId);
+        ChallengeStatus status = resultQueryService.getLatestStatus(memberId, challengeId);
 
         Map<String, String> data = Map.of("status", status.name());
         String message = ChallengeStatusMessageResolver.resolveMessage(status);

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/PersonalChallengeVerificationSubmitController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/controller/PersonalChallengeVerificationSubmitController.java
@@ -59,7 +59,8 @@ public class PersonalChallengeVerificationSubmitController {
         }
 
         Long memberId = userDetails.getMemberId();
-        ChallengeStatus status = resultQueryService.waitForResult(memberId, challengeId);
+//        ChallengeStatus status = resultQueryService.waitForResult(memberId, challengeId);
+        ChallengeStatus status = resultQueryService.getLatestStatus(memberId, challengeId);
 
         Map<String, String> data = Map.of("status", status.name());
         String message = ChallengeStatusMessageResolver.resolveMessage(status);

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultQueryServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultQueryServiceTest.java
@@ -7,7 +7,6 @@ import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
 import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
 import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
-import ktb.leafresh.backend.global.util.polling.ChallengeVerificationPollingExecutor;
 import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
 import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
 import ktb.leafresh.backend.support.fixture.GroupChallengeParticipantRecordFixture;
@@ -25,61 +24,49 @@ import static org.mockito.Mockito.*;
 class GroupChallengeVerificationResultQueryServiceTest {
 
     private GroupChallengeVerificationRepository verificationRepository;
-    private ChallengeVerificationPollingExecutor pollingExecutor;
     private GroupChallengeVerificationResultQueryService service;
 
     @BeforeEach
     void setUp() {
         verificationRepository = mock(GroupChallengeVerificationRepository.class);
-        pollingExecutor = mock(ChallengeVerificationPollingExecutor.class);
-        service = new GroupChallengeVerificationResultQueryService(verificationRepository, pollingExecutor);
+        service = new GroupChallengeVerificationResultQueryService(verificationRepository);
     }
 
     @Test
-    @DisplayName("검증 결과가 승인(PENDING_APPROVAL이 아님)이면 해당 상태를 반환한다")
-    void waitForResult_GivenApprovedStatus_ThenReturnsStatus() {
+    @DisplayName("오늘 인증 상태가 존재하면 해당 상태를 반환한다")
+    void getLatestStatus_GivenTodayVerificationExists_ThenReturnsStatus() {
         // Given
         Member member = MemberFixture.of();
         GroupChallengeCategory category = GroupChallengeCategoryFixture.of("제로웨이스트");
         GroupChallenge challenge = GroupChallengeFixture.of(member, category);
         GroupChallengeParticipantRecord record = GroupChallengeParticipantRecordFixture.of(challenge, member);
         GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(record);
+        verification.markVerified(ChallengeStatus.SUCCESS);
 
-        Long memberId = member.getId();
-        Long challengeId = challenge.getId();
-        ChallengeStatus expected = ChallengeStatus.SUCCESS;
-
-        // → pollingExecutor는 직접 실행하지 않고 반환 값만 설정
         when(verificationRepository.findTopByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_IdAndCreatedAtBetween(
-                any(), any(), any(), any()))
+                eq(member.getId()), eq(challenge.getId()), any(), any()))
                 .thenReturn(Optional.of(verification));
 
-        when(pollingExecutor.poll(any()))
-                .thenReturn(expected); // 직접 결과를 반환하도록 설정
-
         // When
-        ChallengeStatus result = service.waitForResult(memberId, challengeId);
+        ChallengeStatus result = service.getLatestStatus(member.getId(), challenge.getId());
 
         // Then
-        assertThat(result).isEqualTo(expected);
+        assertThat(result).isEqualTo(ChallengeStatus.SUCCESS);
     }
 
     @Test
     @DisplayName("오늘 인증 기록이 없으면 NOT_SUBMITTED 상태를 반환한다")
-    void waitForResult_GivenNoVerificationToday_ThenReturnsNotSubmitted() {
+    void getLatestStatus_GivenNoTodayVerification_ThenReturnsNotSubmitted() {
         // Given
         Long memberId = 1L;
         Long challengeId = 99L;
 
         when(verificationRepository.findTopByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_IdAndCreatedAtBetween(
-                any(), any(), any(), any()))
+                eq(memberId), eq(challengeId), any(), any()))
                 .thenReturn(Optional.empty());
 
-        when(pollingExecutor.poll(any()))
-                .thenReturn(ChallengeStatus.NOT_SUBMITTED);
-
         // When
-        ChallengeStatus result = service.waitForResult(memberId, challengeId);
+        ChallengeStatus result = service.getLatestStatus(memberId, challengeId);
 
         // Then
         assertThat(result).isEqualTo(ChallengeStatus.NOT_SUBMITTED);

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultQueryServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultQueryServiceTest.java
@@ -3,7 +3,6 @@ package ktb.leafresh.backend.domain.verification.application.service;
 import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
 import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
 import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
-import ktb.leafresh.backend.global.util.polling.ChallengeVerificationPollingExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,32 +16,12 @@ import static org.mockito.Mockito.*;
 class PersonalChallengeVerificationResultQueryServiceTest {
 
     private PersonalChallengeVerificationRepository verificationRepository;
-    private ChallengeVerificationPollingExecutor pollingExecutor;
     private PersonalChallengeVerificationResultQueryService service;
 
     @BeforeEach
     void setUp() {
         verificationRepository = mock(PersonalChallengeVerificationRepository.class);
-        pollingExecutor = mock(ChallengeVerificationPollingExecutor.class);
-
-        service = new PersonalChallengeVerificationResultQueryService(
-                verificationRepository,
-                pollingExecutor
-        );
-    }
-
-    @Test
-    @DisplayName("pollingExecutor를 통해 최종 인증 상태를 가져온다")
-    void waitForResult_returnsLatestStatus() {
-        // given
-        when(pollingExecutor.poll(any())).thenReturn(ChallengeStatus.SUCCESS);
-
-        // when
-        ChallengeStatus status = service.waitForResult(1L, 10L);
-
-        // then
-        assertThat(status).isEqualTo(ChallengeStatus.SUCCESS);
-        verify(pollingExecutor, times(1)).poll(any());
+        service = new PersonalChallengeVerificationResultQueryService(verificationRepository);
     }
 
     @Test
@@ -52,20 +31,13 @@ class PersonalChallengeVerificationResultQueryServiceTest {
         Long memberId = 1L;
         Long challengeId = 10L;
 
-        LocalDateTime now = LocalDateTime.now();
         when(verificationRepository.findTopByMemberIdAndPersonalChallengeIdAndCreatedAtBetween(
                 eq(memberId), eq(challengeId),
                 any(LocalDateTime.class), any(LocalDateTime.class)
         )).thenReturn(Optional.empty());
 
-        // private 메서드 getLatestStatus()는 직접 테스트할 수 없으므로 pollingExecutor 내부 함수 실행을 흉내냅니다
-        when(pollingExecutor.poll(any())).thenAnswer(invocation -> {
-            var supplier = invocation.getArgument(0);
-            return ((java.util.function.Supplier<ChallengeStatus>) supplier).get();
-        });
-
         // when
-        ChallengeStatus status = service.waitForResult(memberId, challengeId);
+        ChallengeStatus status = service.getLatestStatus(memberId, challengeId);
 
         // then
         assertThat(status).isEqualTo(ChallengeStatus.NOT_SUBMITTED);
@@ -86,13 +58,8 @@ class PersonalChallengeVerificationResultQueryServiceTest {
                 any(LocalDateTime.class), any(LocalDateTime.class)
         )).thenReturn(Optional.of(verification));
 
-        when(pollingExecutor.poll(any())).thenAnswer(invocation -> {
-            var supplier = invocation.getArgument(0);
-            return ((java.util.function.Supplier<ChallengeStatus>) supplier).get();
-        });
-
         // when
-        ChallengeStatus status = service.waitForResult(memberId, challengeId);
+        ChallengeStatus status = service.getLatestStatus(memberId, challengeId);
 
         // then
         assertThat(status).isEqualTo(ChallengeStatus.FAILURE);


### PR DESCRIPTION
기존에는 인증 결과를 pollingExecutor를 통해 비동기적으로 대기하는 구조였으나,
단건 조회(getLatestStatus)를 직접 호출하도록 구조를 단순화했습니다.

## 주요 변경 사항
- `ChallengeVerificationPollingExecutor` 제거
- `waitForResult()` → `getLatestStatus()` 직접 호출로 변경
- 테스트 코드에서 pollingExecutor 관련 mock/stub 제거
- 컨트롤러 로직도 pollingExecutor 기반에서 단건 조회 방식으로 전환

## 기대 효과
- 인증 결과 응답 시간 단축
- pollingExecutor 제거로 인한 불필요한 complexity 해소
- 테스트 코드 간결화 및 유지 보수성 향상