### PR TITLE
test: 개인 챌린지 도메인 픽스처 및 테스트 코드 추가

### DIFF
--- a/src/test/java/ktb/leafresh/backend/domain/challenge/personal/application/factory/PersonalChallengeExampleImageAssemblerTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/personal/application/factory/PersonalChallengeExampleImageAssemblerTest.java
@@ -1,0 +1,79 @@
+package ktb.leafresh.backend.domain.challenge.personal.application.factory;
+
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallengeExampleImage;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.request.PersonalChallengeCreateRequestDto;
+import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
+import ktb.leafresh.backend.support.fixture.PersonalChallengeFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class PersonalChallengeExampleImageAssemblerTest {
+
+    @InjectMocks
+    private PersonalChallengeExampleImageAssembler assembler;
+
+    @Test
+    @DisplayName("assemble_정상입력_예시이미지_연결됨")
+    void assemble_withValidInput_attachesExampleImagesToChallenge() {
+        // given
+        PersonalChallenge challenge = PersonalChallengeFixture.of();
+
+        PersonalChallengeCreateRequestDto.ExampleImageRequestDto image1 =
+                new PersonalChallengeCreateRequestDto.ExampleImageRequestDto(
+                        "https://test-bucket/good1.jpg",
+                        ExampleImageType.SUCCESS,
+                        "성공 예시 이미지입니다",
+                        1
+                );
+
+        PersonalChallengeCreateRequestDto.ExampleImageRequestDto image2 =
+                new PersonalChallengeCreateRequestDto.ExampleImageRequestDto(
+                        "https://test-bucket/fail1.jpg",
+                        ExampleImageType.FAILURE,
+                        "실패 예시 이미지입니다",
+                        2
+                );
+
+        PersonalChallengeCreateRequestDto requestDto = new PersonalChallengeCreateRequestDto(
+                "아침 6시 기상",
+                "기상 후 10분 내 사진 인증",
+                DayOfWeek.MONDAY,
+                "https://test-bucket/thumb.jpg",
+                LocalTime.of(6, 0),
+                LocalTime.of(8, 0),
+                List.of(image1, image2)
+        );
+
+        // when
+        assembler.assemble(challenge, requestDto);
+
+        // then
+        List<PersonalChallengeExampleImage> exampleImages = challenge.getExampleImages();
+        assertThat(exampleImages).hasSize(2);
+
+        PersonalChallengeExampleImage first = exampleImages.get(0);
+        assertThat(first.getImageUrl()).isEqualTo(image1.imageUrl());
+        assertThat(first.getType()).isEqualTo(image1.type());
+        assertThat(first.getDescription()).isEqualTo(image1.description());
+        assertThat(first.getSequenceNumber()).isEqualTo(image1.sequenceNumber());
+        assertThat(first.getPersonalChallenge()).isEqualTo(challenge);
+
+        PersonalChallengeExampleImage second = exampleImages.get(1);
+        assertThat(second.getImageUrl()).isEqualTo(image2.imageUrl());
+        assertThat(second.getType()).isEqualTo(image2.type());
+        assertThat(second.getDescription()).isEqualTo(image2.description());
+        assertThat(second.getSequenceNumber()).isEqualTo(image2.sequenceNumber());
+        assertThat(second.getPersonalChallenge()).isEqualTo(challenge);
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/personal/application/factory/PersonalChallengeFactoryTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/personal/application/factory/PersonalChallengeFactoryTest.java
@@ -1,0 +1,53 @@
+package ktb.leafresh.backend.domain.challenge.personal.application.factory;
+
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.request.PersonalChallengeCreateRequestDto;
+import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PersonalChallengeFactoryTest {
+
+    private final PersonalChallengeFactory factory = new PersonalChallengeFactory();
+
+    @Test
+    @DisplayName("create_정상입력_도메인생성됨")
+    void create_withValidInput_returnsPersonalChallenge() {
+        // given
+        PersonalChallengeCreateRequestDto.ExampleImageRequestDto image =
+                new PersonalChallengeCreateRequestDto.ExampleImageRequestDto(
+                        "https://test.image/example.jpg",
+                        ExampleImageType.SUCCESS,
+                        "예시 설명",
+                        1
+                );
+
+        PersonalChallengeCreateRequestDto dto = new PersonalChallengeCreateRequestDto(
+                "아침 기상 챌린지",
+                "기상 후 인증샷 촬영",
+                DayOfWeek.MONDAY,
+                "https://test.image/thumbnail.jpg",
+                LocalTime.of(6, 0),
+                LocalTime.of(8, 0),
+                List.of(image)
+        );
+
+        // when
+        PersonalChallenge result = factory.create(dto);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo(dto.title());
+        assertThat(result.getDescription()).isEqualTo(dto.description());
+        assertThat(result.getDayOfWeek()).isEqualTo(dto.dayOfWeek());
+        assertThat(result.getImageUrl()).isEqualTo(dto.thumbnailImageUrl());
+        assertThat(result.getVerificationStartTime()).isEqualTo(dto.verificationStartTime());
+        assertThat(result.getVerificationEndTime()).isEqualTo(dto.verificationEndTime());
+        assertThat(result.getLeafReward()).isEqualTo(30);
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeCreateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeCreateServiceTest.java
@@ -1,0 +1,106 @@
+package ktb.leafresh.backend.domain.challenge.personal.application.service;
+
+import ktb.leafresh.backend.domain.challenge.personal.application.factory.PersonalChallengeExampleImageAssembler;
+import ktb.leafresh.backend.domain.challenge.personal.application.factory.PersonalChallengeFactory;
+import ktb.leafresh.backend.domain.challenge.personal.application.validator.PersonalChallengeDomainValidator;
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import ktb.leafresh.backend.domain.challenge.personal.infrastructure.repository.PersonalChallengeRepository;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.request.PersonalChallengeCreateRequestDto;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.request.PersonalChallengeCreateRequestDto.ExampleImageRequestDto;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeCreateResponseDto;
+import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
+import ktb.leafresh.backend.support.fixture.PersonalChallengeFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("PersonalChallengeCreateService 테스트")
+class PersonalChallengeCreateServiceTest {
+
+    @Mock
+    private PersonalChallengeDomainValidator validator;
+
+    @Mock
+    private PersonalChallengeFactory factory;
+
+    @Mock
+    private PersonalChallengeExampleImageAssembler assembler;
+
+    @Mock
+    private PersonalChallengeRepository repository;
+
+    @InjectMocks
+    private PersonalChallengeCreateService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @DisplayName("정상적인 요청으로 개인 챌린지를 생성할 수 있다")
+    @Test
+    void createPersonalChallenge_withValidRequest_returnsResponseDto() {
+        // given
+        PersonalChallengeCreateRequestDto request = new PersonalChallengeCreateRequestDto(
+                "매일 스트레칭하기",
+                "매일 아침 10분 스트레칭",
+                DayOfWeek.MONDAY,
+                "https://cdn.test.com/thumbnail.png",
+                LocalTime.of(6, 0),
+                LocalTime.of(22, 0),
+                List.of(new ExampleImageRequestDto("https://cdn.test.com/image1.png", ExampleImageType.SUCCESS, "성공 예시", 1))
+        );
+
+        PersonalChallenge created = PersonalChallengeFixture.of("매일 스트레칭하기");
+        ReflectionTestUtils.setField(created, "id", 10L);
+
+        given(factory.create(request)).willReturn(created);
+        willDoNothing().given(assembler).assemble(created, request);
+        given(repository.save(created)).willReturn(created);
+
+        // when
+        PersonalChallengeCreateResponseDto response = service.create(request);
+
+        // then
+        assertThat(response.id()).isEqualTo(created.getId());
+        then(validator).should().validate(DayOfWeek.MONDAY);
+        then(factory).should().create(request);
+        then(assembler).should().assemble(created, request);
+        then(repository).should().save(created);
+    }
+
+    @DisplayName("잘못된 요일 입력 시 예외가 발생한다")
+    @Test
+    void createPersonalChallenge_withInvalidDayOfWeek_throwsException() {
+        // given
+        PersonalChallengeCreateRequestDto request = new PersonalChallengeCreateRequestDto(
+                "잘못된 챌린지",
+                "잘못된 설명",
+                DayOfWeek.FRIDAY,
+                "https://cdn.test.com/image.png",
+                LocalTime.of(0, 0),
+                LocalTime.of(1, 0),
+                List.of()
+        );
+
+        willThrow(new IllegalArgumentException("유효하지 않은 요일입니다."))
+                .given(validator).validate(DayOfWeek.FRIDAY);
+
+        // when & then
+        assertThatThrownBy(() -> service.create(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("유효하지 않은 요일");
+
+        then(factory).should(never()).create(any());
+        then(repository).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/personal/application/service/PersonalChallengeReadServiceTest.java
@@ -1,0 +1,167 @@
+package ktb.leafresh.backend.domain.challenge.personal.application.service;
+
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallengeExampleImage;
+import ktb.leafresh.backend.domain.challenge.personal.infrastructure.repository.PersonalChallengeRepository;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeDetailResponseDto;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeListResponseDto;
+import ktb.leafresh.backend.domain.challenge.personal.presentation.dto.response.PersonalChallengeRuleResponseDto;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.PersonalChallengeVerificationRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.global.common.entity.enums.DayOfWeek;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import ktb.leafresh.backend.support.fixture.PersonalChallengeExampleImageFixture;
+import ktb.leafresh.backend.support.fixture.PersonalChallengeFixture;
+import ktb.leafresh.backend.support.fixture.PersonalChallengeVerificationFixture;
+
+import org.junit.jupiter.api.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("PersonalChallengeReadService 단위 테스트")
+class PersonalChallengeReadServiceTest {
+
+    @Mock
+    private PersonalChallengeRepository challengeRepository;
+
+    @Mock
+    private PersonalChallengeVerificationRepository verificationRepository;
+
+    @InjectMocks
+    private PersonalChallengeReadService readService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @DisplayName("요일 기준으로 개인 챌린지를 조회할 수 있다")
+    @Test
+    void getByDayOfWeek_withValidDay_returnsList() {
+        // given
+        PersonalChallenge challenge = PersonalChallengeFixture.of("매일 물 마시기");
+        ReflectionTestUtils.setField(challenge, "id", 1L);
+        given(challengeRepository.findAllByDayOfWeek(DayOfWeek.MONDAY)).willReturn(List.of(challenge));
+
+        // when
+        PersonalChallengeListResponseDto response = readService.getByDayOfWeek(DayOfWeek.MONDAY);
+
+        // then
+        assertThat(response.personalChallenges()).hasSize(1);
+        assertThat(response.personalChallenges().get(0).title()).isEqualTo(challenge.getTitle());
+    }
+
+    @DisplayName("해당 요일에 챌린지가 없으면 예외를 던진다")
+    @Test
+    void getByDayOfWeek_withNoChallenges_throwsException() {
+        // given
+        given(challengeRepository.findAllByDayOfWeek(DayOfWeek.TUESDAY)).willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> readService.getByDayOfWeek(DayOfWeek.TUESDAY))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.PERSONAL_CHALLENGE_READ_FAILED.getMessage());
+    }
+
+    @DisplayName("회원이 챌린지 상세를 조회할 수 있다")
+    @Test
+    void getChallengeDetail_withValidMember_returnsDetail() {
+        // given
+        Long challengeId = 1L;
+        Long memberId = 100L;
+
+        PersonalChallenge challenge = PersonalChallengeFixture.of("독서하기");
+        ReflectionTestUtils.setField(challenge, "id", challengeId);
+
+        List<PersonalChallengeExampleImage> images = PersonalChallengeExampleImageFixture.list(challenge);
+        challenge.getExampleImages().addAll(images);
+
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+        given(verificationRepository.findTopByMemberIdAndPersonalChallengeIdAndCreatedAtBetween(
+                anyLong(), anyLong(), any(), any()))
+                .willReturn(Optional.of(PersonalChallengeVerificationFixture.of(MemberFixture.of(), challenge)));
+
+        // when
+        PersonalChallengeDetailResponseDto response = readService.getChallengeDetail(memberId, challengeId);
+
+        // then
+        assertThat(response.status()).isEqualTo(ChallengeStatus.SUCCESS);
+        assertThat(response.title()).isEqualTo(challenge.getTitle());
+        assertThat(response.exampleImages()).hasSize(2);
+    }
+
+    @DisplayName("존재하지 않는 챌린지 ID로 상세조회 시 예외를 던진다")
+    @Test
+    void getChallengeDetail_withInvalidId_throwsException() {
+        // given
+        given(challengeRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> readService.getChallengeDetail(1L, 999L))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.PERSONAL_CHALLENGE_DETAIL_READ_FAILED.getMessage());
+    }
+
+    @DisplayName("비회원은 인증 상태 없이 상세 정보를 조회할 수 있다")
+    @Test
+    void getChallengeDetail_withNullMemberId_returnsDefaultStatus() {
+        // given
+        Long challengeId = 1L;
+        PersonalChallenge challenge = PersonalChallengeFixture.of("명상하기");
+        ReflectionTestUtils.setField(challenge, "id", challengeId);
+
+        List<PersonalChallengeExampleImage> images = PersonalChallengeExampleImageFixture.list(challenge);
+        challenge.getExampleImages().addAll(images);
+
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+
+        // when
+        PersonalChallengeDetailResponseDto response = readService.getChallengeDetail(null, challengeId);
+
+        // then
+        assertThat(response.status()).isEqualTo(ChallengeStatus.NOT_SUBMITTED);
+        assertThat(response.exampleImages()).hasSize(2);
+    }
+
+    @DisplayName("챌린지 규칙 조회 시 예시 이미지와 인증 시간을 반환한다")
+    @Test
+    void getChallengeRules_withValidChallenge_returnsRuleInfo() {
+        // given
+        Long challengeId = 1L;
+        PersonalChallenge challenge = PersonalChallengeFixture.of("아침 조깅하기");
+        ReflectionTestUtils.setField(challenge, "id", challengeId);
+
+        List<PersonalChallengeExampleImage> images = PersonalChallengeExampleImageFixture.list(challenge);
+        challenge.getExampleImages().addAll(images);
+
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+
+        // when
+        PersonalChallengeRuleResponseDto response = readService.getChallengeRules(challengeId);
+
+        // then
+        assertThat(response.certificationPeriod().dayOfWeek()).isEqualTo(challenge.getDayOfWeek());
+        assertThat(response.exampleImages()).hasSize(2);
+    }
+
+    @DisplayName("존재하지 않는 챌린지 규칙 요청 시 예외를 던진다")
+    @Test
+    void getChallengeRules_withInvalidId_throwsException() {
+        // given
+        given(challengeRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> readService.getChallengeRules(999L))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.PERSONAL_CHALLENGE_RULE_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/support/fixture/PersonalChallengeExampleImageFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/PersonalChallengeExampleImageFixture.java
@@ -1,0 +1,29 @@
+package ktb.leafresh.backend.support.fixture;
+
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallengeExampleImage;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
+
+import java.util.List;
+
+public class PersonalChallengeExampleImageFixture {
+
+    public static List<PersonalChallengeExampleImage> list(PersonalChallenge challenge) {
+        return List.of(
+                PersonalChallengeExampleImage.of(
+                        challenge,
+                        "https://cdn.test.com/success.png",
+                        ExampleImageType.SUCCESS,
+                        "성공 예시",
+                        1
+                ),
+                PersonalChallengeExampleImage.of(
+                        challenge,
+                        "https://cdn.test.com/fail.png",
+                        ExampleImageType.FAILURE,
+                        "실패 예시",
+                        2
+                )
+        );
+    }
+}


### PR DESCRIPTION
- 테스트용 Fixture 클래스 구현
- PersonalChallengeReadService 등 단위 테스트 작성
  - 챌린지 목록 조회 (정상/예외)
  - 챌린지 상세 조회 (로그인/비로그인/예외)
  - 챌린지 규칙 조회 및 인증 이력 조회 (정상/예외)
- 시간 비교는 LocalDateTime 고정값 사용하여 테스트 안정성 확보