### PR TITLE
refactor: 도메인 테스트 스타일 통일

### DIFF
--- a/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/TimedealOrderCreateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/TimedealOrderCreateServiceTest.java
@@ -1,151 +1,179 @@
-//package ktb.leafresh.backend.domain.store.order.application.service;
-//
-//import ktb.leafresh.backend.domain.member.domain.entity.Member;
-//import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
-//import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
-//import ktb.leafresh.backend.domain.store.order.domain.entity.PurchaseIdempotencyKey;
-//import ktb.leafresh.backend.domain.store.order.infrastructure.publisher.PurchaseMessagePublisher;
-//import ktb.leafresh.backend.domain.store.order.infrastructure.repository.PurchaseIdempotencyKeyRepository;
-//import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
-//import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
-//import ktb.leafresh.backend.domain.store.product.infrastructure.repository.TimedealPolicyRepository;
-//import ktb.leafresh.backend.global.exception.*;
-//import ktb.leafresh.backend.global.util.redis.StockRedisLuaService;
-//import ktb.leafresh.backend.support.fixture.MemberFixture;
-//import ktb.leafresh.backend.support.fixture.ProductFixture;
-//import ktb.leafresh.backend.support.fixture.TimedealPolicyFixture;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.*;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.dao.DataIntegrityViolationException;
-//
-//import java.util.Optional;
-//
-//import static org.assertj.core.api.Assertions.*;
-//import static org.mockito.Mockito.*;
-//
-//@ExtendWith(MockitoExtension.class)
-//@DisplayName("TimedealOrderCreateService 테스트")
-//class TimedealOrderCreateServiceTest {
-//
-//    @Mock
-//    private MemberRepository memberRepository;
-//
-//    @Mock
-//    private TimedealPolicyRepository timedealPolicyRepository;
-//
-//    @Mock
-//    private PurchaseIdempotencyKeyRepository idempotencyKeyRepository;
-//
-//    @Mock
-//    private StockRedisLuaService stockRedisLuaService;
-//
-//    @Mock
-//    private PurchaseMessagePublisher purchaseMessagePublisher;
-//
-//    @InjectMocks
-//    private TimedealOrderCreateService service;
-//
-//    private final Long memberId = 1L;
-//    private final Long dealId = 10L;
-//    private final String idempotencyKey = "unique-key";
-//    private final int quantity = 2;
-//
-//    private final Member member = MemberFixture.of(memberId, "user@leafresh.com", "테스터");
-//    private final Product product = ProductFixture.createDefaultProduct();
-//
-//    @Test
-//    @DisplayName("타임딜 주문 성공")
-//    void create_success() {
-//        TimedealPolicy policy = TimedealPolicyFixture.createOngoingTimedeal(product);
-//
-//        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-//        when(timedealPolicyRepository.findById(dealId)).thenReturn(Optional.of(policy));
-//        when(stockRedisLuaService.decreaseStock(anyString(), eq(quantity))).thenReturn(1L);
-//
-//        service.create(memberId, dealId, quantity, idempotencyKey);
-//
-//        verify(idempotencyKeyRepository).save(any(PurchaseIdempotencyKey.class));
-//        verify(purchaseMessagePublisher).publish(any(PurchaseCommand.class));
-//    }
-//
-//    @Test
-//    @DisplayName("존재하지 않는 사용자")
-//    void create_fail_memberNotFound() {
-//        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
-//
-//        CustomException ex = catchThrowableOfType(
-//                () -> service.create(memberId, dealId, quantity, idempotencyKey),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
-//    }
-//
-//    @Test
-//    @DisplayName("중복 구매 요청")
-//    void create_fail_duplicateRequest() {
-//        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-//        doThrow(new DataIntegrityViolationException("중복")).when(idempotencyKeyRepository)
-//                .save(any(PurchaseIdempotencyKey.class));
-//
-//        CustomException ex = catchThrowableOfType(
-//                () -> service.create(memberId, dealId, quantity, idempotencyKey),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(PurchaseErrorCode.DUPLICATE_PURCHASE_REQUEST);
-//    }
-//
-//    @Test
-//    @DisplayName("존재하지 않는 타임딜 정책")
-//    void create_fail_timedealNotFound() {
-//        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-//        when(idempotencyKeyRepository.save(any())).thenReturn(mock(PurchaseIdempotencyKey.class));
-//        when(timedealPolicyRepository.findById(dealId)).thenReturn(Optional.empty());
-//
-//        CustomException ex = catchThrowableOfType(
-//                () -> service.create(memberId, dealId, quantity, idempotencyKey),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(TimedealErrorCode.PRODUCT_NOT_FOUND);
-//    }
-//
-//    @Test
-//    @DisplayName("구매 가능 시간이 아님")
-//    void create_fail_invalidTime() {
-//        TimedealPolicy expired = TimedealPolicyFixture.createExpiredTimedeal(product);
-//
-//        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-//        when(idempotencyKeyRepository.save(any())).thenReturn(mock(PurchaseIdempotencyKey.class));
-//        when(timedealPolicyRepository.findById(dealId)).thenReturn(Optional.of(expired));
-//
-//        CustomException ex = catchThrowableOfType(
-//                () -> service.create(memberId, dealId, quantity, idempotencyKey),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(ProductErrorCode.INVALID_STATUS);
-//    }
-//
-//    @Test
-//    @DisplayName("Redis 재고 없음")
-//    void create_fail_outOfStock() {
-//        TimedealPolicy policy = TimedealPolicyFixture.createOngoingTimedeal(product);
-//
-//        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-//        when(idempotencyKeyRepository.save(any())).thenReturn(mock(PurchaseIdempotencyKey.class));
-//        when(timedealPolicyRepository.findById(dealId)).thenReturn(Optional.of(policy));
-//        when(stockRedisLuaService.decreaseStock(anyString(), eq(quantity))).thenReturn(-2L);
-//
-//        CustomException ex = catchThrowableOfType(
-//                () -> service.create(memberId, dealId, quantity, idempotencyKey),
-//                CustomException.class
-//        );
-//
-//        assertThat(ex.getErrorCode()).isEqualTo(ProductErrorCode.OUT_OF_STOCK);
-//    }
-//}
+package ktb.leafresh.backend.domain.store.order.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
+import ktb.leafresh.backend.domain.store.order.infrastructure.publisher.PurchaseMessagePublisher;
+import ktb.leafresh.backend.domain.store.order.infrastructure.repository.PurchaseIdempotencyKeyRepository;
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.domain.entity.TimedealPolicy;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.TimedealPolicyRepository;
+import ktb.leafresh.backend.global.exception.*;
+import ktb.leafresh.backend.global.util.redis.StockRedisLuaService;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import ktb.leafresh.backend.support.fixture.ProductFixture;
+import ktb.leafresh.backend.support.fixture.TimedealPolicyFixture;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TimedealOrderCreateServiceTest {
+
+    @InjectMocks
+    private TimedealOrderCreateService service;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private TimedealPolicyRepository timedealPolicyRepository;
+
+    @Mock
+    private PurchaseIdempotencyKeyRepository idempotencyRepository;
+
+    @Mock
+    private StockRedisLuaService stockRedisLuaService;
+
+    @Mock
+    private PurchaseMessagePublisher purchaseMessagePublisher;
+
+    private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2025, 7, 1, 12, 0);
+    private static MockedStatic<LocalDateTime> localDateTimeMock;
+
+    private Member member;
+    private Product product;
+    private TimedealPolicy policy;
+
+    @BeforeAll
+    static void beforeAll() {
+        localDateTimeMock = Mockito.mockStatic(LocalDateTime.class, CALLS_REAL_METHODS);
+        localDateTimeMock.when(LocalDateTime::now).thenReturn(FIXED_NOW);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        localDateTimeMock.close();
+    }
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.of();
+        product = ProductFixture.createDefaultProduct();
+        policy = TimedealPolicyFixture.createDefaultTimedeal(product);
+    }
+
+    @Test
+    void createTimedealOrder_withValidInput_succeeds() {
+        // given
+        Long memberId = 1L;
+        Long dealId = 2L;
+        int quantity = 1;
+        String idempotencyKey = "unique-key";
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(timedealPolicyRepository.findById(dealId)).willReturn(Optional.of(policy));
+        given(stockRedisLuaService.decreaseStock(anyString(), eq(quantity))).willReturn(1L);
+
+        // when & then
+        assertThatCode(() -> service.create(memberId, dealId, quantity, idempotencyKey))
+                .doesNotThrowAnyException();
+
+        then(idempotencyRepository).should().save(any());
+        then(purchaseMessagePublisher).should().publish(any(PurchaseCommand.class));
+    }
+
+    @Test
+    void createTimedealOrder_withDuplicateIdempotencyKey_throwsException() {
+        // given
+        Long memberId = 1L;
+        Long dealId = 2L;
+        String key = "duplicate-key";
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        willThrow(DataIntegrityViolationException.class).given(idempotencyRepository).save(any());
+
+        // when & then
+        assertThatThrownBy(() -> service.create(memberId, dealId, 1, key))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(PurchaseErrorCode.DUPLICATE_PURCHASE_REQUEST.getMessage());
+    }
+
+    @Test
+    void createTimedealOrder_withExpiredPolicy_throwsException() {
+        // given
+        TimedealPolicy expiredPolicy = TimedealPolicyFixture.createExpiredTimedeal(product);
+
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(member));
+        given(idempotencyRepository.save(any())).willReturn(null);
+        given(timedealPolicyRepository.findById(anyLong())).willReturn(Optional.of(expiredPolicy));
+
+        // when & then
+        assertThatThrownBy(() -> service.create(1L, 2L, 1, "key"))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("현재는 구매할 수 없는 시간입니다.");
+    }
+
+    @Test
+    void createTimedealOrder_withOutOfStock_throwsException() {
+        // given
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(member));
+        given(idempotencyRepository.save(any())).willReturn(null);
+        given(timedealPolicyRepository.findById(anyLong())).willReturn(Optional.of(policy));
+        given(stockRedisLuaService.decreaseStock(anyString(), anyInt())).willReturn(-2L);
+
+        // when & then
+        assertThatThrownBy(() -> service.create(1L, 2L, 1, "key"))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ProductErrorCode.OUT_OF_STOCK.getMessage());
+    }
+
+    @Test
+    void createTimedealOrder_withMissingMember_throwsException() {
+        // given
+        given(memberRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> service.create(1L, 2L, 1, "key"))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void createTimedealOrder_withInvalidPolicyId_throwsException() {
+        // given
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(member));
+        given(idempotencyRepository.save(any())).willReturn(null);
+        given(timedealPolicyRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> service.create(1L, 2L, 1, "key"))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(TimedealErrorCode.PRODUCT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void createTimedealOrder_withMissingStockInRedis_throwsException() {
+        // given
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(member));
+        given(idempotencyRepository.save(any())).willReturn(null);
+        given(timedealPolicyRepository.findById(anyLong())).willReturn(Optional.of(policy));
+        given(stockRedisLuaService.decreaseStock(anyString(), anyInt())).willReturn(-1L);
+
+        // when & then
+        assertThatThrownBy(() -> service.create(1L, 2L, 1, "key"))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ProductErrorCode.PRODUCT_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/ProductUpdateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/product/application/service/ProductUpdateServiceTest.java
@@ -1,171 +1,128 @@
-//package ktb.leafresh.backend.domain.store.product.application.service;
-//
-//import ktb.leafresh.backend.domain.store.order.application.facade.ProductCacheLockFacade;
-//import ktb.leafresh.backend.domain.store.product.application.event.ProductUpdatedEvent;
-//import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
-//import ktb.leafresh.backend.domain.store.product.domain.entity.enums.ProductStatus;
-//import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
-//import ktb.leafresh.backend.domain.store.product.presentation.dto.request.ProductUpdateRequestDto;
-//import ktb.leafresh.backend.global.exception.CustomException;
-//import ktb.leafresh.backend.global.exception.ProductErrorCode;
-//import ktb.leafresh.backend.support.fixture.ProductFixture;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.context.ApplicationEventPublisher;
-//import org.springframework.test.util.ReflectionTestUtils;
-//
-//import java.util.Optional;
-//
-//import static org.assertj.core.api.Assertions.*;
-//import static org.mockito.Mockito.*;
-//
-//@ExtendWith(MockitoExtension.class)
-//@DisplayName("ProductUpdateService 테스트")
-//class ProductUpdateServiceTest {
-//
-//    private static final Long FIXED_PRODUCT_ID = 1L;
-//
-//    @Mock
-//    private ProductRepository productRepository;
-//
-//    @Mock
-//    private ProductCacheLockFacade productCacheLockFacade;
-//
-//    @Mock
-//    private ApplicationEventPublisher eventPublisher;
-//
-//    @InjectMocks
-//    private ProductUpdateService productUpdateService;
-//
-//    @Test
-//    @DisplayName("상품을 정상적으로 수정한다")
-//    void update_success() {
-//        // given
-//        Product product = ProductFixture.createDefaultProduct();
-//        ReflectionTestUtils.setField(product, "id", FIXED_PRODUCT_ID);
-//
-//        ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
-//                "수정상품",
-//                "수정 설명",
-//                "https://new.image/product.png",
-//                2000,
-//                15,
-//                ProductStatus.INACTIVE.name()
-//        );
-//
-//        when(productRepository.findById(FIXED_PRODUCT_ID)).thenReturn(Optional.of(product));
-//
-//        // when
-//        productUpdateService.update(FIXED_PRODUCT_ID, dto);
-//
-//        // then
-//        assertThat(product.getName()).isEqualTo(dto.name());
-//        assertThat(product.getDescription()).isEqualTo(dto.description());
-//        assertThat(product.getImageUrl()).isEqualTo(dto.imageUrl());
-//        assertThat(product.getPrice()).isEqualTo(dto.price());
-//        assertThat(product.getStock()).isEqualTo(dto.stock());
-//        assertThat(product.getStatus()).isEqualTo(ProductStatus.INACTIVE);
-//
-//        verify(productCacheLockFacade).cacheProductStock(FIXED_PRODUCT_ID, dto.stock());
-//        verify(productCacheLockFacade).evictCacheByProduct(product);
-//
-//        ArgumentCaptor<ProductUpdatedEvent> eventCaptor = ArgumentCaptor.forClass(ProductUpdatedEvent.class);
-//        verify(eventPublisher).publishEvent(eventCaptor.capture());
-//        assertThat(eventCaptor.getValue().productId()).isEqualTo(FIXED_PRODUCT_ID);
-//    }
-//
-//    @Test
-//    @DisplayName("존재하지 않는 상품이면 예외 발생")
-//    void update_fail_product_not_found() {
-//        // given
-//        Long invalidId = 999L;
-//        ProductUpdateRequestDto dto = createValidDto();
-//        when(productRepository.findById(invalidId)).thenReturn(Optional.empty());
-//
-//        // when
-//        CustomException exception = catchThrowableOfType(
-//                () -> productUpdateService.update(invalidId, dto),
-//                CustomException.class
-//        );
-//
-//        // then
-//        assertThat(exception.getErrorCode()).isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND);
-//    }
-//
-//    @Test
-//    @DisplayName("가격이 0원 이하면 예외 발생")
-//    void update_fail_invalid_price() {
-//        // given
-//        Product product = ProductFixture.createDefaultProduct();
-//        ReflectionTestUtils.setField(product, "id", FIXED_PRODUCT_ID);
-//        when(productRepository.findById(FIXED_PRODUCT_ID)).thenReturn(Optional.of(product));
-//
-//        ProductUpdateRequestDto dto = new ProductUpdateRequestDto(null, null, null, 0, null, null);
-//
-//        // when
-//        CustomException exception = catchThrowableOfType(
-//                () -> productUpdateService.update(FIXED_PRODUCT_ID, dto),
-//                CustomException.class
-//        );
-//
-//        // then
-//        assertThat(exception.getErrorCode()).isEqualTo(ProductErrorCode.INVALID_PRICE);
-//    }
-//
-//    @Test
-//    @DisplayName("재고가 음수면 예외 발생")
-//    void update_fail_invalid_stock() {
-//        // given
-//        Product product = ProductFixture.createDefaultProduct();
-//        ReflectionTestUtils.setField(product, "id", FIXED_PRODUCT_ID);
-//        when(productRepository.findById(FIXED_PRODUCT_ID)).thenReturn(Optional.of(product));
-//
-//        ProductUpdateRequestDto dto = new ProductUpdateRequestDto(null, null, null, null, -10, null);
-//
-//        // when
-//        CustomException exception = catchThrowableOfType(
-//                () -> productUpdateService.update(FIXED_PRODUCT_ID, dto),
-//                CustomException.class
-//        );
-//
-//        // then
-//        assertThat(exception.getErrorCode()).isEqualTo(ProductErrorCode.INVALID_STOCK);
-//    }
-//
-//    @Test
-//    @DisplayName("상태값이 잘못된 경우 예외 발생")
-//    void update_fail_invalid_status() {
-//        // given
-//        Product product = ProductFixture.createDefaultProduct();
-//        ReflectionTestUtils.setField(product, "id", FIXED_PRODUCT_ID);
-//        when(productRepository.findById(FIXED_PRODUCT_ID)).thenReturn(Optional.of(product));
-//
-//        ProductUpdateRequestDto dto = new ProductUpdateRequestDto(null, null, null, null, null, "WRONG_STATUS");
-//
-//        // when
-//        CustomException exception = catchThrowableOfType(
-//                () -> productUpdateService.update(FIXED_PRODUCT_ID, dto),
-//                CustomException.class
-//        );
-//
-//        // then
-//        assertThat(exception.getErrorCode()).isEqualTo(ProductErrorCode.INVALID_STATUS);
-//    }
-//
-//    // 헬퍼 메서드
-//    private ProductUpdateRequestDto createValidDto() {
-//        return new ProductUpdateRequestDto(
-//                "테스트 상품",
-//                "테스트 설명",
-//                "https://image.test/product.png",
-//                1000,
-//                5,
-//                ProductStatus.ACTIVE.name()
-//        );
-//    }
-//}
+package ktb.leafresh.backend.domain.store.product.application.service;
+
+import ktb.leafresh.backend.domain.store.order.application.facade.ProductCacheLockFacade;
+import ktb.leafresh.backend.domain.store.product.application.event.ProductUpdatedEvent;
+import ktb.leafresh.backend.domain.store.product.domain.entity.Product;
+import ktb.leafresh.backend.domain.store.product.domain.entity.enums.ProductStatus;
+import ktb.leafresh.backend.domain.store.product.infrastructure.repository.ProductRepository;
+import ktb.leafresh.backend.domain.store.product.presentation.dto.request.ProductUpdateRequestDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ProductErrorCode;
+import ktb.leafresh.backend.support.fixture.ProductFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+class ProductUpdateServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private ProductCacheLockFacade productCacheLockFacade;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private ProductUpdateService productUpdateService;
+
+    private Product product;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        product = ProductFixture.createDefaultProduct();
+    }
+
+    @Test
+    void update_withValidData_success() {
+        // given
+        given(productRepository.findById(anyLong())).willReturn(Optional.of(product));
+        ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
+                "새 이름",
+                "새 설명",
+                "https://image.new.png",
+                5000,
+                20,
+                ProductStatus.INACTIVE.name()
+        );
+
+        // when
+        productUpdateService.update(1L, dto);
+
+        // then
+        assertThat(product.getName()).isEqualTo(dto.name());
+        assertThat(product.getDescription()).isEqualTo(dto.description());
+        assertThat(product.getImageUrl()).isEqualTo(dto.imageUrl());
+        assertThat(product.getPrice()).isEqualTo(dto.price());
+        assertThat(product.getStock()).isEqualTo(dto.stock());
+        assertThat(product.getStatus().name()).isEqualTo(dto.status());
+
+        then(productCacheLockFacade).should().cacheProductStock(product.getId(), dto.stock());
+        then(productCacheLockFacade).should().evictCacheByProduct(product);
+        then(eventPublisher).should().publishEvent(any(ProductUpdatedEvent.class));
+    }
+
+    @Test
+    void update_withNegativePrice_throwsException() {
+        // given
+        given(productRepository.findById(anyLong())).willReturn(Optional.of(product));
+        ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
+                null, null, null, -1000, null, null
+        );
+
+        // when & then
+        assertThatThrownBy(() -> productUpdateService.update(1L, dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ProductErrorCode.INVALID_PRICE.getMessage());
+    }
+
+    @Test
+    void update_withNegativeStock_throwsException() {
+        // given
+        given(productRepository.findById(anyLong())).willReturn(Optional.of(product));
+        ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
+                null, null, null, null, -5, null
+        );
+
+        // when & then
+        assertThatThrownBy(() -> productUpdateService.update(1L, dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ProductErrorCode.INVALID_STOCK.getMessage());
+    }
+
+    @Test
+    void update_withInvalidStatus_throwsException() {
+        // given
+        given(productRepository.findById(anyLong())).willReturn(Optional.of(product));
+        ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
+                null, null, null, null, null, "INVALID_STATUS"
+        );
+
+        // when & then
+        assertThatThrownBy(() -> productUpdateService.update(1L, dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ProductErrorCode.INVALID_STATUS.getMessage());
+    }
+
+    @Test
+    void update_whenProductNotFound_throwsException() {
+        // given
+        given(productRepository.findById(anyLong())).willReturn(Optional.empty());
+        ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
+                "새 이름", null, null, null, null, null
+        );
+
+        // when & then
+        assertThatThrownBy(() -> productUpdateService.update(1L, dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ProductErrorCode.PRODUCT_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationSubmitServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/verification/application/service/PersonalChallengeVerificationSubmitServiceTest.java
@@ -1,135 +1,101 @@
-//package ktb.leafresh.backend.domain.verification.application.service;
-//
-//import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
-//import ktb.leafresh.backend.domain.challenge.personal.infrastructure.repository.PersonalChallengeRepository;
-//import ktb.leafresh.backend.domain.member.domain.entity.Member;
-//import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
-//import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
-//import ktb.leafresh.backend.domain.verification.domain.event.VerificationCreatedEvent;
-//import ktb.leafresh.backend.domain.verification.domain.support.validator.VerificationSubmitValidator;
-//import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
-//import ktb.leafresh.backend.domain.verification.presentation.dto.request.PersonalChallengeVerificationRequestDto;
-//import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
-//import ktb.leafresh.backend.global.exception.CustomException;
-//import ktb.leafresh.backend.global.exception.MemberErrorCode;
-//import ktb.leafresh.backend.global.exception.VerificationErrorCode;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.context.ApplicationEventPublisher;
-//import org.springframework.data.redis.core.StringRedisTemplate;
-//import org.springframework.data.redis.core.ValueOperations;
-//
-//import java.util.Optional;
-//
-//import static ktb.leafresh.backend.support.fixture.MemberFixture.of;
-//import static ktb.leafresh.backend.support.fixture.PersonalChallengeFixture.of;
-//import static org.assertj.core.api.Assertions.assertThatThrownBy;
-//import static org.mockito.Mockito.*;
-//
-//class PersonalChallengeVerificationSubmitServiceTest {
-//
-//    private MemberRepository memberRepository;
-//    private PersonalChallengeRepository challengeRepository;
-//    private PersonalChallengeVerificationRepository verificationRepository;
-//    private VerificationSubmitValidator validator;
-//    private ApplicationEventPublisher eventPublisher;
-//    private StringRedisTemplate redisTemplate;
-//    private ValueOperations<String, String> valueOps;
-//    private PersonalChallengeVerificationSubmitService service;
-//
-//    private Member member;
-//    private PersonalChallenge challenge;
-//
-//    @BeforeEach
-//    void setUp() {
-//        memberRepository = mock(MemberRepository.class);
-//        challengeRepository = mock(PersonalChallengeRepository.class);
-//        verificationRepository = mock(PersonalChallengeVerificationRepository.class);
-//        validator = mock(VerificationSubmitValidator.class);
-//        eventPublisher = mock(ApplicationEventPublisher.class);
-//        redisTemplate = mock(StringRedisTemplate.class);
-//        valueOps = mock(ValueOperations.class);
-//        when(redisTemplate.opsForValue()).thenReturn(valueOps);
-//
-//        service = new PersonalChallengeVerificationSubmitService(
-//                memberRepository, challengeRepository, verificationRepository,
-//                validator, eventPublisher, redisTemplate
-//        );
-//
-//        member = of(1L, "test@leafresh.com", "테스터");
-//        challenge = of("제로웨이스트 챌린지");
-//    }
-//
-//    @Test
-//    @DisplayName("개인 인증을 정상적으로 제출한다")
-//    void submit_success() {
-//        var dto = new PersonalChallengeVerificationRequestDto("https://img.jpg", "잘 인증했어요");
-//
-//        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-//        when(challengeRepository.findById(1L)).thenReturn(Optional.of(challenge));
-//        when(verificationRepository.findTopByMemberIdAndPersonalChallengeIdAndCreatedAtBetween(
-//                eq(1L), eq(1L), any(), any())).thenReturn(Optional.empty());
-//
-//        service.submit(1L, 1L, dto);
-//
-//        verify(validator).validate("잘 인증했어요");
-//        verify(verificationRepository).save(any(PersonalChallengeVerification.class));
-//        verify(eventPublisher).publishEvent(any(VerificationCreatedEvent.class));
-//        verify(valueOps).increment("leafresh:totalVerifications:count"); // ✅ 변경됨
-//    }
-//
-//    @Test
-//    @DisplayName("이미 오늘 인증한 경우 예외 발생")
-//    void submit_fail_alreadySubmitted() {
-//        var dto = new PersonalChallengeVerificationRequestDto("https://img.jpg", "중복 인증");
-//        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-//        when(challengeRepository.findById(1L)).thenReturn(Optional.of(challenge));
-//        when(verificationRepository.findTopByMemberIdAndPersonalChallengeIdAndCreatedAtBetween(
-//                eq(1L), eq(1L), any(), any())).thenReturn(Optional.of(mock(PersonalChallengeVerification.class)));
-//
-//        assertThatThrownBy(() -> service.submit(1L, 1L, dto))
-//                .isInstanceOf(CustomException.class)
-//                .hasMessageContaining(VerificationErrorCode.ALREADY_SUBMITTED.getMessage());
-//    }
-//
-//    @Test
-//    @DisplayName("회원이 존재하지 않으면 예외 발생")
-//    void submit_fail_memberNotFound() {
-//        var dto = new PersonalChallengeVerificationRequestDto("https://img.jpg", "인증");
-//        when(memberRepository.findById(1L)).thenReturn(Optional.empty());
-//
-//        assertThatThrownBy(() -> service.submit(1L, 1L, dto))
-//                .isInstanceOf(CustomException.class)
-//                .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
-//    }
-//
-//    @Test
-//    @DisplayName("챌린지를 찾을 수 없으면 예외 발생")
-//    void submit_fail_challengeNotFound() {
-//        var dto = new PersonalChallengeVerificationRequestDto("https://img.jpg", "인증");
-//        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-//        when(challengeRepository.findById(1L)).thenReturn(Optional.empty());
-//
-//        assertThatThrownBy(() -> service.submit(1L, 1L, dto))
-//                .isInstanceOf(CustomException.class)
-//                .hasMessageContaining(ChallengeErrorCode.PERSONAL_CHALLENGE_NOT_FOUND.getMessage());
-//    }
-//
-//    @Test
-//    @DisplayName("AI 이벤트 발행 중 예외 발생 시 AI_SERVER_ERROR 예외 반환")
-//    void submit_fail_aiServerError() {
-//        var dto = new PersonalChallengeVerificationRequestDto("https://img.jpg", "인증");
-//        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-//        when(challengeRepository.findById(1L)).thenReturn(Optional.of(challenge));
-//        when(verificationRepository.findTopByMemberIdAndPersonalChallengeIdAndCreatedAtBetween(
-//                anyLong(), anyLong(), any(), any())).thenReturn(Optional.empty());
-//
-//        doThrow(new RuntimeException("MQ Error"))
-//                .when(eventPublisher).publishEvent(any(VerificationCreatedEvent.class));
-//
-//        assertThatThrownBy(() -> service.submit(1L, 1L, dto))
-//                .isInstanceOf(CustomException.class)
-//                .hasMessageContaining(VerificationErrorCode.AI_SERVER_ERROR.getMessage());
-//    }
-//}
+package ktb.leafresh.backend.domain.verification.application.service;
+
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import ktb.leafresh.backend.domain.challenge.personal.infrastructure.repository.PersonalChallengeRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.verification.domain.entity.PersonalChallengeVerification;
+import ktb.leafresh.backend.domain.verification.domain.event.VerificationCreatedEvent;
+import ktb.leafresh.backend.domain.verification.domain.support.validator.VerificationSubmitValidator;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.presentation.dto.request.PersonalChallengeVerificationRequestDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PersonalChallengeVerificationSubmitServiceTest {
+
+    @Mock private MemberRepository memberRepository;
+    @Mock private PersonalChallengeRepository challengeRepository;
+    @Mock private PersonalChallengeVerificationRepository verificationRepository;
+    @Mock private VerificationSubmitValidator validator;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private StringRedisTemplate redisTemplate;
+    @Mock private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private PersonalChallengeVerificationSubmitService submitService;
+
+    private final Long memberId = 1L;
+    private final Long challengeId = 10L;
+
+    private Member member;
+    private PersonalChallenge challenge;
+    private PersonalChallengeVerificationRequestDto dto;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder().nickname("test").email("test@email.com").build();
+        challenge = PersonalChallenge.builder().title("환경지키기").description("비닐 사용 줄이기").build();
+        dto = new PersonalChallengeVerificationRequestDto("https://image.jpg", "비닐봉투 대신 장바구니 사용!");
+    }
+
+    @Test
+    @DisplayName("정상 제출 시 - 인증 저장 및 이벤트 발행, Redis 증가")
+    void submit_success() {
+        // given
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+        given(verificationRepository.findTopByMemberIdAndPersonalChallengeIdAndCreatedAtBetween(
+                eq(memberId), eq(challengeId), any(LocalDateTime.class), any(LocalDateTime.class))
+        ).willReturn(Optional.empty());
+        given(verificationRepository.save(any())).willAnswer(invocation -> {
+            PersonalChallengeVerification saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 123L);
+            return saved;
+        });
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        submitService.submit(memberId, challengeId, dto);
+
+        // then
+        verify(validator).validate(dto.content());
+        verify(verificationRepository).save(any(PersonalChallengeVerification.class));
+        verify(eventPublisher).publishEvent(any(VerificationCreatedEvent.class));
+        verify(redisTemplate.opsForValue()).increment("leafresh:totalVerifications:count");
+    }
+
+    @Test
+    @DisplayName("이미 인증 제출한 경우 - 예외 발생")
+    void submit_alreadySubmitted_throwsException() {
+        // given
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+        given(verificationRepository.findTopByMemberIdAndPersonalChallengeIdAndCreatedAtBetween(
+                eq(memberId), eq(challengeId), any(), any())
+        ).willReturn(Optional.of(mock(PersonalChallengeVerification.class)));
+
+        // when & then
+        assertThatThrownBy(() -> submitService.submit(memberId, challengeId, dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.ALREADY_SUBMITTED.getMessage());
+    }
+}


### PR DESCRIPTION
## 작업 개요
- 도메인 테스트 코드에 대해 내부 테스트 스타일 통일 작업을 진행했습니다.

## 주요 변경 사항
- `@Mock`, `@InjectMocks` 기반 테스트 구조 통일
- Fixture 객체의 ID, 시간 등 불필요한 설정 제거
- `assertThat(응답).isEqualTo(하드코딩)` → 객체 기반 검증 방식으로 수정
- 에러 메시지 비교 시 `ErrorCode.getMessage()` 기반 검증 방식 도입
- 시간 비교 시 `LocalDateTime.now()` → 고정값으로 대체