### PR TITLE
refactor: 피드백 결과 조회 시 pollingExecutor 제거 및 단건 조회 방식으로 리팩토링

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultQueryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultQueryService.java
@@ -5,9 +5,7 @@ import ktb.leafresh.backend.domain.feedback.infrastructure.repository.FeedbackRe
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.global.exception.CustomException;
-import ktb.leafresh.backend.global.exception.FeedbackErrorCode;
 import ktb.leafresh.backend.global.exception.GlobalErrorCode;
-import ktb.leafresh.backend.global.util.polling.FeedbackPollingExecutor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -24,10 +22,28 @@ public class FeedbackResultQueryService {
 
     private final MemberRepository memberRepository;
     private final FeedbackRepository feedbackRepository;
-    private final FeedbackPollingExecutor feedbackPollingExecutor;
+//    private final FeedbackPollingExecutor feedbackPollingExecutor;
     private final RedisTemplate<String, Object> redisTemplate;
 
-    public FeedbackResponseDto waitForFeedback(Long memberId) {
+//    public FeedbackResponseDto waitForFeedback(Long memberId) {
+//        Member member = memberRepository.findById(memberId)
+//                .orElseThrow(() -> new CustomException(GlobalErrorCode.UNAUTHORIZED));
+//
+//        if (!member.getActivated()) {
+//            throw new CustomException(GlobalErrorCode.ACCESS_DENIED);
+//        }
+//
+//        log.info("[피드백 롱폴링 시작] memberId={}", memberId);
+//
+//        try {
+//            return feedbackPollingExecutor.poll(() -> getLatestFeedback(member));
+//        } catch (Exception e) {
+//            log.error("[피드백 롱폴링 실패] memberId={}, error={}", memberId, e.getMessage(), e);
+//            throw new CustomException(FeedbackErrorCode.FEEDBACK_SERVER_ERROR);
+//        }
+//    }
+
+    public FeedbackResponseDto getFeedbackResult(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(GlobalErrorCode.UNAUTHORIZED));
 
@@ -35,14 +51,8 @@ public class FeedbackResultQueryService {
             throw new CustomException(GlobalErrorCode.ACCESS_DENIED);
         }
 
-        log.info("[피드백 롱폴링 시작] memberId={}", memberId);
-
-        try {
-            return feedbackPollingExecutor.poll(() -> getLatestFeedback(member));
-        } catch (Exception e) {
-            log.error("[피드백 롱폴링 실패] memberId={}, error={}", memberId, e.getMessage(), e);
-            throw new CustomException(FeedbackErrorCode.FEEDBACK_SERVER_ERROR);
-        }
+        log.info("[피드백 결과 단건 조회] memberId={}", memberId);
+        return getLatestFeedback(member);
     }
 
     private FeedbackResponseDto getLatestFeedback(Member member) {

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/presentation/controller/FeedbackResultController.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/presentation/controller/FeedbackResultController.java
@@ -6,7 +6,6 @@ import ktb.leafresh.backend.domain.feedback.application.service.FeedbackResultSe
 import ktb.leafresh.backend.domain.feedback.presentation.dto.request.FeedbackResultRequestDto;
 import ktb.leafresh.backend.domain.feedback.presentation.dto.response.FeedbackResponseDto;
 import ktb.leafresh.backend.global.exception.CustomException;
-import ktb.leafresh.backend.global.exception.FeedbackErrorCode;
 import ktb.leafresh.backend.global.exception.GlobalErrorCode;
 import ktb.leafresh.backend.global.response.ApiResponse;
 import ktb.leafresh.backend.global.security.CustomUserDetails;
@@ -46,7 +45,8 @@ public class FeedbackResultController {
         Long memberId = userDetails.getMemberId();
         log.info("[피드백 결과 조회 요청] memberId={}", memberId);
 
-        FeedbackResponseDto response = feedbackResultQueryService.waitForFeedback(memberId);
+//        FeedbackResponseDto response = feedbackResultQueryService.waitForFeedback(memberId);
+        FeedbackResponseDto response = feedbackResultQueryService.getFeedbackResult(memberId);
 
         if (response.getContent() == null) {
             log.info("[피드백 결과 없음] memberId={}", memberId);

--- a/src/test/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultQueryServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultQueryServiceTest.java
@@ -6,9 +6,7 @@ import ktb.leafresh.backend.domain.feedback.presentation.dto.response.FeedbackRe
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
 import ktb.leafresh.backend.global.exception.CustomException;
-import ktb.leafresh.backend.global.exception.FeedbackErrorCode;
 import ktb.leafresh.backend.global.exception.GlobalErrorCode;
-import ktb.leafresh.backend.global.util.polling.FeedbackPollingExecutor;
 import ktb.leafresh.backend.support.fixture.FeedbackFixture;
 import ktb.leafresh.backend.support.fixture.MemberFixture;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +17,6 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
-import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
@@ -32,7 +29,6 @@ class FeedbackResultQueryServiceTest {
     private FeedbackResultQueryService service;
     private MemberRepository memberRepository;
     private FeedbackRepository feedbackRepository;
-    private FeedbackPollingExecutor feedbackPollingExecutor;
     private RedisTemplate<String, Object> redisTemplate;
     private ValueOperations<String, Object> valueOperations;
 
@@ -41,12 +37,10 @@ class FeedbackResultQueryServiceTest {
 
     @BeforeEach
     void setUp() {
-        // fixture를 통해 활성화된 member 생성
         member = MemberFixture.of(memberId, "test@leafresh.com", "테스터");
 
         memberRepository = mock(MemberRepository.class);
         feedbackRepository = mock(FeedbackRepository.class);
-        feedbackPollingExecutor = mock(FeedbackPollingExecutor.class);
         redisTemplate = mock(RedisTemplate.class);
         valueOperations = mock(ValueOperations.class);
 
@@ -55,49 +49,36 @@ class FeedbackResultQueryServiceTest {
         service = new FeedbackResultQueryService(
                 memberRepository,
                 feedbackRepository,
-                feedbackPollingExecutor,
                 redisTemplate
         );
     }
 
     @Test
     @DisplayName("Redis 캐시에 피드백이 있으면 해당 값을 반환한다")
-    void waitForFeedback_cached() {
+    void getFeedbackResult_cached() {
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         when(valueOperations.get("feedback:result:1")).thenReturn("캐시된 피드백");
 
-        when(feedbackPollingExecutor.poll(any(Supplier.class)))
-                .thenAnswer(invocation -> {
-                    Supplier<FeedbackResponseDto> supplier = invocation.getArgument(0);
-                    return supplier.get();
-                });
-
-        FeedbackResponseDto result = service.waitForFeedback(memberId);
+        FeedbackResponseDto result = service.getFeedbackResult(memberId);
         assertThat(result.getContent()).isEqualTo("캐시된 피드백");
     }
 
     @Test
     @DisplayName("Redis 캐시에 없고 DB에도 피드백이 없으면 null을 포함한 응답을 반환한다")
-    void waitForFeedback_notReady() {
+    void getFeedbackResult_notFound() {
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         when(valueOperations.get("feedback:result:1")).thenReturn(null);
         when(feedbackRepository.findFeedbackByMemberAndWeekMonday(eq(member), any()))
                 .thenReturn(Optional.empty());
 
-        when(feedbackPollingExecutor.poll(any(Supplier.class)))
-                .thenAnswer(invocation -> {
-                    Supplier<FeedbackResponseDto> supplier = invocation.getArgument(0);
-                    return supplier.get();
-                });
-
-        FeedbackResponseDto result = service.waitForFeedback(memberId);
+        FeedbackResponseDto result = service.getFeedbackResult(memberId);
         assertThat(result).isNotNull();
         assertThat(result.getContent()).isNull();
     }
 
     @Test
     @DisplayName("DB에서 피드백이 조회되면 해당 값을 반환한다")
-    void waitForFeedback_fromDb() {
+    void getFeedbackResult_fromDb() {
         Feedback feedback = FeedbackFixture.of(member, "DB 피드백");
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
@@ -105,46 +86,28 @@ class FeedbackResultQueryServiceTest {
         when(feedbackRepository.findFeedbackByMemberAndWeekMonday(eq(member), any()))
                 .thenReturn(Optional.of(feedback));
 
-        when(feedbackPollingExecutor.poll(any(Supplier.class)))
-                .thenAnswer(invocation -> {
-                    Supplier<FeedbackResponseDto> supplier = invocation.getArgument(0);
-                    return supplier.get();
-                });
-
-        FeedbackResponseDto result = service.waitForFeedback(memberId);
+        FeedbackResponseDto result = service.getFeedbackResult(memberId);
         assertThat(result.getContent()).isEqualTo("DB 피드백");
     }
 
     @Test
     @DisplayName("존재하지 않는 멤버라면 UNAUTHORIZED 예외를 던진다")
-    void waitForFeedback_noMember() {
+    void getFeedbackResult_noMember() {
         when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
 
-        CustomException ex = catchThrowableOfType(() -> service.waitForFeedback(memberId), CustomException.class);
+        CustomException ex = catchThrowableOfType(() -> service.getFeedbackResult(memberId), CustomException.class);
         assertThat(ex.getErrorCode()).isEqualTo(GlobalErrorCode.UNAUTHORIZED);
     }
 
     @Test
     @DisplayName("비활성화된 멤버라면 ACCESS_DENIED 예외를 던진다")
-    void waitForFeedback_notActivated() {
-        // 비활성화된 멤버 fixture 생성
+    void getFeedbackResult_notActivated() {
         Member inactiveMember = MemberFixture.of(memberId, "inactive@leafresh.com", "비활성");
         ReflectionTestUtils.setField(inactiveMember, "activated", false);
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(inactiveMember));
 
-        CustomException ex = catchThrowableOfType(() -> service.waitForFeedback(memberId), CustomException.class);
+        CustomException ex = catchThrowableOfType(() -> service.getFeedbackResult(memberId), CustomException.class);
         assertThat(ex.getErrorCode()).isEqualTo(GlobalErrorCode.ACCESS_DENIED);
-    }
-
-    @Test
-    @DisplayName("poll 도중 예외가 발생하면 FEEDBACK_SERVER_ERROR 예외를 던진다")
-    void waitForFeedback_pollingFailure() {
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(feedbackPollingExecutor.poll(any(Supplier.class)))
-                .thenThrow(new RuntimeException("서버 내부 오류"));
-
-        CustomException ex = catchThrowableOfType(() -> service.waitForFeedback(memberId), CustomException.class);
-        assertThat(ex.getErrorCode()).isEqualTo(FeedbackErrorCode.FEEDBACK_SERVER_ERROR);
     }
 }


### PR DESCRIPTION
기존 피드백 결과 조회는 pollingExecutor를 통해 결과 생성을 기다리는 방식이었으나,  
단건 조회(getFeedbackResult)를 즉시 수행하는 방식으로 단순화하여 응답 속도 및 가독성을 개선했습니다.

## 주요 변경 사항
- FeedbackPollingExecutor 및 관련 의존성 제거
- waitForFeedback() 제거 및 getFeedbackResult() 메서드로 직접 조회
- 컨트롤러에서 waitForFeedback() → getFeedbackResult() 호출로 변경
- Redis 캐시, DB 단건 조회 기반 로직 유지
- 테스트 코드도 pollingExecutor 관련 mock 제거 및 시나리오 재작성

## 기대 효과
- 불필요한 polling 제거로 코드 간결화
- 테스트 안정성 및 속도 개선
- 가독성 향상 및 유지보수성 향상