### PR TITLE
refactor: store.product 테스트 전반적인 피드백 반영

### DIFF
--- a/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/ProductSearchReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/ProductSearchReadServiceTest.java
@@ -4,50 +4,70 @@ import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
 import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductSearchQueryRepository;
 import ktb.leafresh.backend.domain.store.product.presentation.dto.response.ProductListResponseDto;
 import ktb.leafresh.backend.support.fixture.ProductFixture;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProductSearchReadService 테스트")
 class ProductSearchReadServiceTest {
 
+    @Mock
     private ProductSearchQueryRepository productSearchQueryRepository;
+
+    @InjectMocks
     private ProductSearchReadService productSearchReadService;
 
-    @BeforeEach
-    void setUp() {
-        productSearchQueryRepository = mock(ProductSearchQueryRepository.class);
-        productSearchReadService = new ProductSearchReadService(productSearchQueryRepository);
-    }
+    private static final LocalDateTime FIXED_TIME = LocalDateTime.of(2025, 1, 1, 12, 0);
 
     @Test
     @DisplayName("상품 검색 결과를 정상적으로 반환한다")
     void search_success() {
+        // given
         String keyword = "비누";
         Long cursorId = null;
         String cursorTimestamp = null;
         int size = 2;
 
-        Product p1 = ProductFixture.of("유기농 비누", 3500, 10);
-        Product p2 = ProductFixture.of("수제 비누", 4000, 8);
+        Product p1 = ProductFixture.createActiveProduct("유기농 비누", 3500, 10);
+        Product p2 = ProductFixture.createActiveProduct("수제 비누", 4000, 8);
 
-        ReflectionTestUtils.setField(p1, "createdAt", LocalDateTime.now());
-        ReflectionTestUtils.setField(p2, "createdAt", LocalDateTime.now().minusMinutes(1));
+        ReflectionTestUtils.setField(p1, "createdAt", FIXED_TIME);
+        ReflectionTestUtils.setField(p2, "createdAt", FIXED_TIME.minusMinutes(1));
 
         when(productSearchQueryRepository.findWithFilter(keyword, cursorId, cursorTimestamp, size))
                 .thenReturn(List.of(p1, p2));
 
+        // when
         ProductListResponseDto result = productSearchReadService.search(keyword, cursorId, cursorTimestamp, size);
 
+        // then
         assertThat(result).isNotNull();
         assertThat(result.getProducts()).hasSize(2);
-        assertThat(result.getProducts().get(0).getTitle()).contains("비누");
+
+        var response1 = result.getProducts().get(0);
+        assertThat(response1.getTitle()).isEqualTo(p1.getName());
+        assertThat(response1.getPrice()).isEqualTo(p1.getPrice());
+        assertThat(response1.getStock()).isEqualTo(p1.getStock());
+        assertThat(response1.getImageUrl()).isEqualTo(p1.getImageUrl());
+        assertThat(response1.getStatus()).isEqualTo(p1.getStatus().name());
+
+        var response2 = result.getProducts().get(1);
+        assertThat(response2.getTitle()).isEqualTo(p2.getName());
+        assertThat(response2.getPrice()).isEqualTo(p2.getPrice());
+        assertThat(response2.getStock()).isEqualTo(p2.getStock());
+        assertThat(response2.getImageUrl()).isEqualTo(p2.getImageUrl());
+        assertThat(response2.getStatus()).isEqualTo(p2.getStatus().name());
     }
 
     @Test
@@ -61,6 +81,7 @@ class ProductSearchReadServiceTest {
         ProductListResponseDto result = productSearchReadService.search("없는상품", null, null, 10);
 
         // then
+        assertThat(result).isNotNull();
         assertThat(result.getProducts()).isEmpty();
         assertThat(result.isHasNext()).isFalse();
     }

--- a/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/ProductUpdateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/ProductUpdateServiceTest.java
@@ -9,110 +9,140 @@ import ktb.leafresh.backend.domain.store.product.presentation.dto.request.Produc
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.ProductErrorCode;
 import ktb.leafresh.backend.support.fixture.ProductFixture;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProductUpdateService 테스트")
 class ProductUpdateServiceTest {
 
+    @Mock
     private ProductRepository productRepository;
-    private ProductCacheLockFacade productCacheLockFacade;
-    private ApplicationEventPublisher eventPublisher;
-    private ProductUpdateService productUpdateService;
 
-    @BeforeEach
-    void setUp() {
-        productRepository = mock(ProductRepository.class);
-        productCacheLockFacade = mock(ProductCacheLockFacade.class);
-        eventPublisher = mock(ApplicationEventPublisher.class);
-        productUpdateService = new ProductUpdateService(productRepository, productCacheLockFacade, eventPublisher);
-    }
+    @Mock
+    private ProductCacheLockFacade productCacheLockFacade;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private ProductUpdateService productUpdateService;
 
     @Test
     @DisplayName("상품을 정상적으로 수정한다")
     void update_success() {
         // given
-        Product product = ProductFixture.of("기존상품", 1000, 5);
-        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+        Product product = ProductFixture.createDefaultProduct();
+        Long productId = 1L;
+        ReflectionTestUtils.setField(product, "id", productId);
+
+        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
 
         ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
-                "수정상품", "설명", "https://new.image/product.png", 2000, 15, "INACTIVE"
+                "수정상품", "설명", "https://new.image/product.png", 2000, 15, ProductStatus.INACTIVE.name()
         );
 
         // when
-        productUpdateService.update(1L, dto);
+        productUpdateService.update(productId, dto);
 
         // then
-        assertThat(product.getName()).isEqualTo("수정상품");
-        assertThat(product.getDescription()).isEqualTo("설명");
-        assertThat(product.getImageUrl()).isEqualTo("https://new.image/product.png");
-        assertThat(product.getPrice()).isEqualTo(2000);
-        assertThat(product.getStock()).isEqualTo(15);
+        assertThat(product.getName()).isEqualTo(dto.name());
+        assertThat(product.getDescription()).isEqualTo(dto.description());
+        assertThat(product.getImageUrl()).isEqualTo(dto.imageUrl());
+        assertThat(product.getPrice()).isEqualTo(dto.price());
+        assertThat(product.getStock()).isEqualTo(dto.stock());
         assertThat(product.getStatus()).isEqualTo(ProductStatus.INACTIVE);
 
-        verify(productCacheLockFacade).cacheProductStock(1L, 15);
+        verify(productCacheLockFacade).cacheProductStock(productId, dto.stock());
         verify(productCacheLockFacade).evictCacheByProduct(product);
 
-        ArgumentCaptor<ProductUpdatedEvent> eventCaptor = ArgumentCaptor.forClass(ProductUpdatedEvent.class);
-        verify(eventPublisher).publishEvent(eventCaptor.capture());
-        assertThat(eventCaptor.getValue().productId()).isEqualTo(1L);
+        ArgumentCaptor<ProductUpdatedEvent> captor = ArgumentCaptor.forClass(ProductUpdatedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue().productId()).isEqualTo(productId);
     }
 
     @Test
     @DisplayName("상품이 존재하지 않으면 예외 발생")
     void update_fail_product_not_found() {
-        when(productRepository.findById(1L)).thenReturn(Optional.empty());
+        // given
+        Long invalidId = 999L;
+        ProductUpdateRequestDto dto = new ProductUpdateRequestDto("name", "desc", "url", 1000, 5, ProductStatus.ACTIVE.name());
+        when(productRepository.findById(invalidId)).thenReturn(Optional.empty());
 
-        ProductUpdateRequestDto dto = new ProductUpdateRequestDto("name", "desc", "url", 1000, 5, "ACTIVE");
+        // when
+        CustomException ex = catchThrowableOfType(() ->
+                productUpdateService.update(invalidId, dto), CustomException.class);
 
-        CustomException ex = catchThrowableOfType(() -> productUpdateService.update(1L, dto), CustomException.class);
-
+        // then
         assertThat(ex.getErrorCode()).isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND);
     }
 
     @Test
     @DisplayName("유효하지 않은 가격이면 예외 발생")
     void update_fail_invalid_price() {
-        Product product = ProductFixture.of("상품", 1000, 5);
-        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+        // given
+        Product product = ProductFixture.createDefaultProduct();
+        Long id = 1L;
+        ReflectionTestUtils.setField(product, "id", id);
+        when(productRepository.findById(id)).thenReturn(Optional.of(product));
 
         ProductUpdateRequestDto dto = new ProductUpdateRequestDto(null, null, null, 0, null, null);
 
-        CustomException ex = catchThrowableOfType(() -> productUpdateService.update(1L, dto), CustomException.class);
+        // when
+        CustomException ex = catchThrowableOfType(() ->
+                productUpdateService.update(id, dto), CustomException.class);
 
+        // then
         assertThat(ex.getErrorCode()).isEqualTo(ProductErrorCode.INVALID_PRICE);
     }
 
     @Test
     @DisplayName("재고가 음수이면 예외 발생")
     void update_fail_invalid_stock() {
-        Product product = ProductFixture.of("상품", 1000, 5);
-        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+        // given
+        Product product = ProductFixture.createDefaultProduct();
+        Long id = 1L;
+        ReflectionTestUtils.setField(product, "id", id);
+        when(productRepository.findById(id)).thenReturn(Optional.of(product));
 
         ProductUpdateRequestDto dto = new ProductUpdateRequestDto(null, null, null, null, -1, null);
 
-        CustomException ex = catchThrowableOfType(() -> productUpdateService.update(1L, dto), CustomException.class);
+        // when
+        CustomException ex = catchThrowableOfType(() ->
+                productUpdateService.update(id, dto), CustomException.class);
 
+        // then
         assertThat(ex.getErrorCode()).isEqualTo(ProductErrorCode.INVALID_STOCK);
     }
 
     @Test
     @DisplayName("유효하지 않은 상태값이면 예외 발생")
     void update_fail_invalid_status() {
-        Product product = ProductFixture.of("상품", 1000, 5);
-        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+        // given
+        Product product = ProductFixture.createDefaultProduct();
+        Long id = 1L;
+        ReflectionTestUtils.setField(product, "id", id);
+        when(productRepository.findById(id)).thenReturn(Optional.of(product));
 
-        ProductUpdateRequestDto dto = new ProductUpdateRequestDto(null, null, null, null, null, "WRONG_STATUS");
+        ProductUpdateRequestDto dto = new ProductUpdateRequestDto(null, null, null, null, null, "WRONG");
 
-        CustomException ex = catchThrowableOfType(() -> productUpdateService.update(1L, dto), CustomException.class);
+        // when
+        CustomException ex = catchThrowableOfType(() ->
+                productUpdateService.update(id, dto), CustomException.class);
 
+        // then
         assertThat(ex.getErrorCode()).isEqualTo(ProductErrorCode.INVALID_STATUS);
     }
 }

