### PR TITLE
refactor: 인증 도메인 테스트 코드 스타일 통일

### DIFF
--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationFeedServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationFeedServiceTest.java
@@ -1,91 +1,117 @@
-//package ktb.leafresh.backend.domain.verification.application.service;
-//
-//import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
-//import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
-//import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
-//import ktb.leafresh.backend.domain.member.domain.entity.Member;
-//import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
-//import ktb.leafresh.backend.domain.verification.infrastructure.cache.VerificationStatCacheService;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationFeedQueryRepository;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.LikeRepository;
-//import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
-//import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
-//import ktb.leafresh.backend.support.fixture.GroupChallengeParticipantRecordFixture;
-//import ktb.leafresh.backend.support.fixture.GroupChallengeVerificationFixture;
-//import ktb.leafresh.backend.support.fixture.MemberFixture;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//
-//import java.util.List;
-//import java.util.Map;
-//import java.util.Set;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.mockito.BDDMockito.given;
-//import static org.mockito.Mockito.mock;
-//
-//class GroupChallengeVerificationFeedServiceTest {
-//
-//    private GroupChallengeVerificationFeedQueryRepository feedQueryRepository;
-//    private VerificationStatCacheService verificationStatCacheService;
-//    private LikeRepository likeRepository;
-//    private GroupChallengeVerificationFeedService service;
-//
-//    @BeforeEach
-//    void setUp() {
-//        feedQueryRepository = mock(GroupChallengeVerificationFeedQueryRepository.class);
-//        verificationStatCacheService = mock(VerificationStatCacheService.class);
-//        likeRepository = mock(LikeRepository.class);
-//        service = new GroupChallengeVerificationFeedService(feedQueryRepository, verificationStatCacheService, likeRepository);
-//    }
-//
-//    @Test
-//    @DisplayName("카테고리 필터와 로그인 회원 정보를 기준으로 인증 피드를 조회한다")
-//    void getGroupChallengeVerifications_GivenCategoryAndLoginMemberId_ThenReturnsVerificationFeed() {
-//        // Given
-//        Long loginMemberId = 1L;
-//        String category = "ZERO_WASTE";
-//        int size = 10;
-//        Long cursorId = null;
-//        String cursorTimestamp = null;
-//
-//        Member member = MemberFixture.of();
-//        GroupChallengeCategory groupChallengeCategory = GroupChallengeCategoryFixture.of(category);
-//        GroupChallenge challenge = GroupChallengeFixture.of(member, groupChallengeCategory);
-//        GroupChallengeParticipantRecord record = GroupChallengeParticipantRecordFixture.of(challenge, member);
-//        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(record);
-//
-//        given(feedQueryRepository.findAllByFilter(category, cursorId, cursorTimestamp, size + 1))
-//                .willReturn(List.of(verification));
-//
-//        given(verificationStatCacheService.getStats(verification.getId()))
-//                .willReturn(Map.of(
-//                        "viewCount", "10",
-//                        "likeCount", "5",
-//                        "commentCount", "3"
-//                ));
-//
-//        given(likeRepository.findLikedVerificationIdsByMemberId(loginMemberId, List.of(verification.getId())))
-//                .willReturn(Set.of(verification.getId()));
-//
-//        // When
-//        var result = service.getGroupChallengeVerifications(cursorId, cursorTimestamp, size, category, loginMemberId);
-//
-//        // Then
-//        assertThat(result.items()).hasSize(1);
-//        var dto = result.items().get(0);
-//
-//        assertThat(dto.id()).isEqualTo(verification.getId());
-//        assertThat(dto.challengeId()).isEqualTo(challenge.getId());
-//        assertThat(dto.nickname()).isEqualTo(member.getNickname());
-//        assertThat(dto.profileImageUrl()).isEqualTo(member.getImageUrl());
-//        assertThat(dto.verificationImageUrl()).isEqualTo(verification.getImageUrl());
-//        assertThat(dto.description()).isEqualTo(verification.getContent());
-//        assertThat(dto.category()).isEqualTo(category);
-//        assertThat(dto.isLiked()).isTrue();
-//        assertThat(dto.counts().view()).isEqualTo(10);
-//        assertThat(dto.counts().like()).isEqualTo(5);
-//        assertThat(dto.counts().comment()).isEqualTo(3);
-//    }
-//}
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.cache.VerificationStatCacheService;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationFeedQueryRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.LikeRepository;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.GroupChallengeVerificationFeedSummaryDto;
+import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
+import ktb.leafresh.backend.support.fixture.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeVerificationFeedService 테스트")
+class GroupChallengeVerificationFeedServiceTest {
+
+    @Mock
+    private GroupChallengeVerificationFeedQueryRepository feedQueryRepository;
+
+    @Mock
+    private VerificationStatCacheService verificationStatCacheService;
+
+    @Mock
+    private LikeRepository likeRepository;
+
+    @InjectMocks
+    private GroupChallengeVerificationFeedService feedService;
+
+    private Member member;
+    private GroupChallengeVerification verification;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.of();
+        var category = GroupChallengeCategoryFixture.defaultCategory();
+        var challenge = GroupChallengeFixture.of(member, category);
+        var record = GroupChallengeParticipantRecordFixture.of(challenge, member);
+        verification = GroupChallengeVerificationFixture.of(record);
+        ReflectionTestUtils.setField(verification, "id", 1L);
+        ReflectionTestUtils.setField(challenge, "id", 100L);
+    }
+
+    @Test
+    @DisplayName("인증 피드 조회 시 - 로그인된 사용자는 좋아요 여부와 함께 페이징 결과를 반환한다")
+    void getGroupChallengeVerifications_withValidInput_returnsPaginatedFeed() {
+        // given
+        Long loginMemberId = 10L;
+        List<GroupChallengeVerification> verificationList = List.of(verification);
+        Map<Object, Object> cachedStats = Map.of("viewCount", 30, "likeCount", 5, "commentCount", 2);
+        Set<Long> likedIds = Set.of(1L);
+
+        given(feedQueryRepository.findAllByFilter("ZERO_WASTE", null, null, 6))
+                .willReturn(verificationList);
+        given(verificationStatCacheService.getStats(1L)).willReturn(cachedStats);
+        given(likeRepository.findLikedVerificationIdsByMemberId(loginMemberId, List.of(1L)))
+                .willReturn(likedIds);
+
+        // when
+        CursorPaginationResult<GroupChallengeVerificationFeedSummaryDto> result =
+                feedService.getGroupChallengeVerifications(null, null, 5, "ZERO_WASTE", loginMemberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.items()).hasSize(1);
+
+        var dto = result.items().get(0);
+        assertThat(dto.id()).isEqualTo(verification.getId());
+        assertThat(dto.challengeId()).isEqualTo(verification.getParticipantRecord().getGroupChallenge().getId());
+        assertThat(dto.nickname()).isEqualTo(member.getNickname());
+        assertThat(dto.profileImageUrl()).isEqualTo(member.getImageUrl());
+        assertThat(dto.verificationImageUrl()).isEqualTo(verification.getImageUrl());
+        assertThat(dto.description()).isEqualTo(verification.getContent());
+        assertThat(dto.category()).isEqualTo(verification.getParticipantRecord().getGroupChallenge().getCategory().getName());
+        assertThat(dto.counts().view()).isEqualTo(30);
+        assertThat(dto.counts().like()).isEqualTo(5);
+        assertThat(dto.counts().comment()).isEqualTo(2);
+        assertThat(dto.isLiked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("인증 피드 조회 시 - 로그인하지 않은 경우 좋아요 여부 없이 페이징 결과를 반환한다")
+    void getGroupChallengeVerifications_withoutLogin_returnsFeedWithoutLikeInfo() {
+        // given
+        List<GroupChallengeVerification> verificationList = List.of(verification);
+        Map<Object, Object> cachedStats = Map.of(); // 캐시 없는 경우 fallback
+
+        given(feedQueryRepository.findAllByFilter("ZERO_WASTE", null, null, 6))
+                .willReturn(verificationList);
+        given(verificationStatCacheService.getStats(1L)).willReturn(cachedStats);
+
+        // when
+        CursorPaginationResult<GroupChallengeVerificationFeedSummaryDto> result =
+                feedService.getGroupChallengeVerifications(null, null, 5, "ZERO_WASTE", null);
+
+        // then
+        assertThat(result).isNotNull();
+        var dto = result.items().get(0);
+        assertThat(dto.isLiked()).isFalse(); // 로그인하지 않은 경우 false
+        assertThat(dto.counts().view()).isEqualTo(verification.getViewCount());
+        assertThat(dto.counts().like()).isEqualTo(verification.getLikeCount());
+        assertThat(dto.counts().comment()).isEqualTo(verification.getCommentCount());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultSaveServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationResultSaveServiceTest.java
@@ -2,63 +2,43 @@ package ktb.leafresh.backend.domain.verification.application.service;
 
 import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
 import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class GroupChallengeVerificationResultSaveServiceTest {
 
+    @Mock
     private VerificationResultProcessor verificationResultProcessor;
-    private GroupChallengeVerificationResultSaveService service;
 
-    @BeforeEach
-    void setUp() {
-        verificationResultProcessor = mock(VerificationResultProcessor.class);
-        service = new GroupChallengeVerificationResultSaveService(verificationResultProcessor);
-    }
+    @InjectMocks
+    private GroupChallengeVerificationResultSaveService saveService;
 
     @Test
-    @DisplayName("result가 true/false일 경우 VerificationResultProcessor에 위임한다")
-    void saveResult_DelegatesToProcessor_WhenResultIsTrueOrFalse() {
+    @DisplayName("단체 인증 결과 저장 요청 시, Processor로 위임된다")
+    void saveResult_delegatesToProcessor() {
         // given
         Long verificationId = 1L;
-        VerificationResultRequestDto dto = VerificationResultRequestDto.builder()
+
+        VerificationResultRequestDto request = VerificationResultRequestDto.builder()
                 .type(ChallengeType.GROUP)
                 .memberId(10L)
-                .challengeId(123L)
+                .challengeId(100L)
                 .verificationId(verificationId)
-                .date("2025-06-08")
+                .date("2024-01-01")
                 .result("true")
                 .build();
 
         // when
-        service.saveResult(verificationId, dto);
+        saveService.saveResult(verificationId, request);
 
         // then
-        verify(verificationResultProcessor, times(1)).process(verificationId, dto);
-    }
-
-    @Test
-    @DisplayName("result가 HTTP 오류 코드일 경우 VerificationResultProcessor가 무시한다")
-    void saveResult_DoesNotDelegate_WhenResultIsHttpErrorCode() {
-        // given
-        Long verificationId = 2L;
-        VerificationResultRequestDto dto = VerificationResultRequestDto.builder()
-                .type(ChallengeType.GROUP)
-                .memberId(20L)
-                .challengeId(456L)
-                .verificationId(verificationId)
-                .date("2025-06-08")
-                .result("422")
-                .build();
-
-        // when
-        service.saveResult(verificationId, dto);
-
-        // then
-        verify(verificationResultProcessor, times(1)).process(verificationId, dto);
-        // 내부적으로 무시되더라도 서비스 단에서는 위임이 이뤄짐 (→ VerificationResultProcessor의 동작 테스트는 별도로 분리됨)
+        verify(verificationResultProcessor, times(1)).process(verificationId, request);
     }
 }

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationSubmitServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupChallengeVerificationSubmitServiceTest.java
@@ -1,142 +1,155 @@
-//package ktb.leafresh.backend.domain.verification.application.service;
-//
-//import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeParticipantRecordRepository;
-//import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
-//import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
-//import ktb.leafresh.backend.domain.verification.domain.support.validator.VerificationSubmitValidator;
-//import ktb.leafresh.backend.domain.verification.infrastructure.publisher.GcpAiVerificationPubSubPublisher;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
-//import ktb.leafresh.backend.domain.verification.presentation.dto.request.GroupChallengeVerificationRequestDto;
-//import ktb.leafresh.backend.global.exception.CustomException;
-//import ktb.leafresh.backend.global.exception.VerificationErrorCode;
-//import ktb.leafresh.backend.support.fixture.*;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.data.redis.core.StringRedisTemplate;
-//import org.springframework.data.redis.core.ValueOperations;
-//
-//import java.lang.reflect.Field;
-//import java.util.Optional;
-//
-//import static org.assertj.core.api.Assertions.assertThatThrownBy;
-//import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.*;
-//
-//class GroupChallengeVerificationSubmitServiceTest {
-//
-//    private GroupChallengeRepository groupChallengeRepository;
-//    private GroupChallengeParticipantRecordRepository recordRepository;
-//    private GroupChallengeVerificationRepository verificationRepository;
-//    private VerificationSubmitValidator validator;
-//    private StringRedisTemplate redisTemplate;
-//    private GcpAiVerificationPubSubPublisher pubSubPublisher;
-//    private GroupChallengeVerificationSubmitService service;
-//
-//    @BeforeEach
-//    void setUp() {
-//        groupChallengeRepository = mock(GroupChallengeRepository.class);
-//        recordRepository = mock(GroupChallengeParticipantRecordRepository.class);
-//        verificationRepository = mock(GroupChallengeVerificationRepository.class);
-//        validator = mock(VerificationSubmitValidator.class);
-//        redisTemplate = mock(StringRedisTemplate.class);
-//        pubSubPublisher = mock(GcpAiVerificationPubSubPublisher.class);
-//
-//        service = new GroupChallengeVerificationSubmitService(
-//                groupChallengeRepository,
-//                recordRepository,
-//                verificationRepository,
-//                validator,
-//                redisTemplate,
-//                pubSubPublisher
-//        );
-//    }
-//
-//    @Test
-//    @DisplayName("단체 챌린지 인증 제출에 성공하면 저장 및 Pub/Sub 발행, Redis 증가가 수행된다")
-//    void submit_Success() {
-//        // Given
-//        Long memberId = 1L;
-//        Long challengeId = 2L;
-//
-//        var member = MemberFixture.of();
-//        var category = GroupChallengeCategoryFixture.of("제로웨이스트");
-//        var challenge = GroupChallengeFixture.of(member, category);
-//        var record = GroupChallengeParticipantRecordFixture.of(challenge, member);
-//
-//        GroupChallengeVerificationRequestDto dto = new GroupChallengeVerificationRequestDto(
-//                "https://dummy.image/verify.jpg",
-//                "이건 인증 내용입니다."
-//        );
-//
-//        when(groupChallengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge));
-//        when(recordRepository.findByGroupChallengeIdAndMemberIdAndDeletedAtIsNull(challengeId, memberId))
-//                .thenReturn(Optional.of(record));
-//        when(verificationRepository
-//                .findTopByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_IdOrderByCreatedAtDesc(
-//                        memberId, challengeId))
-//                .thenReturn(Optional.empty());
-//        when(verificationRepository.save(any(GroupChallengeVerification.class)))
-//                .thenAnswer(invocation -> {
-//                    GroupChallengeVerification saved = invocation.getArgument(0);
-//
-//                    // 리플렉션으로 id 필드에 직접 값 주입
-//                    Field idField = GroupChallengeVerification.class.getDeclaredField("id");
-//                    idField.setAccessible(true);
-//                    idField.set(saved, 100L);
-//
-//                    return saved;
-//                });
-//
-//        ValueOperations<String, String> valueOps = mock(ValueOperations.class);
-//        when(redisTemplate.opsForValue()).thenReturn(valueOps);
-//
-//        // When
-//        service.submit(memberId, challengeId, dto);
-//
-//        // Then
-//        verify(validator).validate(dto.content());
-//        verify(verificationRepository).save(any(GroupChallengeVerification.class));
-//        verify(pubSubPublisher).publishAsyncWithRetry(any());
-//        verify(redisTemplate.opsForValue()).increment("leafresh:totalVerifications:count");
-//    }
-//
-//    @Test
-//    @DisplayName("이미 오늘 인증한 경우 예외를 발생시킨다")
-//    void submit_AlreadySubmitted_ThrowsException() {
-//        // Given
-//        Long memberId = 1L;
-//        Long challengeId = 2L;
-//
-//        var member = MemberFixture.of();
-//        var category = GroupChallengeCategoryFixture.of("제로웨이스트");
-//        var challenge = GroupChallengeFixture.of(member, category);
-//        var record = GroupChallengeParticipantRecordFixture.of(challenge, member);
-//        var verification = GroupChallengeVerificationFixture.of(record);
-//
-//        GroupChallengeVerificationRequestDto dto = new GroupChallengeVerificationRequestDto(
-//                "https://dummy.image/verify.jpg",
-//                "오늘 이미 인증함"
-//        );
-//
-//        when(groupChallengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge));
-//        when(recordRepository.findByGroupChallengeIdAndMemberIdAndDeletedAtIsNull(challengeId, memberId))
-//                .thenReturn(Optional.of(record));
-//        when(verificationRepository
-//                .findTopByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_IdOrderByCreatedAtDesc(
-//                        memberId, challengeId))
-//                .thenReturn(Optional.of(verification)); // 오늘 인증했으므로
-//
-//        // Expect
-//        assertThatThrownBy(() -> service.submit(memberId, challengeId, dto))
-//                .isInstanceOf(CustomException.class)
-//                .satisfies(ex -> {
-//                    CustomException ce = (CustomException) ex;
-//                    assertThat(ce.getErrorCode()).isEqualTo(VerificationErrorCode.ALREADY_SUBMITTED);
-//                });
-//
-//        verify(verificationRepository, never()).save(any());
-//        verify(pubSubPublisher, never()).publishAsyncWithRetry(any());
-//    }
-//}
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeParticipantRecordRepository;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.domain.support.validator.VerificationSubmitValidator;
+import ktb.leafresh.backend.domain.verification.infrastructure.publisher.GcpAiVerificationPubSubPublisher;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.presentation.dto.request.GroupChallengeVerificationRequestDto;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import ktb.leafresh.backend.support.fixture.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("GroupChallengeVerificationSubmitService 테스트")
+@ExtendWith(MockitoExtension.class)
+class GroupChallengeVerificationSubmitServiceTest {
+
+    @Mock
+    private GroupChallengeRepository groupChallengeRepository;
+
+    @Mock
+    private GroupChallengeParticipantRecordRepository recordRepository;
+
+    @Mock
+    private GroupChallengeVerificationRepository verificationRepository;
+
+    @Mock
+    private VerificationSubmitValidator validator;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private GcpAiVerificationPubSubPublisher pubSubPublisher;
+
+    @InjectMocks
+    private GroupChallengeVerificationSubmitService submitService;
+
+    private Member member;
+    private GroupChallenge challenge;
+    private GroupChallengeParticipantRecord participantRecord;
+    private GroupChallengeVerificationRequestDto requestDto;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.of();
+        challenge = GroupChallengeFixture.of(member, null);
+        participantRecord = GroupChallengeParticipantRecordFixture.of(challenge, member);
+        requestDto = new GroupChallengeVerificationRequestDto("https://img.test", "플라스틱 줄이기 캠페인 참여");
+    }
+
+    @Test
+    @DisplayName("그룹 챌린지 인증 제출 성공")
+    void submit_success() {
+        // given
+        Long memberId = 1L;
+        Long challengeId = 1L;
+
+        given(groupChallengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+        given(recordRepository.findByGroupChallengeIdAndMemberIdAndDeletedAtIsNull(challengeId, memberId))
+                .willReturn(Optional.of(participantRecord));
+        given(verificationRepository
+                .findTopByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_IdOrderByCreatedAtDesc(
+                        memberId, challengeId)).willReturn(Optional.empty());
+        given(verificationRepository.save(any())).willAnswer(invocation -> {
+            GroupChallengeVerification saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 10L);
+            return saved;
+        });
+
+        ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+        given(redisTemplate.opsForValue()).willReturn(valueOps);
+
+        // when
+        submitService.submit(memberId, challengeId, requestDto);
+
+        // then
+        then(validator).should().validate(requestDto.content());
+        then(groupChallengeRepository).should().findById(challengeId);
+        then(recordRepository).should()
+                .findByGroupChallengeIdAndMemberIdAndDeletedAtIsNull(challengeId, memberId);
+        then(verificationRepository).should()
+                .save(any(GroupChallengeVerification.class));
+        then(pubSubPublisher).should().publishAsyncWithRetry(any());
+        then(redisTemplate.opsForValue()).should().increment("leafresh:totalVerifications:count");
+    }
+
+    @Test
+    @DisplayName("그룹 챌린지를 찾을 수 없는 경우 예외 발생")
+    void submit_groupChallengeNotFound() {
+        // given
+        given(groupChallengeRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> submitService.submit(1L, 1L, requestDto))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("참가 기록이 없는 경우 예외 발생")
+    void submit_recordNotFound() {
+        // given
+        given(groupChallengeRepository.findById(anyLong())).willReturn(Optional.of(challenge));
+        given(recordRepository.findByGroupChallengeIdAndMemberIdAndDeletedAtIsNull(anyLong(), anyLong()))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> submitService.submit(1L, 1L, requestDto))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_RECORD_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("이미 당일 인증 제출한 경우 예외 발생")
+    void submit_alreadySubmittedToday() {
+        // given
+        GroupChallengeVerification existing = GroupChallengeVerificationFixture.of(participantRecord);
+        ReflectionTestUtils.setField(existing, "createdAt", LocalDateTime.now());
+
+        given(groupChallengeRepository.findById(anyLong())).willReturn(Optional.of(challenge));
+        given(recordRepository.findByGroupChallengeIdAndMemberIdAndDeletedAtIsNull(anyLong(), anyLong()))
+                .willReturn(Optional.of(participantRecord));
+        given(verificationRepository
+                .findTopByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_IdOrderByCreatedAtDesc(
+                        anyLong(), anyLong()))
+                .willReturn(Optional.of(existing));
+
+        // Redis 연산은 예외 발생 전에 도달하지 않으므로 stub 생략
+
+        // when & then
+        assertThatThrownBy(() -> submitService.submit(1L, 1L, requestDto))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.ALREADY_SUBMITTED.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentCreateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentCreateServiceTest.java
@@ -1,179 +1,327 @@
-//package ktb.leafresh.backend.domain.verification.application.service;
-//
-//import ktb.leafresh.backend.domain.member.domain.entity.Member;
-//import ktb.leafresh.backend.domain.verification.domain.entity.Comment;
-//import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.CommentRepository;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
-//import ktb.leafresh.backend.domain.verification.presentation.dto.request.GroupVerificationCommentCreateRequestDto;
-//import ktb.leafresh.backend.domain.verification.presentation.dto.response.CommentResponseDto;
-//import ktb.leafresh.backend.global.exception.CustomException;
-//import ktb.leafresh.backend.global.exception.VerificationErrorCode;
-//import ktb.leafresh.backend.global.util.redis.VerificationStatRedisLuaService;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.stubbing.Answer;
-//import org.springframework.test.util.ReflectionTestUtils;
-//
-//import java.time.LocalDateTime;
-//import java.util.Optional;
-//
-//import static ktb.leafresh.backend.support.fixture.GroupChallengeVerificationFixture.of;
-//import static ktb.leafresh.backend.support.fixture.MemberFixture.of;
-//import static org.assertj.core.api.Assertions.*;
-//import static org.mockito.Mockito.*;
-//
-//class GroupVerificationCommentCreateServiceTest {
-//
-//    private CommentRepository commentRepository;
-//    private GroupChallengeVerificationRepository verificationRepository;
-//    private VerificationStatRedisLuaService redisLuaService;
-//    private ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository memberRepository;
-//    private GroupVerificationCommentCreateService service;
-//
-//    private Member member;
-//    private GroupChallengeVerification verification;
-//
-//    @BeforeEach
-//    void setUp() {
-//        commentRepository = mock(CommentRepository.class);
-//        verificationRepository = mock(GroupChallengeVerificationRepository.class);
-//        redisLuaService = mock(VerificationStatRedisLuaService.class);
-//        memberRepository = mock(ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository.class);
-//
-//        service = new GroupVerificationCommentCreateService(
-//                commentRepository,
-//                verificationRepository,
-//                memberRepository,
-//                redisLuaService
-//        );
-//
-//        member = of(1L, "test@leafresh.com", "테스터");
-//        verification = of(null);
-//    }
-//
-//    @Test
-//    @DisplayName("일반 댓글을 생성한다")
-//    void createComment_success() {
-//        var requestDto = new GroupVerificationCommentCreateRequestDto("좋은 챌린지네요!");
-//        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//
-//        // save()로 전달된 Comment 객체에 createdAt을 세팅해서 그대로 반환
-//        when(commentRepository.save(any(Comment.class))).thenAnswer((Answer<Comment>) invocation -> {
-//            Comment comment = invocation.getArgument(0);
-//            ReflectionTestUtils.setField(comment, "id", 1L); // 테스트용 ID도 세팅
-//            ReflectionTestUtils.setField(comment, "createdAt", LocalDateTime.now());
-//            return comment;
-//        });
-//
-//        CommentResponseDto response = service.createComment(1L, 1L, 1L, requestDto);
-//
-//        assertThat(response.content()).isEqualTo("좋은 챌린지네요!");
-//        verify(commentRepository).save(any(Comment.class));
-//        verify(redisLuaService).increaseVerificationCommentCount(1L);
-//    }
-//
-//    @Test
-//    @DisplayName("대댓글을 생성한다")
-//    void createReply_success() {
-//        var requestDto = new GroupVerificationCommentCreateRequestDto("동의합니다!");
-//        Comment parent = Comment.builder()
-//                .id(999L)
-//                .content("좋은 챌린지네요!")
-//                .member(member)
-//                .verification(verification)
-//                .build();
-//        ReflectionTestUtils.setField(parent, "createdAt", LocalDateTime.now());
-//
-//        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        when(commentRepository.findById(999L)).thenReturn(Optional.of(parent));
-//
-//        // save 시점에 createdAt 세팅
-//        when(commentRepository.save(any(Comment.class))).thenAnswer((Answer<Comment>) invocation -> {
-//            Comment reply = invocation.getArgument(0);
-//            ReflectionTestUtils.setField(reply, "id", 1000L);
-//            ReflectionTestUtils.setField(reply, "createdAt", LocalDateTime.now());
-//            return reply;
-//        });
-//
-//        CommentResponseDto response = service.createReply(1L, 1L, 999L, 1L, requestDto);
-//
-//        assertThat(response.parentCommentId()).isEqualTo(999L);
-//        verify(commentRepository).save(any(Comment.class));
-//        verify(redisLuaService).increaseVerificationCommentCount(1L);
-//    }
-//
-//    @Test
-//    @DisplayName("삭제된 댓글에 대댓글을 작성하려고 하면 예외가 발생한다")
-//    void createReply_fail_deletedParent() {
-//        // Given
-//        var requestDto = new GroupVerificationCommentCreateRequestDto("동의합니다!");
-//        Comment deletedParent = mock(Comment.class);
-//        when(deletedParent.getDeletedAt()).thenReturn(java.time.LocalDateTime.now());
-//
-//        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        when(commentRepository.findById(999L)).thenReturn(Optional.of(deletedParent));
-//
-//        // When
-//        CustomException exception = catchThrowableOfType(
-//                () -> service.createReply(1L, 1L, 999L, 1L, requestDto),
-//                CustomException.class
-//        );
-//
-//        // Then
-//        assertThat(exception).isNotNull();
-//        assertThat(exception.getErrorCode()).isEqualTo(VerificationErrorCode.CANNOT_REPLY_TO_DELETED_COMMENT);
-//    }
-//
-//    @Test
-//    @DisplayName("댓글 생성 중 예상치 못한 예외가 발생하면 COMMENT_CREATE_FAILED 예외를 반환한다")
-//    void createComment_fail_by_unexpected_exception() {
-//        // Given
-//        var requestDto = new GroupVerificationCommentCreateRequestDto("좋은 챌린지네요!");
-//        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        doThrow(new RuntimeException("Redis 에러")).when(redisLuaService).increaseVerificationCommentCount(anyLong());
-//
-//        // When
-//        CustomException exception = catchThrowableOfType(
-//                () -> service.createComment(1L, 1L, 1L, requestDto),
-//                CustomException.class
-//        );
-//
-//        // Then
-//        assertThat(exception).isNotNull();
-//        assertThat(exception.getErrorCode()).isEqualTo(VerificationErrorCode.COMMENT_CREATE_FAILED);
-//    }
-//
-//    @Test
-//    @DisplayName("대댓글 생성 중 예상치 못한 예외가 발생하면 COMMENT_CREATE_FAILED 예외를 반환한다")
-//    void createReply_fail_by_unexpected_exception() {
-//        // Given
-//        var requestDto = new GroupVerificationCommentCreateRequestDto("저도 동의합니다!");
-//        Comment parent = Comment.builder()
-//                .id(999L)
-//                .content("좋은 챌린지네요!")
-//                .member(member)
-//                .verification(verification)
-//                .build();
-//
-//        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        when(commentRepository.findById(999L)).thenReturn(Optional.of(parent));
-//        doThrow(new RuntimeException("Redis 에러")).when(redisLuaService).increaseVerificationCommentCount(anyLong());
-//
-//        // When
-//        CustomException exception = catchThrowableOfType(
-//                () -> service.createReply(1L, 1L, 999L, 1L, requestDto),
-//                CustomException.class
-//        );
-//
-//        // Then
-//        assertThat(exception).isNotNull();
-//        assertThat(exception.getErrorCode()).isEqualTo(VerificationErrorCode.COMMENT_CREATE_FAILED);
-//    }
-//}
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.verification.domain.entity.Comment;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.CommentRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.presentation.dto.request.GroupVerificationCommentCreateRequestDto;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.CommentResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import ktb.leafresh.backend.global.util.redis.VerificationStatRedisLuaService;
+import ktb.leafresh.backend.support.fixture.GroupChallengeVerificationFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GroupVerificationCommentCreateServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private GroupChallengeVerificationRepository verificationRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private VerificationStatRedisLuaService verificationStatRedisLuaService;
+
+    @InjectMocks
+    private GroupVerificationCommentCreateService commentCreateService;
+
+    @Test
+    @DisplayName("댓글 생성에 성공한다")
+    void createComment_withValidInput_returnsResponse() {
+        // given
+        Long memberId = 1L;
+        Long verificationId = 10L;
+        Long challengeId = 100L;
+        String content = "좋은 인증이네요!";
+
+        Member member = MemberFixture.of();
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+        GroupVerificationCommentCreateRequestDto requestDto = new GroupVerificationCommentCreateRequestDto(content);
+
+        given(commentRepository.save(any(Comment.class)))
+                .willAnswer(invocation -> {
+                    Comment saved = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(saved, "id", 999L);
+                    ReflectionTestUtils.setField(saved, "createdAt", LocalDateTime.of(2024, 1, 1, 0, 0));
+                    return saved;
+                });
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+
+        // when
+        CommentResponseDto result = commentCreateService.createComment(challengeId, verificationId, memberId, requestDto);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(999L); // 또는 ArgumentCaptor 활용
+        assertThat(result.content()).isEqualTo(content);
+        assertThat(result.nickname()).isEqualTo(member.getNickname());
+        assertThat(result.profileImageUrl()).isEqualTo(member.getImageUrl());
+        assertThat(result.deleted()).isFalse();
+        assertThat(result.parentCommentId()).isNull();
+
+        then(memberRepository).should().findById(memberId);
+        then(verificationRepository).should().findByIdAndDeletedAtIsNull(verificationId);
+        then(commentRepository).should().save(any(Comment.class));
+        then(verificationStatRedisLuaService).should().increaseVerificationCommentCount(verificationId);
+    }
+
+    @Test
+    @DisplayName("댓글 생성 시 존재하지 않는 회원이면 예외가 발생한다")
+    void createComment_withInvalidMember_throwsException() {
+        // given
+        Long memberId = 1L;
+        Long verificationId = 10L;
+        Long challengeId = 100L;
+        GroupVerificationCommentCreateRequestDto requestDto = new GroupVerificationCommentCreateRequestDto("내용");
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                commentCreateService.createComment(challengeId, verificationId, memberId, requestDto)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+
+        then(memberRepository).should().findById(memberId);
+        then(verificationRepository).shouldHaveNoInteractions();
+        then(commentRepository).shouldHaveNoInteractions();
+        then(verificationStatRedisLuaService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("댓글 생성 시 존재하지 않는 인증이면 예외가 발생한다")
+    void createComment_withInvalidVerification_throwsException() {
+        // given
+        Long memberId = 1L;
+        Long verificationId = 10L;
+        Long challengeId = 100L;
+        Member member = MemberFixture.of();
+        GroupVerificationCommentCreateRequestDto requestDto = new GroupVerificationCommentCreateRequestDto("내용");
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                commentCreateService.createComment(challengeId, verificationId, memberId, requestDto)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.VERIFICATION_DETAIL_NOT_FOUND.getMessage());
+
+        then(memberRepository).should().findById(memberId);
+        then(verificationRepository).should().findByIdAndDeletedAtIsNull(verificationId);
+        then(commentRepository).shouldHaveNoInteractions();
+        then(verificationStatRedisLuaService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("대댓글 생성에 성공한다")
+    void createReply_withValidInput_returnsResponse() {
+        // given
+        Long memberId = 1L;
+        Long verificationId = 10L;
+        Long parentCommentId = 999L;
+        Long challengeId = 100L;
+        String content = "좋은 의견 감사합니다!";
+
+        Member member = MemberFixture.of();
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+
+        Comment parentComment = Comment.builder()
+                .verification(verification)
+                .member(member)
+                .content("부모 댓글")
+                .build();
+        ReflectionTestUtils.setField(parentComment, "id", parentCommentId);
+        ReflectionTestUtils.setField(parentComment, "createdAt", LocalDateTime.of(2024, 1, 1, 0, 0));
+
+        GroupVerificationCommentCreateRequestDto requestDto = new GroupVerificationCommentCreateRequestDto(content);
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(parentCommentId)).willReturn(Optional.of(parentComment));
+        given(commentRepository.save(any(Comment.class)))
+                .willAnswer(invocation -> {
+                    Comment reply = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(reply, "id", 1000L);
+                    ReflectionTestUtils.setField(reply, "createdAt", LocalDateTime.of(2024, 1, 2, 0, 0));
+                    return reply;
+                });
+
+        // when
+        CommentResponseDto result = commentCreateService.createReply(challengeId, verificationId, parentCommentId, memberId, requestDto);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(1000L);
+        assertThat(result.content()).isEqualTo(content);
+        assertThat(result.parentCommentId()).isEqualTo(parentCommentId);
+        assertThat(result.deleted()).isFalse();
+        assertThat(result.nickname()).isEqualTo(member.getNickname());
+        assertThat(result.profileImageUrl()).isEqualTo(member.getImageUrl());
+
+        then(memberRepository).should().findById(memberId);
+        then(verificationRepository).should().findByIdAndDeletedAtIsNull(verificationId);
+        then(commentRepository).should().findById(parentCommentId);
+        then(commentRepository).should().save(any(Comment.class));
+        then(verificationStatRedisLuaService).should().increaseVerificationCommentCount(verificationId);
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 시 존재하지 않는 부모 댓글이면 예외가 발생한다")
+    void createReply_withInvalidParentComment_throwsException() {
+        // given
+        Long memberId = 1L;
+        Long verificationId = 10L;
+        Long parentCommentId = 999L;
+        Long challengeId = 100L;
+        Member member = MemberFixture.of();
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+        GroupVerificationCommentCreateRequestDto requestDto = new GroupVerificationCommentCreateRequestDto("대댓글");
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(parentCommentId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                commentCreateService.createReply(challengeId, verificationId, parentCommentId, memberId, requestDto)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.COMMENT_NOT_FOUND.getMessage());
+
+        then(memberRepository).should().findById(memberId);
+        then(verificationRepository).should().findByIdAndDeletedAtIsNull(verificationId);
+        then(commentRepository).should().findById(parentCommentId);
+        then(commentRepository).should(never()).save(any());
+        then(verificationStatRedisLuaService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("삭제된 부모 댓글에는 대댓글을 달 수 없다")
+    void createReply_withDeletedParentComment_throwsException() {
+        // given
+        Long memberId = 1L;
+        Long verificationId = 10L;
+        Long parentCommentId = 999L;
+        Long challengeId = 100L;
+        Member member = MemberFixture.of();
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+
+        Comment deletedParent = Comment.builder()
+                .verification(verification)
+                .member(member)
+                .content("삭제된 댓글")
+                .build();
+        ReflectionTestUtils.setField(deletedParent, "id", parentCommentId);
+        ReflectionTestUtils.setField(deletedParent, "deletedAt", LocalDateTime.of(2024, 3, 1, 0, 0));
+
+        GroupVerificationCommentCreateRequestDto requestDto = new GroupVerificationCommentCreateRequestDto("대댓글");
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(parentCommentId)).willReturn(Optional.of(deletedParent));
+
+        // when & then
+        assertThatThrownBy(() ->
+                commentCreateService.createReply(challengeId, verificationId, parentCommentId, memberId, requestDto)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.CANNOT_REPLY_TO_DELETED_COMMENT.getMessage());
+
+        then(memberRepository).should().findById(memberId);
+        then(verificationRepository).should().findByIdAndDeletedAtIsNull(verificationId);
+        then(commentRepository).should().findById(parentCommentId);
+        then(commentRepository).should(never()).save(any());
+        then(verificationStatRedisLuaService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("댓글 생성 중 예기치 못한 예외가 발생하면 COMMENT_CREATE_FAILED 예외가 발생한다")
+    void createComment_whenUnexpectedExceptionThrown_throwsCreateFailedException() {
+        // given
+        Long memberId = 1L;
+        Long verificationId = 10L;
+        Long challengeId = 100L;
+
+        Member member = MemberFixture.of();
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+        GroupVerificationCommentCreateRequestDto requestDto = new GroupVerificationCommentCreateRequestDto("예외 테스트");
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.save(any(Comment.class))).willThrow(new RuntimeException("DB ERROR"));
+
+        // when & then
+        assertThatThrownBy(() ->
+                commentCreateService.createComment(challengeId, verificationId, memberId, requestDto)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.COMMENT_CREATE_FAILED.getMessage());
+
+        then(memberRepository).should().findById(memberId);
+        then(verificationRepository).should().findByIdAndDeletedAtIsNull(verificationId);
+        then(commentRepository).should().save(any(Comment.class));
+        then(verificationStatRedisLuaService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 중 예기치 못한 예외가 발생하면 COMMENT_CREATE_FAILED 예외가 발생한다")
+    void createReply_whenUnexpectedExceptionThrown_throwsCreateFailedException() {
+        // given
+        Long memberId = 1L;
+        Long verificationId = 10L;
+        Long parentCommentId = 999L;
+        Long challengeId = 100L;
+
+        Member member = MemberFixture.of();
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+        Comment parent = Comment.builder().verification(verification).member(member).content("부모 댓글").build();
+
+        ReflectionTestUtils.setField(parent, "id", parentCommentId);
+
+        GroupVerificationCommentCreateRequestDto requestDto = new GroupVerificationCommentCreateRequestDto("대댓글 예외");
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(parentCommentId)).willReturn(Optional.of(parent));
+        given(commentRepository.save(any(Comment.class))).willThrow(new RuntimeException("DB ERROR"));
+
+        // when & then
+        assertThatThrownBy(() ->
+                commentCreateService.createReply(challengeId, verificationId, parentCommentId, memberId, requestDto)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.COMMENT_CREATE_FAILED.getMessage());
+
+        then(memberRepository).should().findById(memberId);
+        then(verificationRepository).should().findByIdAndDeletedAtIsNull(verificationId);
+        then(commentRepository).should().findById(parentCommentId);
+        then(commentRepository).should().save(any(Comment.class));
+        then(verificationStatRedisLuaService).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentDeleteServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentDeleteServiceTest.java
@@ -1,166 +1,230 @@
-//package ktb.leafresh.backend.domain.verification.application.service;
-//
-//import ktb.leafresh.backend.domain.verification.domain.entity.Comment;
-//import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.CommentRepository;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
-//import ktb.leafresh.backend.global.exception.CustomException;
-//import ktb.leafresh.backend.global.exception.GlobalErrorCode;
-//import ktb.leafresh.backend.global.exception.VerificationErrorCode;
-//import ktb.leafresh.backend.global.util.redis.VerificationStatRedisLuaService;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//
-//import java.time.LocalDateTime;
-//import java.util.Optional;
-//
-//import static ktb.leafresh.backend.support.fixture.GroupChallengeVerificationFixture.of;
-//import static ktb.leafresh.backend.support.fixture.MemberFixture.of;
-//import static org.assertj.core.api.Assertions.*;
-//import static org.mockito.Mockito.*;
-//
-//class GroupVerificationCommentDeleteServiceTest {
-//
-//    private GroupChallengeVerificationRepository verificationRepository;
-//    private CommentRepository commentRepository;
-//    private VerificationStatRedisLuaService redisLuaService;
-//    private GroupVerificationCommentDeleteService service;
-//
-//    private final Long memberId = 1L;
-//    private final Long challengeId = 2L;
-//    private final Long verificationId = 3L;
-//    private final Long commentId = 4L;
-//
-//    @BeforeEach
-//    void setUp() {
-//        verificationRepository = mock(GroupChallengeVerificationRepository.class);
-//        commentRepository = mock(CommentRepository.class);
-//        redisLuaService = mock(VerificationStatRedisLuaService.class);
-//
-//        service = new GroupVerificationCommentDeleteService(
-//                verificationRepository,
-//                commentRepository,
-//                redisLuaService
-//        );
-//    }
-//
-//    @Test
-//    @DisplayName("댓글 삭제 성공")
-//    void deleteComment_success() {
-//        var member = of(memberId, "test@leafresh.com", "테스터");
-//        var verification = of(null);
-//        var comment = Comment.builder()
-//                .id(commentId)
-//                .member(member)
-//                .verification(verification)
-//                .content("삭제할 댓글")
-//                .build();
-//
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).thenReturn(Optional.of(verification));
-//        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
-//
-//        service.deleteComment(challengeId, verificationId, commentId, memberId);
-//
-//        assertThat(comment.isDeleted()).isTrue();
-//        verify(redisLuaService).decreaseVerificationCommentCount(verificationId);
-//    }
-//
-//    @Test
-//    @DisplayName("검증 정보가 없으면 예외 발생")
-//    void deleteComment_fail_verification_not_found() {
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).thenReturn(Optional.empty());
-//
-//        CustomException ex = catchThrowableOfType(() ->
-//                        service.deleteComment(challengeId, verificationId, commentId, memberId),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(VerificationErrorCode.VERIFICATION_DETAIL_NOT_FOUND);
-//    }
-//
-//    @Test
-//    @DisplayName("댓글 정보가 없으면 예외 발생")
-//    void deleteComment_fail_comment_not_found() {
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).thenReturn(Optional.of(of(null)));
-//        when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
-//
-//        CustomException ex = catchThrowableOfType(() ->
-//                        service.deleteComment(challengeId, verificationId, commentId, memberId),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(VerificationErrorCode.COMMENT_NOT_FOUND);
-//    }
-//
-//    @Test
-//    @DisplayName("다른 사용자가 댓글 삭제 시도하면 예외 발생")
-//    void deleteComment_fail_access_denied() {
-//        var wrongMember = of(999L, "other@leafresh.com", "다른 사람");
-//        var comment = Comment.builder()
-//                .id(commentId)
-//                .member(wrongMember)
-//                .verification(of(null))
-//                .content("댓글")
-//                .build();
-//
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).thenReturn(Optional.of(of(null)));
-//        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
-//
-//        CustomException ex = catchThrowableOfType(() ->
-//                        service.deleteComment(challengeId, verificationId, commentId, memberId),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(GlobalErrorCode.ACCESS_DENIED);
-//    }
-//
-//    @Test
-//    @DisplayName("이미 삭제된 댓글은 삭제할 수 없음")
-//    void deleteComment_fail_already_deleted() {
-//        var member = of(memberId, "test@leafresh.com", "테스터");
-//        var comment = Comment.builder()
-//                .id(commentId)
-//                .member(member)
-//                .verification(of(null))
-//                .content("삭제된 댓글")
-//                .build();
-//
-//        // soft delete 처리
-//        comment.softDelete();
-//
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).thenReturn(Optional.of(of(null)));
-//        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
-//
-//        CustomException ex = catchThrowableOfType(() ->
-//                        service.deleteComment(challengeId, verificationId, commentId, memberId),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(VerificationErrorCode.CANNOT_EDIT_DELETED_COMMENT);
-//    }
-//
-//    @Test
-//    @DisplayName("예상치 못한 예외가 발생하면 COMMENT_UPDATE_FAILED 예외 발생")
-//    void deleteComment_fail_by_unexpected_exception() {
-//        var member = of(memberId, "test@leafresh.com", "테스터");
-//        var verification = of(null);
-//        var comment = Comment.builder()
-//                .id(commentId)
-//                .member(member)
-//                .verification(verification)
-//                .content("댓글")
-//                .build();
-//
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).thenReturn(Optional.of(verification));
-//        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
-//        doThrow(new RuntimeException("Redis 에러")).when(redisLuaService).decreaseVerificationCommentCount(verificationId);
-//
-//        CustomException ex = catchThrowableOfType(() ->
-//                        service.deleteComment(challengeId, verificationId, commentId, memberId),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(VerificationErrorCode.COMMENT_UPDATE_FAILED);
-//    }
-//}
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.verification.domain.entity.Comment;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.CommentRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import ktb.leafresh.backend.global.util.redis.VerificationStatRedisLuaService;
+import ktb.leafresh.backend.support.fixture.GroupChallengeVerificationFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GroupVerificationCommentDeleteServiceTest {
+
+    @Mock
+    private GroupChallengeVerificationRepository verificationRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private VerificationStatRedisLuaService verificationStatRedisLuaService;
+
+    @InjectMocks
+    private GroupVerificationCommentDeleteService deleteService;
+
+    @Test
+    @DisplayName("댓글 삭제에 성공한다")
+    void deleteComment_withValidInput_success() {
+        // given
+        Long challengeId = 1L;
+        Long verificationId = 10L;
+        Long commentId = 100L;
+        Long memberId = 50L;
+
+        Member member = MemberFixture.of();
+        ReflectionTestUtils.setField(member, "id", memberId);
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+
+        Comment comment = Comment.builder()
+                .member(member)
+                .verification(verification)
+                .content("삭제할 댓글")
+                .build();
+        ReflectionTestUtils.setField(comment, "id", commentId);
+        ReflectionTestUtils.setField(comment, "deletedAt", null); // 삭제되지 않은 상태
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+
+        // when
+        deleteService.deleteComment(challengeId, verificationId, commentId, memberId);
+
+        // then
+        assertThat(comment.isDeleted()).isTrue();
+        then(verificationRepository).should().findByIdAndDeletedAtIsNull(verificationId);
+        then(commentRepository).should().findById(commentId);
+        then(verificationStatRedisLuaService).should().decreaseVerificationCommentCount(verificationId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 인증 ID이면 예외 발생")
+    void deleteComment_withInvalidVerification_throwsException() {
+        // given
+        Long challengeId = 1L;
+        Long verificationId = 10L;
+        Long commentId = 100L;
+        Long memberId = 50L;
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                deleteService.deleteComment(challengeId, verificationId, commentId, memberId)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.VERIFICATION_DETAIL_NOT_FOUND.getMessage());
+
+        then(verificationRepository).should().findByIdAndDeletedAtIsNull(verificationId);
+        then(commentRepository).shouldHaveNoInteractions();
+        then(verificationStatRedisLuaService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글 ID이면 예외 발생")
+    void deleteComment_withInvalidComment_throwsException() {
+        // given
+        Long challengeId = 1L;
+        Long verificationId = 10L;
+        Long commentId = 100L;
+        Long memberId = 50L;
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(commentId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                deleteService.deleteComment(challengeId, verificationId, commentId, memberId)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.COMMENT_NOT_FOUND.getMessage());
+
+        then(commentRepository).should().findById(commentId);
+        then(verificationStatRedisLuaService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 댓글은 삭제할 수 없다")
+    void deleteComment_withOtherUser_throwsAccessDenied() {
+        // given
+        Long challengeId = 1L;
+        Long verificationId = 10L;
+        Long commentId = 100L;
+        Long memberId = 1L;
+        Long anotherMemberId = 2L;
+
+        Member anotherMember = MemberFixture.of();
+        ReflectionTestUtils.setField(anotherMember, "id", anotherMemberId);
+
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+
+        Comment comment = Comment.builder()
+                .member(anotherMember)
+                .verification(verification)
+                .content("남의 댓글")
+                .build();
+        ReflectionTestUtils.setField(comment, "id", commentId);
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+
+        // when & then
+        assertThatThrownBy(() ->
+                deleteService.deleteComment(challengeId, verificationId, commentId, memberId)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(GlobalErrorCode.ACCESS_DENIED.getMessage());
+
+        then(verificationStatRedisLuaService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 댓글이면 예외 발생")
+    void deleteComment_whenAlreadyDeleted_throwsException() {
+        // given
+        Long challengeId = 1L;
+        Long verificationId = 10L;
+        Long commentId = 100L;
+        Long memberId = 1L;
+
+        Member member = MemberFixture.of();
+        ReflectionTestUtils.setField(member, "id", memberId);
+
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+
+        Comment comment = Comment.builder()
+                .member(member)
+                .verification(verification)
+                .content("이미 삭제된 댓글")
+                .build();
+        ReflectionTestUtils.setField(comment, "id", commentId);
+        ReflectionTestUtils.setField(comment, "deletedAt", LocalDateTime.of(2024, 1, 1, 0, 0));
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+
+        // when & then
+        assertThatThrownBy(() ->
+                deleteService.deleteComment(challengeId, verificationId, commentId, memberId)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.CANNOT_EDIT_DELETED_COMMENT.getMessage());
+
+        then(verificationStatRedisLuaService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 중 예기치 못한 예외가 발생하면 COMMENT_UPDATE_FAILED 예외 발생")
+    void deleteComment_whenUnexpectedException_throwsCreateFailed() {
+        // given
+        Long challengeId = 1L;
+        Long verificationId = 10L;
+        Long commentId = 100L;
+        Long memberId = 1L;
+
+        Member member = MemberFixture.of();
+        ReflectionTestUtils.setField(member, "id", memberId);
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+
+        Comment comment = Comment.builder()
+                .member(member)
+                .verification(verification)
+                .content("예외 발생 댓글")
+                .build();
+        ReflectionTestUtils.setField(comment, "id", commentId);
+        ReflectionTestUtils.setField(comment, "deletedAt", null);
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+        willThrow(new RuntimeException("Redis 오류")).given(verificationStatRedisLuaService)
+                .decreaseVerificationCommentCount(verificationId);
+
+        // when & then
+        assertThatThrownBy(() ->
+                deleteService.deleteComment(challengeId, verificationId, commentId, memberId)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.COMMENT_UPDATE_FAILED.getMessage());
+
+        then(verificationStatRedisLuaService).should().decreaseVerificationCommentCount(verificationId);
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentQueryServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentQueryServiceTest.java
@@ -1,102 +1,135 @@
-//package ktb.leafresh.backend.domain.verification.application.service;
-//
-//import ktb.leafresh.backend.domain.verification.domain.entity.Comment;
-//import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.CommentRepository;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
-//import ktb.leafresh.backend.domain.verification.presentation.dto.response.CommentSummaryResponseDto;
-//import ktb.leafresh.backend.global.exception.CustomException;
-//import ktb.leafresh.backend.global.exception.VerificationErrorCode;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.test.util.ReflectionTestUtils;
-//
-//import java.util.List;
-//import java.util.Optional;
-//
-//import static ktb.leafresh.backend.support.fixture.GroupChallengeVerificationFixture.of;
-//import static ktb.leafresh.backend.support.fixture.MemberFixture.of;
-//import static org.assertj.core.api.Assertions.*;
-//import static org.mockito.Mockito.*;
-//
-//class GroupVerificationCommentQueryServiceTest {
-//
-//    private GroupChallengeVerificationRepository verificationRepository;
-//    private CommentRepository commentRepository;
-//    private GroupVerificationCommentQueryService service;
-//
-//    @BeforeEach
-//    void setUp() {
-//        verificationRepository = mock(GroupChallengeVerificationRepository.class);
-//        commentRepository = mock(CommentRepository.class);
-//        service = new GroupVerificationCommentQueryService(verificationRepository, commentRepository);
-//    }
-//
-//    @Test
-//    @DisplayName("댓글 목록을 정상 조회한다")
-//    void getComments_success() {
-//        // Given
-//        Long challengeId = 1L;
-//        Long verificationId = 2L;
-//        Long loginMemberId = 3L;
-//
-//        GroupChallengeVerification verification = of(null);
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).thenReturn(Optional.of(verification));
-//
-//        var member = of(loginMemberId, "test@leafresh.com", "테스터");
-//
-//        var comment1 = Comment.builder()
-//                .id(1L)
-//                .member(member)
-//                .verification(verification)
-//                .content("댓글1")
-//                .build();
-//
-//        var comment2 = Comment.builder()
-//                .id(2L)
-//                .member(member)
-//                .verification(verification)
-//                .content("댓글2")
-//                .build();
-//
-//        var now = java.time.LocalDateTime.now();
-//        ReflectionTestUtils.setField(comment1, "createdAt", now.minusSeconds(10));
-//        ReflectionTestUtils.setField(comment1, "updatedAt", now.minusSeconds(5));
-//
-//        ReflectionTestUtils.setField(comment2, "createdAt", now);
-//        ReflectionTestUtils.setField(comment2, "updatedAt", now);
-//
-//        when(commentRepository.findAllByVerificationIdWithMember(verificationId))
-//                .thenReturn(List.of(comment1, comment2));
-//
-//        // When
-//        List<CommentSummaryResponseDto> result = service.getComments(challengeId, verificationId, loginMemberId);
-//
-//        // Then
-//        assertThat(result).hasSize(2);
-//        assertThat(result.get(0).getContent()).isEqualTo("댓글1");
-//        assertThat(result.get(1).getContent()).isEqualTo("댓글2");
-//    }
-//
-//    @Test
-//    @DisplayName("존재하지 않는 인증 ID면 예외를 반환한다")
-//    void getComments_fail_verificationNotFound() {
-//        // Given
-//        Long challengeId = 1L;
-//        Long verificationId = 999L;
-//        Long loginMemberId = 1L;
-//
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).thenReturn(Optional.empty());
-//
-//        // When
-//        CustomException exception = catchThrowableOfType(
-//                () -> service.getComments(challengeId, verificationId, loginMemberId),
-//                CustomException.class
-//        );
-//
-//        // Then
-//        assertThat(exception).isNotNull();
-//        assertThat(exception.getErrorCode()).isEqualTo(VerificationErrorCode.VERIFICATION_DETAIL_NOT_FOUND);
-//    }
-//}
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.verification.domain.entity.Comment;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.CommentRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.CommentSummaryResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import ktb.leafresh.backend.support.fixture.GroupChallengeVerificationFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GroupVerificationCommentQueryServiceTest {
+
+    @Mock
+    private GroupChallengeVerificationRepository verificationRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @InjectMocks
+    private GroupVerificationCommentQueryService commentQueryService;
+
+    @Test
+    @DisplayName("댓글 계층 목록 조회에 성공한다")
+    void getComments_withValidInput_returnsHierarchy() {
+        // given
+        Long challengeId = 1L;
+        Long verificationId = 10L;
+        Long memberId = 99L;
+
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+        Member member = MemberFixture.of();
+        ReflectionTestUtils.setField(member, "id", memberId);
+
+        // 부모 댓글
+        Comment parent = Comment.builder()
+                .verification(verification)
+                .member(member)
+                .content("부모 댓글")
+                .build();
+        ReflectionTestUtils.setField(parent, "id", 100L);
+        ReflectionTestUtils.setField(parent, "createdAt", LocalDateTime.of(2024, 1, 1, 12, 0));
+        ReflectionTestUtils.setField(parent, "updatedAt", LocalDateTime.of(2024, 1, 1, 12, 0));
+
+        // 자식 댓글
+        Comment child = Comment.builder()
+                .verification(verification)
+                .member(member)
+                .parentComment(parent)
+                .content("대댓글")
+                .build();
+        ReflectionTestUtils.setField(child, "id", 101L);
+        ReflectionTestUtils.setField(child, "createdAt", LocalDateTime.of(2024, 1, 1, 12, 1));
+        ReflectionTestUtils.setField(child, "updatedAt", LocalDateTime.of(2024, 1, 1, 12, 1));
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.findAllByVerificationIdWithMember(verificationId))
+                .willReturn(List.of(parent, child));
+
+        // when
+        List<CommentSummaryResponseDto> result = commentQueryService.getComments(challengeId, verificationId, memberId);
+
+        // then
+        assertThat(result).hasSize(1);
+        CommentSummaryResponseDto parentDto = result.get(0);
+        assertThat(parentDto.getId()).isEqualTo(parent.getId());
+        assertThat(parentDto.getReplies()).hasSize(1);
+        assertThat(parentDto.getReplies().get(0).getId()).isEqualTo(child.getId());
+        assertThat(parentDto.isMine()).isTrue();
+        assertThat(parentDto.getReplies().get(0).isMine()).isTrue();
+
+        then(verificationRepository).should().findByIdAndDeletedAtIsNull(verificationId);
+        then(commentRepository).should().findAllByVerificationIdWithMember(verificationId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 인증 ID이면 예외 발생")
+    void getComments_withInvalidVerification_throwsException() {
+        // given
+        Long challengeId = 1L;
+        Long verificationId = 99L;
+        Long loginMemberId = 1L;
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                commentQueryService.getComments(challengeId, verificationId, loginMemberId)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.VERIFICATION_DETAIL_NOT_FOUND.getMessage());
+
+        then(verificationRepository).should().findByIdAndDeletedAtIsNull(verificationId);
+        then(commentRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("댓글이 하나도 없는 경우 빈 리스트를 반환한다")
+    void getComments_withNoComments_returnsEmptyList() {
+        // given
+        Long challengeId = 1L;
+        Long verificationId = 10L;
+        Long loginMemberId = 1L;
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.findAllByVerificationIdWithMember(verificationId)).willReturn(List.of());
+
+        // when
+        List<CommentSummaryResponseDto> result = commentQueryService.getComments(challengeId, verificationId, loginMemberId);
+
+        // then
+        assertThat(result).isEmpty();
+
+        then(verificationRepository).should().findByIdAndDeletedAtIsNull(verificationId);
+        then(commentRepository).should().findAllByVerificationIdWithMember(verificationId);
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentUpdateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationCommentUpdateServiceTest.java
@@ -1,143 +1,206 @@
-//package ktb.leafresh.backend.domain.verification.application.service;
-//
-//import ktb.leafresh.backend.domain.member.domain.entity.Member;
-//import ktb.leafresh.backend.domain.verification.domain.entity.Comment;
-//import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.CommentRepository;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
-//import ktb.leafresh.backend.domain.verification.presentation.dto.request.GroupVerificationCommentCreateRequestDto;
-//import ktb.leafresh.backend.domain.verification.presentation.dto.response.CommentUpdateResponseDto;
-//import ktb.leafresh.backend.global.exception.CustomException;
-//import ktb.leafresh.backend.global.exception.GlobalErrorCode;
-//import ktb.leafresh.backend.global.exception.VerificationErrorCode;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.test.util.ReflectionTestUtils;
-//
-//import java.time.LocalDateTime;
-//import java.util.List;
-//import java.util.Optional;
-//
-//import static ktb.leafresh.backend.support.fixture.GroupChallengeVerificationFixture.of;
-//import static ktb.leafresh.backend.support.fixture.MemberFixture.of;
-//import static org.assertj.core.api.Assertions.*;
-//import static org.mockito.Mockito.*;
-//
-//class GroupVerificationCommentUpdateServiceTest {
-//
-//    private CommentRepository commentRepository;
-//    private GroupChallengeVerificationRepository verificationRepository;
-//    private GroupVerificationCommentUpdateService service;
-//
-//    private Member member;
-//    private GroupChallengeVerification verification;
-//    private Comment comment;
-//
-//    @BeforeEach
-//    void setUp() {
-//        commentRepository = mock(CommentRepository.class);
-//        verificationRepository = mock(GroupChallengeVerificationRepository.class);
-//
-//        service = new GroupVerificationCommentUpdateService(
-//                verificationRepository,
-//                commentRepository
-//        );
-//
-//        member = of(1L, "user@leafresh.com", "테스터");
-//        verification = of(null);
-//
-//        comment = Comment.builder()
-//                .id(100L)
-//                .content("기존 댓글 내용")
-//                .member(member)
-//                .verification(verification)
-//                .build();
-//    }
-//
-//    @Test
-//    @DisplayName("댓글 수정 성공")
-//    void updateComment_success() {
-//        // given
-//        var dto = new GroupVerificationCommentCreateRequestDto("수정된 댓글 내용");
-//
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        when(commentRepository.findById(100L)).thenReturn(Optional.of(comment));
-//        when(commentRepository.findByParentCommentAndDeletedAtIsNull(comment)).thenReturn(List.of());
-//
-//        // 수정 로직 후 updatedAt이 null인 상태이므로, 테스트에서 수동 세팅
-//        ReflectionTestUtils.setField(comment, "updatedAt", LocalDateTime.now());
-//
-//        // when
-//        CommentUpdateResponseDto response = service.updateComment(1L, 1L, 100L, 1L, dto);
-//
-//        // then
-//        assertThat(response.content()).isEqualTo("수정된 댓글 내용");
-//        verify(commentRepository, times(1)).findByParentCommentAndDeletedAtIsNull(comment);
-//    }
-//
-//    @Test
-//    @DisplayName("댓글을 찾을 수 없으면 예외 발생")
-//    void updateComment_fail_comment_not_found() {
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        when(commentRepository.findById(100L)).thenReturn(Optional.empty());
-//
-//        CustomException ex = catchThrowableOfType(() ->
-//                        service.updateComment(1L, 1L, 100L, 1L, new GroupVerificationCommentCreateRequestDto("업데이트")),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(VerificationErrorCode.COMMENT_NOT_FOUND);
-//    }
-//
-//    @Test
-//    @DisplayName("다른 사용자가 댓글 수정 시도 시 예외 발생")
-//    void updateComment_fail_access_denied() {
-//        Member other = of(2L, "other@leafresh.com", "다른사람");
-//        comment = Comment.builder()
-//                .id(100L)
-//                .content("내용")
-//                .member(other)
-//                .verification(verification)
-//                .build();
-//
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        when(commentRepository.findById(100L)).thenReturn(Optional.of(comment));
-//
-//        CustomException ex = catchThrowableOfType(() ->
-//                        service.updateComment(1L, 1L, 100L, 1L, new GroupVerificationCommentCreateRequestDto("업데이트")),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(GlobalErrorCode.ACCESS_DENIED);
-//    }
-//
-//    @Test
-//    @DisplayName("삭제된 댓글 수정 시도 시 예외 발생")
-//    void updateComment_fail_deleted_comment() {
-//        comment.softDelete();
-//
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        when(commentRepository.findById(100L)).thenReturn(Optional.of(comment));
-//
-//        CustomException ex = catchThrowableOfType(() ->
-//                        service.updateComment(1L, 1L, 100L, 1L, new GroupVerificationCommentCreateRequestDto("업데이트")),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(VerificationErrorCode.CANNOT_EDIT_DELETED_COMMENT);
-//    }
-//
-//    @Test
-//    @DisplayName("예상치 못한 예외 발생 시 COMMENT_UPDATE_FAILED 반환")
-//    void updateComment_fail_by_unexpected_exception() {
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenThrow(new RuntimeException("DB Error"));
-//
-//        CustomException ex = catchThrowableOfType(() ->
-//                        service.updateComment(1L, 1L, 100L, 1L, new GroupVerificationCommentCreateRequestDto("업데이트")),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(VerificationErrorCode.COMMENT_UPDATE_FAILED);
-//    }
-//}
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.verification.domain.entity.Comment;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.CommentRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.presentation.dto.request.GroupVerificationCommentCreateRequestDto;
+import ktb.leafresh.backend.domain.verification.presentation.dto.response.CommentUpdateResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import ktb.leafresh.backend.support.fixture.GroupChallengeVerificationFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GroupVerificationCommentUpdateServiceTest {
+
+    @Mock
+    private GroupChallengeVerificationRepository verificationRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @InjectMocks
+    private GroupVerificationCommentUpdateService updateService;
+
+    @Test
+    @DisplayName("댓글 수정에 성공한다")
+    void updateComment_withValidInput_returnsUpdatedResponse() {
+        // given
+        Long challengeId = 1L;
+        Long verificationId = 10L;
+        Long commentId = 100L;
+        Long memberId = 999L;
+        String newContent = "수정된 댓글 내용";
+
+        Member member = MemberFixture.of();
+        ReflectionTestUtils.setField(member, "id", memberId);
+
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+
+        Comment comment = Comment.builder()
+                .verification(verification)
+                .member(member)
+                .content("기존 댓글")
+                .build();
+        ReflectionTestUtils.setField(comment, "id", commentId);
+        ReflectionTestUtils.setField(comment, "createdAt", LocalDateTime.of(2024, 1, 1, 12, 0));
+        ReflectionTestUtils.setField(comment, "updatedAt", LocalDateTime.of(2024, 1, 1, 12, 0));
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+        given(commentRepository.findByParentCommentAndDeletedAtIsNull(comment)).willReturn(List.of());
+
+        // when
+        GroupVerificationCommentCreateRequestDto dto = new GroupVerificationCommentCreateRequestDto(newContent);
+        CommentUpdateResponseDto result = updateService.updateComment(challengeId, verificationId, commentId, memberId, dto);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(commentId);
+        assertThat(result.content()).isEqualTo(newContent);
+        assertThat(result.nickname()).isEqualTo(member.getNickname());
+        assertThat(result.profileImageUrl()).isEqualTo(member.getImageUrl());
+        assertThat(result.deleted()).isFalse();
+        assertThat(result.replies()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 인증이면 예외 발생")
+    void updateComment_withInvalidVerification_throwsException() {
+        // given
+        Long verificationId = 10L;
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                updateService.updateComment(1L, verificationId, 100L, 999L, new GroupVerificationCommentCreateRequestDto("수정"))
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.VERIFICATION_DETAIL_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글이면 예외 발생")
+    void updateComment_withInvalidComment_throwsException() {
+        // given
+        Long verificationId = 10L;
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(100L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                updateService.updateComment(1L, verificationId, 100L, 999L, new GroupVerificationCommentCreateRequestDto("수정"))
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.COMMENT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("본인의 댓글이 아니면 예외 발생")
+    void updateComment_notMine_throwsAccessDenied() {
+        // given
+        Long memberId = 1L;
+        Long anotherId = 2L;
+
+        Member other = MemberFixture.of();
+        ReflectionTestUtils.setField(other, "id", anotherId);
+
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+
+        Comment comment = Comment.builder()
+                .verification(verification)
+                .member(other)
+                .content("다른 사람 댓글")
+                .build();
+        ReflectionTestUtils.setField(comment, "id", 100L);
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(100L)).willReturn(Optional.of(comment));
+
+        // when & then
+        assertThatThrownBy(() ->
+                updateService.updateComment(1L, 10L, 100L, memberId, new GroupVerificationCommentCreateRequestDto("수정"))
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(GlobalErrorCode.ACCESS_DENIED.getMessage());
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 댓글은 수정할 수 없다")
+    void updateComment_withDeletedComment_throwsException() {
+        // given
+        Long memberId = 1L;
+
+        Member member = MemberFixture.of();
+        ReflectionTestUtils.setField(member, "id", memberId);
+
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+
+        Comment comment = Comment.builder()
+                .verification(verification)
+                .member(member)
+                .content("삭제된 댓글")
+                .build();
+        ReflectionTestUtils.setField(comment, "id", 100L);
+        ReflectionTestUtils.setField(comment, "deletedAt", LocalDateTime.of(2024, 1, 1, 0, 0));
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(100L)).willReturn(Optional.of(comment));
+
+        // when & then
+        assertThatThrownBy(() ->
+                updateService.updateComment(1L, 10L, 100L, memberId, new GroupVerificationCommentCreateRequestDto("수정"))
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.CANNOT_EDIT_DELETED_COMMENT.getMessage());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 중 예기치 못한 예외 발생 시 COMMENT_UPDATE_FAILED 예외 발생")
+    void updateComment_whenUnexpectedExceptionThrown_throwsCreateFailed() {
+        // given
+        Long memberId = 1L;
+
+        Member member = MemberFixture.of();
+        ReflectionTestUtils.setField(member, "id", memberId);
+
+        GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(null);
+
+        Comment comment = Comment.builder()
+                .verification(verification)
+                .member(member)
+                .content("기존 댓글")
+                .build();
+        ReflectionTestUtils.setField(comment, "id", 100L);
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(verification));
+        given(commentRepository.findById(100L)).willReturn(Optional.of(comment));
+        given(commentRepository.findByParentCommentAndDeletedAtIsNull(comment)).willThrow(new RuntimeException("DB ERROR"));
+
+        // when & then
+        assertThatThrownBy(() ->
+                updateService.updateComment(1L, 10L, 100L, memberId, new GroupVerificationCommentCreateRequestDto("수정"))
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.COMMENT_UPDATE_FAILED.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationLikeServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/GroupVerificationLikeServiceTest.java
@@ -1,149 +1,173 @@
-//package ktb.leafresh.backend.domain.verification.application.service;
-//
-//import ktb.leafresh.backend.domain.member.domain.entity.Member;
-//import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
-//import ktb.leafresh.backend.domain.verification.domain.entity.Like;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.LikeRepository;
-//import ktb.leafresh.backend.global.exception.CustomException;
-//import ktb.leafresh.backend.global.exception.GlobalErrorCode;
-//import ktb.leafresh.backend.global.exception.VerificationErrorCode;
-//import ktb.leafresh.backend.global.util.redis.VerificationStatRedisLuaService;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//
-//import java.util.Optional;
-//
-//import static ktb.leafresh.backend.support.fixture.GroupChallengeVerificationFixture.of;
-//import static ktb.leafresh.backend.support.fixture.MemberFixture.of;
-//import static org.assertj.core.api.Assertions.*;
-//import static org.mockito.Mockito.*;
-//
-//class GroupVerificationLikeServiceTest {
-//
-//    private GroupChallengeVerificationRepository verificationRepository;
-//    private LikeRepository likeRepository;
-//    private ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository memberRepository;
-//    private VerificationStatRedisLuaService redisService;
-//    private GroupVerificationLikeService service;
-//
-//    private Member member;
-//    private GroupChallengeVerification verification;
-//
-//    @BeforeEach
-//    void setUp() {
-//        verificationRepository = mock(GroupChallengeVerificationRepository.class);
-//        likeRepository = mock(LikeRepository.class);
-//        memberRepository = mock(ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository.class);
-//        redisService = mock(VerificationStatRedisLuaService.class);
-//
-//        service = new GroupVerificationLikeService(
-//                verificationRepository, likeRepository, memberRepository, redisService
-//        );
-//
-//        member = of(1L, "user@leafresh.com", "테스터");
-//        verification = of(null);
-//    }
-//
-//    @Test
-//    @DisplayName("좋아요가 없는 경우 새로 생성한다")
-//    void likeVerification_createNewLike() {
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        when(memberRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(member));
-//        when(likeRepository.existsByVerificationIdAndMemberIdAndDeletedAtIsNull(1L, 1L)).thenReturn(false);
-//        when(likeRepository.findByVerificationIdAndMemberId(1L, 1L)).thenReturn(Optional.empty());
-//
-//        boolean result = service.likeVerification(1L, 1L);
-//
-//        assertThat(result).isTrue();
-//        verify(likeRepository).save(any(Like.class));
-//        verify(redisService).increaseVerificationLikeCount(1L);
-//    }
-//
-//    @Test
-//    @DisplayName("soft delete된 좋아요가 있는 경우 복구한다")
-//    void likeVerification_restoreDeletedLike() {
-//        Like like = mock(Like.class);
-//        when(like.isDeleted()).thenReturn(true);
-//
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        when(memberRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(member));
-//        when(likeRepository.existsByVerificationIdAndMemberIdAndDeletedAtIsNull(1L, 1L)).thenReturn(false);
-//        when(likeRepository.findByVerificationIdAndMemberId(1L, 1L)).thenReturn(Optional.of(like));
-//
-//        boolean result = service.likeVerification(1L, 1L);
-//
-//        assertThat(result).isTrue();
-//        verify(like).restoreLike();
-//        verify(redisService).increaseVerificationLikeCount(1L);
-//    }
-//
-//    @Test
-//    @DisplayName("이미 좋아요가 되어 있는 경우 아무 작업 없이 true 반환")
-//    void likeVerification_alreadyExists() {
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        when(memberRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(member));
-//        when(likeRepository.existsByVerificationIdAndMemberIdAndDeletedAtIsNull(1L, 1L)).thenReturn(true);
-//
-//        boolean result = service.likeVerification(1L, 1L);
-//
-//        assertThat(result).isTrue();
-//        verify(likeRepository, never()).save(any());
-//        verify(redisService, never()).increaseVerificationLikeCount(anyLong());
-//    }
-//
-//    @Test
-//    @DisplayName("좋아요 취소 시 삭제하고 false 반환")
-//    void cancelLike_success() {
-//        Like like = mock(Like.class);
-//
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        when(memberRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(member));
-//        when(likeRepository.findByVerificationIdAndMemberIdAndDeletedAtIsNull(1L, 1L)).thenReturn(Optional.of(like));
-//
-//        boolean result = service.cancelLike(1L, 1L);
-//
-//        assertThat(result).isFalse();
-//        verify(like).softDelete();
-//        verify(redisService).decreaseVerificationLikeCount(1L);
-//    }
-//
-//    @Test
-//    @DisplayName("좋아요 취소 시 이미 취소된 상태라면 false 반환")
-//    void cancelLike_alreadyDeleted() {
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        when(memberRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(member));
-//        when(likeRepository.findByVerificationIdAndMemberIdAndDeletedAtIsNull(1L, 1L)).thenReturn(Optional.empty());
-//
-//        boolean result = service.cancelLike(1L, 1L);
-//
-//        assertThat(result).isFalse();
-//        verify(redisService, never()).decreaseVerificationLikeCount(anyLong());
-//    }
-//
-//    @Test
-//    @DisplayName("좋아요 시 인증을 찾지 못하면 예외 발생")
-//    void likeVerification_fail_verificationNotFound() {
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
-//
-//        CustomException ex = catchThrowableOfType(() ->
-//                service.likeVerification(1L, 1L), CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(VerificationErrorCode.VERIFICATION_DETAIL_NOT_FOUND);
-//    }
-//
-//    @Test
-//    @DisplayName("좋아요 시 멤버를 찾지 못하면 예외 발생")
-//    void likeVerification_fail_memberNotFound() {
-//        when(verificationRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(verification));
-//        when(memberRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
-//
-//        CustomException ex = catchThrowableOfType(() ->
-//                service.likeVerification(1L, 1L), CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(GlobalErrorCode.UNAUTHORIZED);
-//    }
-//}
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.domain.entity.Like;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.LikeRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import ktb.leafresh.backend.global.util.redis.VerificationStatRedisLuaService;
+import ktb.leafresh.backend.support.fixture.GroupChallengeVerificationFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GroupVerificationLikeServiceTest {
+
+    @Mock
+    private GroupChallengeVerificationRepository verificationRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private LikeRepository likeRepository;
+
+    @Mock
+    private VerificationStatRedisLuaService verificationStatRedisLuaService;
+
+    @InjectMocks
+    private GroupVerificationLikeService likeService;
+
+    private final Long memberId = 1L;
+    private final Long verificationId = 10L;
+    private Member member;
+    private GroupChallengeVerification verification;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.of();
+        verification = GroupChallengeVerificationFixture.of(null);
+    }
+
+    @Test
+    @DisplayName("이미 좋아요가 존재하면 true를 반환한다")
+    void likeVerification_alreadyExists_returnsTrue() {
+        // given
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(memberRepository.findByIdAndDeletedAtIsNull(memberId)).willReturn(Optional.of(member));
+        given(likeRepository.existsByVerificationIdAndMemberIdAndDeletedAtIsNull(verificationId, memberId)).willReturn(true);
+
+        // when
+        boolean result = likeService.likeVerification(verificationId, memberId);
+
+        // then
+        assertThat(result).isTrue();
+        then(likeRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("삭제된 좋아요가 있으면 복구하고 true를 반환한다")
+    void likeVerification_softDeletedLike_restoreAndReturnTrue() {
+        // given
+        Like deletedLike = Like.builder().verification(verification).member(member).build();
+        deletedLike.softDelete();
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(memberRepository.findByIdAndDeletedAtIsNull(memberId)).willReturn(Optional.of(member));
+        given(likeRepository.existsByVerificationIdAndMemberIdAndDeletedAtIsNull(verificationId, memberId)).willReturn(false);
+        given(likeRepository.findByVerificationIdAndMemberId(verificationId, memberId)).willReturn(Optional.of(deletedLike));
+
+        // when
+        boolean result = likeService.likeVerification(verificationId, memberId);
+
+        // then
+        assertThat(result).isTrue();
+        assertThat(deletedLike.isDeleted()).isFalse();
+        then(verificationStatRedisLuaService).should().increaseVerificationLikeCount(verificationId);
+    }
+
+    @Test
+    @DisplayName("좋아요가 없으면 새로 생성하고 true를 반환한다")
+    void likeVerification_createNewLike_returnsTrue() {
+        // given
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(memberRepository.findByIdAndDeletedAtIsNull(memberId)).willReturn(Optional.of(member));
+        given(likeRepository.existsByVerificationIdAndMemberIdAndDeletedAtIsNull(verificationId, memberId)).willReturn(false);
+
+        given(likeRepository.findByVerificationIdAndMemberId(verificationId, memberId)).willReturn(Optional.empty());
+
+        // when
+        boolean result = likeService.likeVerification(verificationId, memberId);
+
+        // then
+        assertThat(result).isTrue();
+        then(likeRepository).should().save(any(Like.class));
+        then(verificationStatRedisLuaService).should().increaseVerificationLikeCount(verificationId);
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 - 존재하지 않으면 false 반환")
+    void cancelLike_notExists_returnsFalse() {
+        // given
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(memberRepository.findByIdAndDeletedAtIsNull(memberId)).willReturn(Optional.of(member));
+
+        given(likeRepository.findByVerificationIdAndMemberIdAndDeletedAtIsNull(verificationId, memberId)).willReturn(Optional.empty());
+
+        // when
+        boolean result = likeService.cancelLike(verificationId, memberId);
+
+        // then
+        assertThat(result).isFalse();
+        then(verificationStatRedisLuaService).should(never()).decreaseVerificationLikeCount(anyLong());
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 - 정상 취소되면 false 반환")
+    void cancelLike_exists_softDeleteAndReturnFalse() {
+        // given
+        Like like = Like.builder().verification(verification).member(member).build();
+
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(memberRepository.findByIdAndDeletedAtIsNull(memberId)).willReturn(Optional.of(member));
+        given(likeRepository.findByVerificationIdAndMemberIdAndDeletedAtIsNull(verificationId, memberId)).willReturn(Optional.ofNullable(like));
+
+        // when
+        boolean result = likeService.cancelLike(verificationId, memberId);
+
+        // then
+        assertThat(result).isFalse();
+        assertThat(like.isDeleted()).isTrue();
+        then(verificationStatRedisLuaService).should().decreaseVerificationLikeCount(verificationId);
+    }
+
+    @Test
+    @DisplayName("좋아요 대상 인증이 존재하지 않으면 예외 발생")
+    void likeVerification_invalidVerificationId_throwsException() {
+        // given
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> likeService.likeVerification(verificationId, memberId))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.VERIFICATION_DETAIL_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("좋아요 시 회원이 존재하지 않으면 예외 발생")
+    void likeVerification_invalidMemberId_throwsException() {
+        // given
+        given(verificationRepository.findByIdAndDeletedAtIsNull(verificationId)).willReturn(Optional.of(verification));
+        given(memberRepository.findByIdAndDeletedAtIsNull(memberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> likeService.likeVerification(verificationId, memberId))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(GlobalErrorCode.UNAUTHORIZED.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultSaveServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationResultSaveServiceTest.java
@@ -1,85 +1,35 @@
 package ktb.leafresh.backend.domain.verification.application.service;
 
 import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
-import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class PersonalChallengeVerificationResultSaveServiceTest {
 
+    @Mock
     private VerificationResultProcessor verificationResultProcessor;
-    private PersonalChallengeVerificationResultSaveService service;
 
-    @BeforeEach
-    void setUp() {
-        verificationResultProcessor = mock(VerificationResultProcessor.class);
-        service = new PersonalChallengeVerificationResultSaveService(verificationResultProcessor);
-    }
+    @InjectMocks
+    private PersonalChallengeVerificationResultSaveService saveService;
 
     @Test
-    @DisplayName("성공적인 개인 인증 결과가 정상적으로 위임된다")
-    void saveResult_success() {
+    @DisplayName("개인 인증 결과 저장 요청 시 - Processor가 위임 호출됨")
+    void saveResult_callsProcessor() {
         // given
-        Long verificationId = 10L;
-        VerificationResultRequestDto dto = VerificationResultRequestDto.builder()
-                .type(ChallengeType.PERSONAL)
-                .memberId(1L)
-                .challengeId(100L)
-                .date("2025-06-08")
-                .result("true")
-                .build();
+        Long verificationId = 1L;
+        VerificationResultRequestDto dto = mock(VerificationResultRequestDto.class);
 
         // when
-        service.saveResult(verificationId, dto);
+        saveService.saveResult(verificationId, dto);
 
         // then
         verify(verificationResultProcessor, times(1)).process(verificationId, dto);
-    }
-
-    @Test
-    @DisplayName("Processor 내부 예외 발생 시 그대로 전파된다")
-    void saveResult_throws_whenProcessorFails() {
-        // given
-        Long verificationId = 99L;
-        VerificationResultRequestDto dto = VerificationResultRequestDto.builder()
-                .type(ChallengeType.PERSONAL)
-                .memberId(2L)
-                .challengeId(200L)
-                .date("2025-06-08")
-                .result("false")
-                .build();
-
-        doThrow(new RuntimeException("Mocked Processor Error"))
-                .when(verificationResultProcessor).process(verificationId, dto);
-
-        // when & then
-        org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class, () -> {
-            service.saveResult(verificationId, dto);
-        });
-
-        verify(verificationResultProcessor).process(verificationId, dto);
-    }
-
-    @Test
-    @DisplayName("result 값이 null이더라도 processor에게 위임된다 (isSuccessResult()가 false 처리됨)")
-    void saveResult_resultIsNull() {
-        // given
-        Long verificationId = 777L;
-        VerificationResultRequestDto dto = VerificationResultRequestDto.builder()
-                .type(ChallengeType.PERSONAL)
-                .memberId(3L)
-                .challengeId(300L)
-                .date("2025-06-08")
-                .result(null)
-                .build();
-
-        // when
-        service.saveResult(verificationId, dto);
-
-        // then
-        verify(verificationResultProcessor).process(verificationId, dto);
     }
 }

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountQueryServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountQueryServiceTest.java
@@ -2,54 +2,41 @@ package ktb.leafresh.backend.domain.verification.application.service;
 
 import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
 import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class VerificationCountQueryServiceTest {
 
+    @Mock
     private GroupChallengeVerificationRepository groupRepo;
-    private PersonalChallengeVerificationRepository personalRepo;
-    private VerificationCountQueryService service;
 
-    @BeforeEach
-    void setUp() {
-        groupRepo = mock(GroupChallengeVerificationRepository.class);
-        personalRepo = mock(PersonalChallengeVerificationRepository.class);
-        service = new VerificationCountQueryService(groupRepo, personalRepo);
-    }
+    @Mock
+    private PersonalChallengeVerificationRepository personalRepo;
+
+    @InjectMocks
+    private VerificationCountQueryService queryService;
 
     @Test
-    @DisplayName("DB에 저장된 그룹/개인 인증 수를 합산하여 반환한다")
-    void getTotalVerificationCountFromDB_success() {
+    @DisplayName("전체 인증 수 조회 - 그룹 + 개인 인증 수의 합 반환")
+    void getTotalVerificationCountFromDB_returnsSum() {
         // given
-        when(groupRepo.countAll()).thenReturn(8);
-        when(personalRepo.countAll()).thenReturn(12);
+        given(groupRepo.countAll()).willReturn(120);
+        given(personalRepo.countAll()).willReturn(80);
 
         // when
-        int totalCount = service.getTotalVerificationCountFromDB();
+        int result = queryService.getTotalVerificationCountFromDB();
 
         // then
-        assertThat(totalCount).isEqualTo(20);
-        verify(groupRepo, times(1)).countAll();
-        verify(personalRepo, times(1)).countAll();
-    }
-
-    @Test
-    @DisplayName("DB 쿼리 중 예외가 발생하면 예외가 그대로 던져진다")
-    void getTotalVerificationCountFromDB_fail_dueToException() {
-        // given
-        when(groupRepo.countAll()).thenThrow(new RuntimeException("DB 오류"));
-
-        // when & then
-        org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class, () -> {
-            service.getTotalVerificationCountFromDB();
-        });
-
+        assertThat(result).isEqualTo(200);
         verify(groupRepo).countAll();
-        verifyNoInteractions(personalRepo); // groupRepo에서 실패 시 personalRepo는 호출되지 않아야 함
+        verify(personalRepo).countAll();
     }
 }

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/VerificationCountReadServiceTest.java
@@ -3,99 +3,94 @@ package ktb.leafresh.backend.domain.verification.application.service;
 import ktb.leafresh.backend.domain.verification.presentation.dto.response.VerificationCountResponseDto;
 import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.VerificationErrorCode;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.Duration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowableOfType;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class VerificationCountReadServiceTest {
 
+    @Mock
     private StringRedisTemplate redisTemplate;
-    private ValueOperations<String, String> valueOps;
-    private VerificationCountQueryService queryService;
 
-    private VerificationCountReadService service;
+    @Mock
+    private VerificationCountQueryService verificationCountQueryService;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private VerificationCountReadService readService;
 
     private static final String KEY = "leafresh:totalVerifications:count";
 
-    @BeforeEach
-    void setUp() {
-        redisTemplate = mock(StringRedisTemplate.class);
-        valueOps = mock(ValueOperations.class);
-        queryService = mock(VerificationCountQueryService.class);
+    @Test
+    @DisplayName("캐시 hit 시 - Redis 값 사용하여 count 반환")
+    void getTotalVerificationCount_cacheHit() {
+        // given
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(KEY)).willReturn("123");
 
-        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        // when
+        VerificationCountResponseDto result = readService.getTotalVerificationCount();
 
-        service = new VerificationCountReadService(redisTemplate, queryService);
+        // then
+        assertThat(result.count()).isEqualTo(123);
+        verify(redisTemplate.opsForValue()).get(KEY);
+        verifyNoInteractions(verificationCountQueryService);
     }
 
     @Test
-    @DisplayName("Redis 캐시에 값이 존재하면 해당 값을 반환한다")
-    void getTotalVerificationCount_success_cacheHit() {
-        when(valueOps.get(KEY)).thenReturn("42");
+    @DisplayName("캐시 miss 시 - DB에서 조회하여 반환 (withLock)")
+    void getTotalVerificationCount_cacheMiss_thenDBQuery() {
+        // given
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(KEY)).willReturn(null); // 1차 조회 캐시 miss
+        given(verificationCountQueryService.getTotalVerificationCountFromDB()).willReturn(999);
 
-        VerificationCountResponseDto result = service.getTotalVerificationCount();
+        // 2차 조회도 miss 처리하여 DB 값으로 캐싱
+        given(valueOperations.get(KEY)).willReturn(null);
 
-        assertThat(result.count()).isEqualTo(42);
-        verify(queryService, never()).getTotalVerificationCountFromDB();
+        // when
+        VerificationCountResponseDto result = readService.getTotalVerificationCount();
+
+        // then
+        assertThat(result.count()).isEqualTo(999);
+        verify(verificationCountQueryService).getTotalVerificationCountFromDB();
+        verify(valueOperations).set(KEY, "999", Duration.ofHours(24));
     }
 
     @Test
-    @DisplayName("Redis 캐시에 없고 DB에서 조회하여 캐싱한다")
-    void getTotalVerificationCount_cacheMiss_dbFallback() {
-        when(valueOps.get(KEY)).thenReturn(null).thenReturn(null);
-        when(queryService.getTotalVerificationCountFromDB()).thenReturn(99);
+    @DisplayName("캐시 파싱 오류 시 - 예외 발생")
+    void getTotalVerificationCount_cacheParseError() {
+        // given
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(KEY)).willReturn("not-a-number");
 
-        VerificationCountResponseDto result = service.getTotalVerificationCount();
-
-        assertThat(result.count()).isEqualTo(99);
-        verify(queryService).getTotalVerificationCountFromDB();
-        verify(valueOps).set(eq(KEY), eq("99"), eq(Duration.ofHours(24)));
+        // when & then
+        assertThatThrownBy(() -> readService.getTotalVerificationCount())
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED.getMessage());
     }
 
     @Test
-    @DisplayName("Redis 캐시에 없고 락 도중 다른 인스턴스가 캐싱하면 그대로 반환")
-    void getTotalVerificationCount_cacheMiss_but_cacheRestoredInLock() {
-        when(valueOps.get(KEY)).thenReturn(null).thenReturn("55");
+    @DisplayName("Redis 조회 중 예외 발생 시 - CustomException 반환")
+    void getTotalVerificationCount_redisException() {
+        // given
+        given(redisTemplate.opsForValue()).willThrow(new RuntimeException("Redis down"));
 
-        VerificationCountResponseDto result = service.getTotalVerificationCount();
-
-        assertThat(result.count()).isEqualTo(55);
-        verify(queryService, never()).getTotalVerificationCountFromDB();
-    }
-
-    @Test
-    @DisplayName("Redis 값이 숫자가 아니면 예외를 던진다")
-    void getTotalVerificationCount_fail_invalidFormat() {
-        when(valueOps.get(KEY)).thenReturn("not-a-number");
-
-        CustomException exception = catchThrowableOfType(
-                () -> service.getTotalVerificationCount(),
-                CustomException.class
-        );
-
-        assertThat(exception).isNotNull();
-        assertThat(exception.getErrorCode()).isEqualTo(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
-    }
-
-    @Test
-    @DisplayName("Redis 조회 중 예외가 발생하면 예외를 던진다")
-    void getTotalVerificationCount_fail_redisError() {
-        when(valueOps.get(KEY)).thenThrow(new RuntimeException("Redis error"));
-
-        CustomException exception = catchThrowableOfType(
-                () -> service.getTotalVerificationCount(),
-                CustomException.class
-        );
-
-        assertThat(exception).isNotNull();
-        assertThat(exception.getErrorCode()).isEqualTo(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED);
+        // when & then
+        assertThatThrownBy(() -> readService.getTotalVerificationCount())
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.VERIFICATION_COUNT_QUERY_FAILED.getMessage());
     }
 }


### PR DESCRIPTION
## 작업 개요
- 인증 도메인 테스트 코드에 대해 내부 테스트 스타일 통일 작업을 진행했습니다.

## 주요 변경 사항
- `@Mock`, `@InjectMocks` 기반 테스트 구조 통일
- Fixture 객체의 ID, 시간 등 불필요한 설정 제거
- `assertThat(응답).isEqualTo(하드코딩)` → 객체 기반 검증 방식으로 수정
- 에러 메시지 비교 시 `ErrorCode.getMessage()` 기반 검증 방식 도입
- 시간 비교 시 `LocalDateTime.now()` → 고정값으로 대체