### PR TITLE
refactor: store.order 테스트 전반적인 피드백 반영

### DIFF
--- a/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateServiceTest.java
@@ -1,6 +1,7 @@
 package ktb.leafresh.backend.domain.store.order.application.service;
 
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
 import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
 import ktb.leafresh.backend.domain.store.order.application.facade.ProductCacheLockFacade;
 import ktb.leafresh.backend.domain.store.order.domain.entity.PurchaseIdempotencyKey;
@@ -13,58 +14,70 @@ import ktb.leafresh.backend.global.exception.MemberErrorCode;
 import ktb.leafresh.backend.global.exception.ProductErrorCode;
 import ktb.leafresh.backend.global.exception.PurchaseErrorCode;
 import ktb.leafresh.backend.global.util.redis.StockRedisLuaService;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import ktb.leafresh.backend.support.fixture.ProductFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.Optional;
 
-import static ktb.leafresh.backend.support.fixture.MemberFixture.of;
-import static ktb.leafresh.backend.support.fixture.ProductFixture.of;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class ProductOrderCreateServiceTest {
 
-    private ProductOrderCreateService service;
+    private static final String IDEMPOTENCY_KEY = "unique-key";
+    private static final String DUPLICATE_KEY = "duplicate-key";
+
+    @Mock
     private ProductRepository productRepository;
+
+    @Mock
     private PurchaseIdempotencyKeyRepository idempotencyRepository;
+
+    @Mock
     private StockRedisLuaService stockRedisLuaService;
+
+    @Mock
     private PurchaseMessagePublisher purchaseMessagePublisher;
-    private ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository memberRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
     private ProductCacheLockFacade productCacheLockFacade;
+
+    @InjectMocks
+    private ProductOrderCreateService service;
+
+    private Member member;
+    private Product product;
 
     @BeforeEach
     void setUp() {
-        productRepository = mock(ProductRepository.class);
-        idempotencyRepository = mock(PurchaseIdempotencyKeyRepository.class);
-        stockRedisLuaService = mock(StockRedisLuaService.class);
-        purchaseMessagePublisher = mock(PurchaseMessagePublisher.class);
-        memberRepository = mock(ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository.class);
-        productCacheLockFacade = mock(ProductCacheLockFacade.class);
-
-        service = new ProductOrderCreateService(
-                memberRepository,
-                productRepository,
-                idempotencyRepository,
-                stockRedisLuaService,
-                purchaseMessagePublisher,
-                productCacheLockFacade
-        );
+        member = MemberFixture.of(1L, "tester@leafresh.com", "테스터");
+        product = ProductFixture.createActiveProduct("비누", 3000, 50);
     }
 
     @Test
     @DisplayName("주문 생성 성공")
     void createOrder_success() {
-        Member member = of();
-        Product product = of("비누", 3000, 50);
-        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
-        when(stockRedisLuaService.decreaseStock(any(), anyInt())).thenReturn(1L);
+        // given
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(productRepository.findById(product.getId())).thenReturn(Optional.of(product));
+        when(stockRedisLuaService.decreaseStock(any(), eq(2))).thenReturn(1L);
 
-        service.create(1L, 1L, 2, "unique-key");
+        // when
+        service.create(member.getId(), product.getId(), 2, IDEMPOTENCY_KEY);
 
+        // then
         verify(idempotencyRepository).save(any(PurchaseIdempotencyKey.class));
         verify(purchaseMessagePublisher).publish(any(PurchaseCommand.class));
     }
@@ -72,25 +85,26 @@ class ProductOrderCreateServiceTest {
     @Test
     @DisplayName("주문 실패 - 존재하지 않는 사용자")
     void createOrder_fail_memberNotFound() {
-        when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.empty());
 
+        // when
         CustomException ex = catchThrowableOfType(
-                () -> service.create(1L, 1L, 1, "unique-key"),
+                () -> service.create(member.getId(), product.getId(), 1, IDEMPOTENCY_KEY),
                 CustomException.class
         );
 
+        // then
         assertThat(ex.getErrorCode()).isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
     }
 
     @Test
     @DisplayName("주문 실패 - Idempotency 중복 요청")
     void createOrder_fail_idempotencyKeyDuplicate() {
-        Member member = of();
-        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-        doThrow(new DataIntegrityViolationException("중복")).when(idempotencyRepository).save(any());
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        doThrow(DataIntegrityViolationException.class).when(idempotencyRepository).save(any());
 
         CustomException ex = catchThrowableOfType(
-                () -> service.create(1L, 1L, 1, "duplicate-key"),
+                () -> service.create(member.getId(), product.getId(), 1, DUPLICATE_KEY),
                 CustomException.class
         );
 
@@ -100,12 +114,11 @@ class ProductOrderCreateServiceTest {
     @Test
     @DisplayName("주문 실패 - 상품 없음")
     void createOrder_fail_productNotFound() {
-        Member member = of();
-        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-        when(productRepository.findById(1L)).thenReturn(Optional.empty());
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(productRepository.findById(product.getId())).thenReturn(Optional.empty());
 
         CustomException ex = catchThrowableOfType(
-                () -> service.create(1L, 1L, 1, "unique-key"),
+                () -> service.create(member.getId(), product.getId(), 1, IDEMPOTENCY_KEY),
                 CustomException.class
         );
 
@@ -115,14 +128,12 @@ class ProductOrderCreateServiceTest {
     @Test
     @DisplayName("주문 실패 - Redis 재고 없음")
     void createOrder_fail_outOfStock() {
-        Member member = of();
-        Product product = of("샴푸", 5000, 0);
-        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(productRepository.findById(product.getId())).thenReturn(Optional.of(product));
         when(stockRedisLuaService.decreaseStock(any(), anyInt())).thenReturn(-2L);
 
         CustomException ex = catchThrowableOfType(
-                () -> service.create(1L, 1L, 1, "unique-key"),
+                () -> service.create(member.getId(), product.getId(), 1, IDEMPOTENCY_KEY),
                 CustomException.class
         );
 

--- a/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/ProductPurchaseReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/ProductPurchaseReadServiceTest.java
@@ -8,47 +8,47 @@ import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
 import ktb.leafresh.backend.support.fixture.MemberFixture;
 import ktb.leafresh.backend.support.fixture.ProductFixture;
 import ktb.leafresh.backend.support.fixture.ProductPurchaseFixture;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 
+@ExtendWith(MockitoExtension.class)
 class ProductPurchaseReadServiceTest {
 
+    @Mock
     private ProductPurchaseQueryRepository productPurchaseQueryRepository;
+
+    @InjectMocks
     private ProductPurchaseReadService service;
 
-    private Member member;
-    private Product product;
-
-    @BeforeEach
-    void setUp() {
-        productPurchaseQueryRepository = mock(ProductPurchaseQueryRepository.class);
-        service = new ProductPurchaseReadService(productPurchaseQueryRepository);
-
-        member = MemberFixture.of(1L, "buyer@leafresh.com", "구매자");
-        product = ProductFixture.of("텀블러", 12000, 50);
-    }
+    private final Member member = MemberFixture.of(1L, "buyer@leafresh.com", "구매자");
+    private final Product product = ProductFixture.createActiveProduct("텀블러", 12000, 50);
 
     @Test
     @DisplayName("구매 목록을 커서 기반으로 조회한다")
     void getPurchases_success() {
         // given
         ProductPurchase purchase = ProductPurchaseFixture.of(member, product);
-        when(productPurchaseQueryRepository.findByMemberWithCursorAndSearch(
-                eq(1L), eq("텀블러"), eq(null), eq(null), eq(10)
-        )).thenReturn(List.of(purchase));
+        given(productPurchaseQueryRepository.findByMemberWithCursorAndSearch(
+                eq(member.getId()), eq("텀블러"), eq(null), eq(null), eq(10)
+        )).willReturn(List.of(purchase));
 
         // when
-        ProductPurchaseListResponseDto result = service.getPurchases(1L, "텀블러", null, null, 10);
+        ProductPurchaseListResponseDto result = service.getPurchases(member.getId(), "텀블러", null, null, 10);
 
         // then
         assertThat(result.getPurchases()).hasSize(1);
-        assertThat(result.getPurchases().get(0).getProduct().getTitle()).isEqualTo("텀블러");
-        assertThat(result.isHasNext()).isFalse(); // 한 개만 조회됐으므로 next 없음
+        var purchaseDto = result.getPurchases().get(0);
+        assertThat(purchaseDto.getProduct().getTitle()).isEqualTo(product.getName());
+        assertThat(result.isHasNext()).isFalse();
     }
 }

--- a/src/test/java/ktb/leafresh/backend/support/fixture/TimedealPolicyFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/TimedealPolicyFixture.java
@@ -7,39 +7,65 @@ import java.time.LocalDateTime;
 
 public class TimedealPolicyFixture {
 
-    public static TimedealPolicy of(Product product) {
+    public static TimedealPolicy createTimedeal(Product product, int price, int percentage, int stock,
+                                                LocalDateTime start, LocalDateTime end) {
         return TimedealPolicy.builder()
-                .id(1L)
                 .product(product)
-                .discountedPrice(2500)
-                .discountedPercentage(30)
-                .stock(10)
-                .startTime(LocalDateTime.now().minusHours(1))
-                .endTime(LocalDateTime.now().plusHours(1))
+                .discountedPrice(price)
+                .discountedPercentage(percentage)
+                .stock(stock)
+                .startTime(start)
+                .endTime(end)
                 .build();
     }
 
-    public static TimedealPolicy expired(Product product) {
-        return TimedealPolicy.builder()
-                .id(2L)
-                .product(product)
-                .discountedPrice(2900)
-                .discountedPercentage(20)
-                .stock(5)
-                .startTime(LocalDateTime.now().minusDays(2))
-                .endTime(LocalDateTime.now().minusDays(1))
-                .build();
+    public static TimedealPolicy createOngoingTimedeal(Product product) {
+        return createTimedeal(
+                product,
+                2500,
+                30,
+                10,
+                LocalDateTime.now().minusHours(1),
+                LocalDateTime.now().plusHours(1)
+        );
     }
 
-    public static TimedealPolicy upcoming(Product product) {
-        return TimedealPolicy.builder()
-                .id(3L)
-                .product(product)
-                .discountedPrice(2700)
-                .discountedPercentage(25)
-                .stock(20)
-                .startTime(LocalDateTime.now().plusDays(1))
-                .endTime(LocalDateTime.now().plusDays(2))
-                .build();
+    public static TimedealPolicy createExpiredTimedeal(Product product) {
+        return createTimedeal(
+                product,
+                2900,
+                20,
+                5,
+                LocalDateTime.now().minusDays(2),
+                LocalDateTime.now().minusDays(1)
+        );
+    }
+
+    public static TimedealPolicy createUpcomingTimedeal(Product product) {
+        return createTimedeal(
+                product,
+                2700,
+                25,
+                20,
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(2)
+        );
+    }
+
+    public static TimedealPolicy createDefaultTimedeal(Product product) {
+        return createOngoingTimedeal(product);
+    }
+
+    public static TimedealPolicy createCustomTimedeal(Product product, int price, int percentage, int stock,
+                                                      int startOffsetMinutes, int endOffsetMinutes) {
+        LocalDateTime now = LocalDateTime.now();
+        return createTimedeal(
+                product,
+                price,
+                percentage,
+                stock,
+                now.plusMinutes(startOffsetMinutes),
+                now.plusMinutes(endOffsetMinutes)
+        );
     }
 }


### PR DESCRIPTION
store.order.application.service 패키지 내 테스트들에 대해 다음과 같은 리팩토링을 수행했습니다:

## 주요 반영 피드백
1. `@Mock`, `@InjectMocks` 활용 → 수동 DI 제거
2. 예외 발생 시 `errorCode` + `message` 모두 검증
3. 메시지/에러 문자열 하드코딩 제거 → 상수화
4. `LocalDateTime.now()` → 고정된 시간 사용
5. `ProductStatus.ACTIVE.name()` → enum 직접 사용
6. `assertThat(response.id()).isEqualTo(...)` → 실제 객체 값 기반 비교로 유연성 확보

## 적용 대상
- ProductOrderCreateServiceTest
- ProductPurchaseProcessingServiceTest
- ProductPurchaseReadServiceTest
- PurchaseProcessorTest
- TimedealOrderCreateServiceTest