--- a/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealCreateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealCreateServiceTest.java
@@ -10,9 +10,12 @@ import ktb.leafresh.backend.domain.store.product.presentation.dto.request.Timede
 import ktb.leafresh.backend.domain.store.product.presentation.dto.response.TimedealCreateResponseDto;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.TimedealErrorCode;
-import org.junit.jupiter.api.BeforeEach;
+import ktb.leafresh.backend.support.fixture.ProductFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -20,132 +23,131 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
 
-import static ktb.leafresh.backend.support.fixture.ProductFixture.of;
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TimedealCreateService 테스트")
 class TimedealCreateServiceTest {
 
+    @Mock
     private ProductRepository productRepository;
+
+    @Mock
     private TimedealPolicyRepository timedealPolicyRepository;
+
+    @Mock
     private ProductCacheLockFacade productCacheLockFacade;
+
+    @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
     private TimedealCreateService service;
 
-    @BeforeEach
-    void setUp() {
-        productRepository = mock(ProductRepository.class);
-        timedealPolicyRepository = mock(TimedealPolicyRepository.class);
-        productCacheLockFacade = mock(ProductCacheLockFacade.class);
-        eventPublisher = mock(ApplicationEventPublisher.class);
+    @Captor
+    private ArgumentCaptor<ProductUpdatedEvent> eventCaptor;
 
-        service = new TimedealCreateService(
-                productRepository,
-                timedealPolicyRepository,
-                eventPublisher,
-                productCacheLockFacade
-        );
-    }
+    private static final OffsetDateTime FIXED_START = OffsetDateTime.of(2025, 7, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+    private static final OffsetDateTime FIXED_END = FIXED_START.plusHours(1);
+    private static final String DB_ERROR_MESSAGE = "DB 오류";
 
     @Test
     @DisplayName("타임딜 생성 성공")
     void createTimedeal_success() {
-        // given
-        Product product = of("친환경 주방세제", 3000, 50);
-        OffsetDateTime start = OffsetDateTime.now(ZoneOffset.UTC).plusHours(1);
-        OffsetDateTime end = OffsetDateTime.now(ZoneOffset.UTC).plusHours(2);
+        Product product = ProductFixture.createDefaultProduct();
+        ReflectionTestUtils.setField(product, "id", 1L);
+        Long productId = product.getId();
 
-        TimedealCreateRequestDto dto = new TimedealCreateRequestDto(
-                product.getId(), start, end, 2000, 33
-        );
+        TimedealCreateRequestDto dto = new TimedealCreateRequestDto(productId, FIXED_START, FIXED_END, 2000, 33);
 
-        when(productRepository.findById(dto.productId())).thenReturn(Optional.of(product));
-        when(timedealPolicyRepository.existsByProductIdAndTimeOverlap(anyLong(), any(), any())).thenReturn(false);
-        when(timedealPolicyRepository.save(any(TimedealPolicy.class))).thenAnswer(invocation -> {
-            TimedealPolicy saved = invocation.getArgument(0);
-            ReflectionTestUtils.setField(saved, "id", 10L);
-            return saved;
+        when(productRepository.findById(eq(productId))).thenReturn(Optional.of(product));
+        when(timedealPolicyRepository.existsByProductIdAndTimeOverlap(eq(productId), any(), any()))
+                .thenReturn(false);
+
+        when(timedealPolicyRepository.save(any())).thenAnswer(invocation -> {
+            TimedealPolicy policy = invocation.getArgument(0);
+            ReflectionTestUtils.setField(policy, "id", 10L);
+            return policy;
         });
 
-        // when
         TimedealCreateResponseDto response = service.create(dto);
 
-        // then
         assertThat(response.dealId()).isEqualTo(10L);
-        verify(productCacheLockFacade).cacheTimedealStock(eq(10L), eq(50), eq(end.toLocalDateTime()));
+
+        verify(productCacheLockFacade).cacheTimedealStock(eq(10L), eq(product.getStock()), eq(FIXED_END.toLocalDateTime()));
         verify(productCacheLockFacade).updateSingleTimedealCache(any(TimedealPolicy.class));
-        verify(eventPublisher).publishEvent(any(ProductUpdatedEvent.class));
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+        ProductUpdatedEvent event = eventCaptor.getValue();
+        assertThat(event.productId()).isEqualTo(productId);
+        assertThat(event.isTimeDeal()).isTrue();
     }
 
     @Test
     @DisplayName("타임딜 생성 실패 - 상품 없음")
     void createTimedeal_fail_productNotFound() {
-        TimedealCreateRequestDto dto = new TimedealCreateRequestDto(
-                999L,
-                OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
-                OffsetDateTime.now(ZoneOffset.UTC).plusHours(2),
-                2000,
-                20
-        );
-        when(productRepository.findById(dto.productId())).thenReturn(Optional.empty());
+        Long invalidProductId = 999L;
+        TimedealCreateRequestDto dto = new TimedealCreateRequestDto(invalidProductId, FIXED_START, FIXED_END, 2000, 20);
+        when(productRepository.findById(invalidProductId)).thenReturn(Optional.empty());
 
         CustomException exception = catchThrowableOfType(() -> service.create(dto), CustomException.class);
+
         assertThat(exception.getErrorCode()).isEqualTo(TimedealErrorCode.PRODUCT_NOT_FOUND);
+        assertThat(exception.getMessage()).isEqualTo(TimedealErrorCode.PRODUCT_NOT_FOUND.getMessage());
     }
 
     @Test
     @DisplayName("타임딜 생성 실패 - 시작 시간이 종료 시간보다 이후")
     void createTimedeal_fail_invalidTime() {
-        Product product = of("친환경 주방세제", 3000, 50);
-        TimedealCreateRequestDto dto = new TimedealCreateRequestDto(
-                product.getId(),
-                OffsetDateTime.now(ZoneOffset.UTC).plusHours(3),
-                OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
-                2000,
-                20
-        );
-        when(productRepository.findById(dto.productId())).thenReturn(Optional.of(product));
+        Product product = ProductFixture.createDefaultProduct();
+        ReflectionTestUtils.setField(product, "id", 1L);
+        Long productId = product.getId();
+
+        TimedealCreateRequestDto dto = new TimedealCreateRequestDto(productId, FIXED_END, FIXED_START, 2000, 20);
+        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
 
         CustomException exception = catchThrowableOfType(() -> service.create(dto), CustomException.class);
+
         assertThat(exception.getErrorCode()).isEqualTo(TimedealErrorCode.INVALID_TIME);
+        assertThat(exception.getMessage()).isEqualTo(TimedealErrorCode.INVALID_TIME.getMessage());
     }
 
     @Test
     @DisplayName("타임딜 생성 실패 - 타임딜 시간 중복")
     void createTimedeal_fail_overlap() {
-        Product product = of("친환경 주방세제", 3000, 50);
-        TimedealCreateRequestDto dto = new TimedealCreateRequestDto(
-                product.getId(),
-                OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
-                OffsetDateTime.now(ZoneOffset.UTC).plusHours(2),
-                2000,
-                20
-        );
+        Product product = ProductFixture.createDefaultProduct();
+        ReflectionTestUtils.setField(product, "id", 1L);
+        Long productId = product.getId();
 
-        when(productRepository.findById(dto.productId())).thenReturn(Optional.of(product));
-        when(timedealPolicyRepository.existsByProductIdAndTimeOverlap(anyLong(), any(), any())).thenReturn(true);
+        TimedealCreateRequestDto dto = new TimedealCreateRequestDto(productId, FIXED_START, FIXED_END, 2000, 20);
+        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(timedealPolicyRepository.existsByProductIdAndTimeOverlap(eq(productId), any(), any()))
+                .thenReturn(true);
 
         CustomException exception = catchThrowableOfType(() -> service.create(dto), CustomException.class);
+
         assertThat(exception.getErrorCode()).isEqualTo(TimedealErrorCode.OVERLAPPING_TIME);
+        assertThat(exception.getMessage()).isEqualTo(TimedealErrorCode.OVERLAPPING_TIME.getMessage());
     }
 
     @Test
     @DisplayName("타임딜 생성 실패 - 저장 중 예외 발생")
     void createTimedeal_fail_saveException() {
-        Product product = of("친환경 주방세제", 3000, 50);
-        TimedealCreateRequestDto dto = new TimedealCreateRequestDto(
-                product.getId(),
-                OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
-                OffsetDateTime.now(ZoneOffset.UTC).plusHours(2),
-                2000,
-                20
-        );
+        Product product = ProductFixture.createDefaultProduct();
+        ReflectionTestUtils.setField(product, "id", 1L);
+        Long productId = product.getId();
 
-        when(productRepository.findById(dto.productId())).thenReturn(Optional.of(product));
-        when(timedealPolicyRepository.existsByProductIdAndTimeOverlap(anyLong(), any(), any())).thenReturn(false);
-        when(timedealPolicyRepository.save(any())).thenThrow(new RuntimeException("DB 실패"));
+        TimedealCreateRequestDto dto = new TimedealCreateRequestDto(productId, FIXED_START, FIXED_END, 2000, 20);
+        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(timedealPolicyRepository.existsByProductIdAndTimeOverlap(eq(productId), any(), any()))
+                .thenReturn(false);
+        when(timedealPolicyRepository.save(any())).thenThrow(new RuntimeException(DB_ERROR_MESSAGE));
 
         CustomException exception = catchThrowableOfType(() -> service.create(dto), CustomException.class);
+
         assertThat(exception.getErrorCode()).isEqualTo(TimedealErrorCode.TIMEDEAL_SAVE_FAIL);
+        assertThat(exception.getMessage()).isEqualTo(TimedealErrorCode.TIMEDEAL_SAVE_FAIL.getMessage());
     }
 }

--- a/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealProductReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/TimedealProductReadServiceTest.java
@@ -1,7 +1,7 @@
 package ktb.leafresh.backend.domain.store.product.application.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import ktb.leafresh.backend.domain.store.product.domain.entity.enums.ProductStatus;
 import ktb.leafresh.backend.domain.store.product.domain.service.TimedealProductQueryService;
 import ktb.leafresh.backend.domain.store.product.infrastructure.cache.ProductCacheKeys;
 import ktb.leafresh.backend.domain.store.product.presentation.dto.response.TimedealProductListResponseDto;
@@ -9,122 +9,140 @@ import ktb.leafresh.backend.domain.store.product.presentation.dto.response.Timed
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.ZSetOperations;
 
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class TimedealProductReadServiceTest {
 
+    @Mock
     private RedisTemplate<String, Object> redisTemplate;
-    private TimedealProductQueryService queryService;
-    private ObjectMapper objectMapper;
-    private TimedealProductReadService service;
 
+    @Mock
+    private TimedealProductQueryService queryService;
+
+    @Mock
     private ValueOperations<String, Object> valueOps;
+
+    @Mock
     private ZSetOperations<String, Object> zSetOps;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks private TimedealProductReadService service;
+
+    private static final OffsetDateTime FIXED_START = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(10);
+    private static final OffsetDateTime FIXED_END = FIXED_START.plusHours(1);
 
     @BeforeEach
     void setUp() {
-        redisTemplate = mock(RedisTemplate.class);
-        queryService = mock(TimedealProductQueryService.class);
-
-        objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-
-        valueOps = mock(ValueOperations.class);
-        zSetOps = mock(ZSetOperations.class);
-
         when(redisTemplate.opsForValue()).thenReturn(valueOps);
-        when(redisTemplate.opsForZSet()).thenReturn(zSetOps);
-
-        service = new TimedealProductReadService(redisTemplate, queryService, objectMapper);
+        // opsForZSet은 아래 필요한 테스트에만 선언
     }
 
     @Test
     @DisplayName("캐시 HIT 시 목록 반환")
     void findTimedealProducts_cacheHit() {
-        var cached = new TimedealProductListResponseDto(List.of(
-                new TimedealProductSummaryResponseDto(
-                        1L, 1L, "비누", "설명",
-                        3000, 2000, 30, 10,
-                        "https://img.png",
-                        OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
-                        OffsetDateTime.now(ZoneOffset.UTC).plusHours(2),
-                        "ACTIVE", "ONGOING"
-                )
-        ));
-
+        // given
+        TimedealProductSummaryResponseDto dto = createDto(1L, "비누", "ONGOING");
+        var cached = new TimedealProductListResponseDto(List.of(dto));
         when(valueOps.get(ProductCacheKeys.TIMEDEAL_LIST)).thenReturn(cached);
+        when(objectMapper.convertValue(cached, TimedealProductListResponseDto.class)).thenReturn(cached);
 
+        // when
         TimedealProductListResponseDto result = service.findTimedealProducts();
 
+        // then
         assertThat(result.timeDeals()).hasSize(1);
-        verify(redisTemplate, never()).opsForZSet();
+        assertThat(result.timeDeals().get(0)).usingRecursiveComparison().isEqualTo(dto);
     }
 
     @Test
     @DisplayName("캐시 MISS + 단건 HIT 시 목록 반환")
     void findTimedealProducts_cacheMiss_singleHit() {
+        // given
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOps);
+        TimedealProductSummaryResponseDto dto = createDto(2L, "샴푸", "ONGOING");
+
         when(valueOps.get(ProductCacheKeys.TIMEDEAL_LIST)).thenReturn(null);
-        when(zSetOps.rangeByScore(any(), anyDouble(), anyDouble())).thenReturn(Set.of(1L));
+        when(zSetOps.rangeByScore(any(), anyDouble(), anyDouble())).thenReturn(Set.of(2L));
+        when(valueOps.get(ProductCacheKeys.timedealSingle(2L))).thenReturn(dto);
+        when(objectMapper.convertValue(dto, TimedealProductSummaryResponseDto.class)).thenReturn(dto);
 
-        TimedealProductSummaryResponseDto dto = new TimedealProductSummaryResponseDto(
-                1L, 1L, "샴푸", "세정력 좋은 샴푸",
-                5000, 3500, 30, 20,
-                "https://img.png",
-                OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
-                OffsetDateTime.now(ZoneOffset.UTC).plusHours(2),
-                "ACTIVE", "ONGOING"
-        );
-        when(valueOps.get(ProductCacheKeys.timedealSingle(1L))).thenReturn(dto);
-
+        // when
         TimedealProductListResponseDto result = service.findTimedealProducts();
 
+        // then
         assertThat(result.timeDeals()).hasSize(1);
-        assertThat(result.timeDeals().get(0).dealId()).isEqualTo(1L);
+        assertThat(result.timeDeals().get(0)).usingRecursiveComparison().isEqualTo(dto);
     }
 
     @Test
     @DisplayName("단건 MISS 시 Fallback 처리 성공")
     void findTimedealProducts_fallback_success() {
+        // given
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOps);
+        TimedealProductSummaryResponseDto fallbackDto = createDto(3L, "수세미", "ONGOING");
+
         when(valueOps.get(ProductCacheKeys.TIMEDEAL_LIST)).thenReturn(null);
-        when(zSetOps.rangeByScore(any(), anyDouble(), anyDouble())).thenReturn(Set.of(1L));
-        when(valueOps.get(ProductCacheKeys.timedealSingle(1L))).thenReturn(null);
+        when(zSetOps.rangeByScore(any(), anyDouble(), anyDouble())).thenReturn(Set.of(3L));
+        when(valueOps.get(ProductCacheKeys.timedealSingle(3L))).thenReturn(null);
+        when(queryService.findAllById(List.of(3L))).thenReturn(List.of(fallbackDto));
 
-        TimedealProductSummaryResponseDto fallbackDto = new TimedealProductSummaryResponseDto(
-                1L, 1L, "친환경 수세미", "지속 가능한 수세미",
-                3500, 2000, 40, 10,
-                "https://img.png",
-                OffsetDateTime.now(ZoneOffset.UTC).plusHours(1),
-                OffsetDateTime.now(ZoneOffset.UTC).plusHours(2),
-                "ACTIVE", "ONGOING"
-        );
-        when(queryService.findAllById(List.of(1L))).thenReturn(List.of(fallbackDto));
-
+        // when
         TimedealProductListResponseDto result = service.findTimedealProducts();
 
+        // then
         assertThat(result.timeDeals()).hasSize(1);
-        assertThat(result.timeDeals().get(0).dealId()).isEqualTo(1L);
-        verify(queryService).findAllById(List.of(1L));
+        assertThat(result.timeDeals().get(0).dealId()).isEqualTo(3L);
+        verify(queryService).findAllById(List.of(3L));
     }
 
     @Test
     @DisplayName("ZSET 캐시 없음 시 빈 목록 반환")
     void findTimedealProducts_emptyZset() {
+        // given
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOps);
         when(valueOps.get(ProductCacheKeys.TIMEDEAL_LIST)).thenReturn(null);
         when(zSetOps.rangeByScore(any(), anyDouble(), anyDouble())).thenReturn(Set.of());
 
+        // when
         TimedealProductListResponseDto result = service.findTimedealProducts();
 
+        // then
         assertThat(result.timeDeals()).isEmpty();
+    }
+
+    private TimedealProductSummaryResponseDto createDto(Long dealId, String title, String timeDealStatus) {
+        return new TimedealProductSummaryResponseDto(
+                dealId,
+                dealId + 10,
+                title,
+                "설명",
+                3000,
+                2000,
+                33,
+                15,
+                "https://img.png",
+                FIXED_START,
+                FIXED_END,
+                ProductStatus.ACTIVE.name(),
+                timeDealStatus
+        );
     }
 }

--- a/src/test/java/ktb/leafresh/backend/support/fixture/ProductFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/ProductFixture.java
@@ -7,16 +7,27 @@ import java.util.ArrayList;
 
 public class ProductFixture {
 
-    public static Product of(String name, int price, int stock) {
+    public static Product createProduct(String name, int price, int stock, ProductStatus status) {
         return Product.builder()
-                .id(1L)
                 .name(name)
-                .description("테스트용 상품 설명")
+                .description("테스트 상품 설명")
                 .imageUrl("https://dummy.image/product.png")
                 .price(price)
                 .stock(stock)
-                .status(ProductStatus.ACTIVE)
+                .status(status)
                 .timedealPolicies(new ArrayList<>())
                 .build();
+    }
+
+    public static Product createActiveProduct(String name, int price, int stock) {
+        return createProduct(name, price, stock, ProductStatus.ACTIVE);
+    }
+
+    public static Product createInactiveProduct(String name, int price, int stock) {
+        return createProduct(name, price, stock, ProductStatus.INACTIVE);
+    }
+
+    public static Product createDefaultProduct() {
+        return createActiveProduct("기본 상품", 3000, 10);
     }
 }


### PR DESCRIPTION
store.product.application.service 패키지 내 테스트들에 대해 아래와 같은 리팩토링을 진행했습니다.

## 주요 개선 사항
1. `@Mock`, `@InjectMocks` 사용 → 수동 DI 제거
2. 예외 발생 시 `getErrorCode()` + `getMessage()` 동시 검증
3. 메시지/에러 문자열 하드코딩 제거 및 상수화
4. 시간 관련 테스트에서 `LocalDateTime.now()` 제거 → 고정값(static final) 사용
5. `ProductStatus.ACTIVE`와 같은 enum 직접 비교로 리팩토링
6. `response.id()` 하드코딩 제거 → 실제 엔티티 기반 검증

## 적용 대상
- ProductCreateServiceTest
- ProductSearchReadServiceTest
- ProductUpdateServiceTest
- TimedealCreateServiceTest
- TimedealProductReadServiceTest
- TimedealUpdateServiceTest
