### PR TITLE
test: 단체 챌린지 도메인 및 이니셜라이저 테스트 추가

### DIFF
--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/factory/GroupChallengeExampleImageAssemblerTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/factory/GroupChallengeExampleImageAssemblerTest.java
@@ -1,0 +1,91 @@
+package ktb.leafresh.backend.domain.challenge.group.application.factory;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeExampleImage;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
+import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeExampleImageAssembler 테스트")
+class GroupChallengeExampleImageAssemblerTest {
+
+    private GroupChallengeExampleImageAssembler assembler;
+
+    @BeforeEach
+    void setUp() {
+        assembler = new GroupChallengeExampleImageAssembler();
+    }
+
+    @Test
+    @DisplayName("예시 이미지 DTO를 GroupChallenge에 매핑하고 양방향 연관관계를 설정한다")
+    void assemble_withValidDto_setsImagesAndRelationships() {
+        // given
+        Member member = MemberFixture.of();
+        GroupChallengeCategory category = GroupChallengeCategoryFixture.defaultCategory();
+        GroupChallenge challenge = GroupChallengeFixture.of(member, category);
+        ReflectionTestUtils.setField(challenge, "exampleImages", new ArrayList<>());
+
+        GroupChallengeCreateRequestDto.ExampleImageRequestDto imageDto1 =
+                new GroupChallengeCreateRequestDto.ExampleImageRequestDto(
+                        "https://image1.jpg", ExampleImageType.SUCCESS, "성공 예시1", 1);
+
+        GroupChallengeCreateRequestDto.ExampleImageRequestDto imageDto2 =
+                new GroupChallengeCreateRequestDto.ExampleImageRequestDto(
+                        "https://image2.jpg", ExampleImageType.FAILURE, "실패 예시1", 2);
+
+        GroupChallengeCreateRequestDto dto = new GroupChallengeCreateRequestDto(
+                "제로웨이스트 챌린지",
+                "일회용품 줄이기",
+                "ZERO_WASTE",
+                30,
+                "https://thumbnail.jpg",
+                OffsetDateTime.now(),
+                OffsetDateTime.now().plusDays(7),
+                LocalTime.of(6, 0),
+                LocalTime.of(22, 0),
+                List.of(imageDto1, imageDto2)
+        );
+
+        // when
+        assembler.assemble(challenge, dto);
+
+        // then
+        List<GroupChallengeExampleImage> exampleImages = challenge.getExampleImages();
+
+        assertThat(exampleImages).hasSize(2);
+
+        assertThat(exampleImages).anySatisfy(image -> {
+            assertThat(image.getImageUrl()).isEqualTo("https://image1.jpg");
+            assertThat(image.getType()).isEqualTo(ExampleImageType.SUCCESS);
+            assertThat(image.getDescription()).isEqualTo("성공 예시1");
+            assertThat(image.getSequenceNumber()).isEqualTo(1);
+            assertThat(image.getGroupChallenge()).isEqualTo(challenge);
+        });
+
+        assertThat(exampleImages).anySatisfy(image -> {
+            assertThat(image.getImageUrl()).isEqualTo("https://image2.jpg");
+            assertThat(image.getType()).isEqualTo(ExampleImageType.FAILURE);
+            assertThat(image.getDescription()).isEqualTo("실패 예시1");
+            assertThat(image.getSequenceNumber()).isEqualTo(2);
+            assertThat(image.getGroupChallenge()).isEqualTo(challenge);
+        });
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/factory/GroupChallengeFactoryTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/factory/GroupChallengeFactoryTest.java
@@ -1,0 +1,116 @@
+package ktb.leafresh.backend.domain.challenge.group.application.factory;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static ktb.leafresh.backend.global.common.entity.enums.ExampleImageType.SUCCESS;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeFactory 테스트")
+class GroupChallengeFactoryTest {
+
+    @Mock
+    private GroupChallengeCategoryRepository categoryRepository;
+
+    @InjectMocks
+    private GroupChallengeFactory groupChallengeFactory;
+
+    @Test
+    @DisplayName("단체 챌린지를 정상적으로 생성할 수 있다")
+    void createGroupChallenge_withValidInput_returnsGroupChallenge() {
+        // given
+        GroupChallengeCategory category = GroupChallengeCategoryFixture.of("ZERO_WASTE");
+        Member member = MemberFixture.of();
+
+        GroupChallengeCreateRequestDto.ExampleImageRequestDto exampleImage =
+                new GroupChallengeCreateRequestDto.ExampleImageRequestDto(
+                        "https://dummy.image/example.png",
+                        SUCCESS,
+                        "성공 인증 예시입니다.",
+                        1
+                );
+
+        GroupChallengeCreateRequestDto dto = new GroupChallengeCreateRequestDto(
+                "제로웨이스트 챌린지",
+                "플라스틱 줄이기 실천",
+                category.getName(),
+                50,
+                "https://dummy.image/thumbnail.png",
+                OffsetDateTime.parse("2024-01-01T00:00:00+09:00"),
+                OffsetDateTime.parse("2024-01-07T23:59:00+09:00"),
+                LocalTime.of(6, 0),
+                LocalTime.of(22, 0),
+                List.of(exampleImage)
+        );
+
+        given(categoryRepository.findByName(dto.category()))
+                .willReturn(Optional.of(category));
+
+        // when
+        GroupChallenge result = groupChallengeFactory.create(dto, member);
+
+        // then
+        assertThat(result.getMember()).isEqualTo(member);
+        assertThat(result.getCategory()).isEqualTo(category);
+        assertThat(result.getTitle()).isEqualTo(dto.title());
+        assertThat(result.getDescription()).isEqualTo(dto.description());
+        assertThat(result.getImageUrl()).isEqualTo(dto.thumbnailImageUrl());
+        assertThat(result.getStartDate()).isEqualTo(dto.startDate().toLocalDateTime());
+        assertThat(result.getEndDate()).isEqualTo(dto.endDate().toLocalDateTime());
+        assertThat(result.getVerificationStartTime()).isEqualTo(dto.verificationStartTime());
+        assertThat(result.getVerificationEndTime()).isEqualTo(dto.verificationEndTime());
+        assertThat(result.getMaxParticipantCount()).isEqualTo(dto.maxParticipantCount());
+        assertThat(result.getCurrentParticipantCount()).isZero(); // 초기값 0
+        assertThat(result.getLeafReward()).isEqualTo(30); // 고정값
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카테고리로 챌린지 생성 시 예외가 발생한다")
+    void createGroupChallenge_withInvalidCategory_throwsException() {
+        // given
+        Member member = MemberFixture.of();
+
+        GroupChallengeCreateRequestDto dto = new GroupChallengeCreateRequestDto(
+                "제로웨이스트 챌린지",
+                "플라스틱 줄이기 실천",
+                "NON_EXISTING_CATEGORY",
+                50,
+                "https://dummy.image/thumbnail.png",
+                OffsetDateTime.now(),
+                OffsetDateTime.now().plusDays(7),
+                LocalTime.of(6, 0),
+                LocalTime.of(22, 0),
+                List.of(new GroupChallengeCreateRequestDto.ExampleImageRequestDto(
+                        "https://dummy.image/example.png", SUCCESS, "설명", 1
+                ))
+        );
+
+        given(categoryRepository.findByName(dto.category()))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> groupChallengeFactory.create(dto, member))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.CHALLENGE_CATEGORY_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/EventChallengeInitServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/EventChallengeInitServiceTest.java
@@ -1,0 +1,124 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.enums.GroupChallengeCategoryName;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeExampleImageRepository;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.domain.entity.TreeLevel;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.TreeLevelRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventChallengeInitService 테스트")
+public class EventChallengeInitServiceTest {
+
+    @Mock
+    private GroupChallengeRepository challengeRepository;
+
+    @Mock
+    private GroupChallengeCategoryRepository categoryRepository;
+
+    @Mock
+    private GroupChallengeExampleImageRepository imageRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private TreeLevelRepository treeLevelRepository;
+
+    @InjectMocks
+    private EventChallengeInitService eventChallengeInitService;
+
+    @Test
+    @DisplayName("이벤트 챌린지가 이미 존재하면 등록하지 않는다")
+    void registerEventChallenge_ifAlreadyExists_doesNothing() {
+        // given
+        int year = LocalDate.now().getYear();
+        String title = "SNS에 습지 보호 캠페인 알리기 " + year;
+        given(challengeRepository.existsByTitleAndEventFlagTrue(title)).willReturn(true);
+
+        // when
+        eventChallengeInitService.registerCurrentYearEventChallengesIfNotExists();
+
+        // then
+        verify(challengeRepository, never()).save(any());
+        verify(imageRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("ETC 카테고리가 없으면 예외 발생")
+    void registerEventChallenge_ifCategoryNotFound_throwsException() {
+        // given
+        int year = LocalDate.now().getYear();
+        given(challengeRepository.existsByTitleAndEventFlagTrue(anyString())).willReturn(false);
+        given(categoryRepository.findByName(GroupChallengeCategoryName.ETC.name())).willReturn(Optional.empty());
+
+        // when/then
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> eventChallengeInitService.registerCurrentYearEventChallengesIfNotExists());
+    }
+
+    @Test
+    @DisplayName("admin 계정이 없으면 새로 생성한다")
+    void registerEventChallenge_ifAdminNotExist_createAdminMember() {
+        // given
+        int year = LocalDate.now().getYear();
+        GroupChallengeCategory etc = mock(GroupChallengeCategory.class);
+        TreeLevel treeLevel = mock(TreeLevel.class);
+
+        given(challengeRepository.existsByTitleAndEventFlagTrue(anyString())).willReturn(false);
+        given(categoryRepository.findByName(GroupChallengeCategoryName.ETC.name())).willReturn(Optional.of(etc));
+        given(memberRepository.findByEmail("admin@leafresh.io")).willReturn(Optional.empty());
+        given(treeLevelRepository.findById(1L)).willReturn(Optional.of(treeLevel));
+        given(memberRepository.save(any(Member.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        eventChallengeInitService.registerCurrentYearEventChallengesIfNotExists();
+
+        // then
+        verify(memberRepository).save(any(Member.class));
+        verify(challengeRepository, atLeastOnce()).save(any(GroupChallenge.class));
+        verify(imageRepository, atLeastOnce()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("admin 계정이 있으면 재사용한다")
+    void registerEventChallenge_ifAdminExists_useExistingAdmin() {
+        // given
+        int year = LocalDate.now().getYear();
+        GroupChallengeCategory etc = mock(GroupChallengeCategory.class);
+        Member admin = mock(Member.class);
+
+        given(challengeRepository.existsByTitleAndEventFlagTrue(anyString())).willReturn(false);
+        given(categoryRepository.findByName(GroupChallengeCategoryName.ETC.name())).willReturn(Optional.of(etc));
+        given(memberRepository.findByEmail("admin@leafresh.io")).willReturn(Optional.of(admin));
+
+        // when
+        eventChallengeInitService.registerCurrentYearEventChallengesIfNotExists();
+
+        // then
+        verify(memberRepository, never()).save(any());
+        verify(challengeRepository, atLeastOnce()).save(any(GroupChallenge.class));
+        verify(imageRepository, atLeastOnce()).saveAll(any());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/EventChallengeReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/EventChallengeReadServiceTest.java
@@ -1,0 +1,74 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.EventChallengeResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture.of;
+import static ktb.leafresh.backend.support.fixture.GroupChallengeFixture.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventChallengeReadService 테스트")
+class EventChallengeReadServiceTest {
+
+    @Mock
+    private GroupChallengeRepository groupChallengeRepository;
+
+    @InjectMocks
+    private EventChallengeReadService eventChallengeReadService;
+
+    private GroupChallenge challenge;
+
+    @BeforeEach
+    void setUp() {
+        challenge = of(mock(ktb.leafresh.backend.domain.member.domain.entity.Member.class), of("ETC"), "챌린지 제목", true);
+    }
+
+    @Test
+    @DisplayName("2주 이내의 이벤트 챌린지 목록을 조회할 수 있다")
+    void getEventChallenges_withinTwoWeeks_returnsDtoList() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        given(groupChallengeRepository.findEventChallengesWithinRange(any(), any()))
+                .willReturn(List.of(challenge));
+
+        // when
+        List<EventChallengeResponseDto> result = eventChallengeReadService.getEventChallenges();
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).id()).isEqualTo(challenge.getId());
+        assertThat(result.get(0).title()).isEqualTo(challenge.getTitle());
+        assertThat(result.get(0).description()).isEqualTo(challenge.getDescription());
+        assertThat(result.get(0).thumbnailUrl()).isEqualTo(challenge.getImageUrl());
+    }
+
+    @Test
+    @DisplayName("조회 중 예외가 발생하면 CustomException이 발생한다")
+    void getEventChallenges_whenExceptionThrown_throwsCustomException() {
+        // given
+        given(groupChallengeRepository.findEventChallengesWithinRange(any(), any()))
+                .willThrow(new RuntimeException("DB 오류"));
+
+        // when & then
+        assertThatThrownBy(() -> eventChallengeReadService.getEventChallenges())
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.EVENT_CHALLENGE_READ_FAILED.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCategoryServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCategoryServiceTest.java
@@ -1,0 +1,85 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeCategoryResponseDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeCategoryService 테스트")
+class GroupChallengeCategoryServiceTest {
+
+    @Mock
+    private GroupChallengeCategoryRepository categoryRepository;
+
+    @InjectMocks
+    private GroupChallengeCategoryService categoryService;
+
+    private GroupChallengeCategory category1;
+    private GroupChallengeCategory category2;
+    private GroupChallengeCategory etcCategory;
+
+    @BeforeEach
+    void setUp() {
+        category1 = of("ZERO_WASTE");
+        category2 = of("PLOGGING");
+        etcCategory = of("ETC");
+    }
+
+    @Test
+    @DisplayName("활성화된 ETC 제외 카테고리 목록을 조회할 수 있다")
+    void getCategories_withValidCategories_returnsList() {
+        // given
+        given(categoryRepository.findAllByActivatedIsTrueOrderBySequenceNumberAsc())
+                .willReturn(List.of(category1, category2, etcCategory));
+
+        // when
+        List<GroupChallengeCategoryResponseDto> result = categoryService.getCategories();
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting("category").containsExactlyInAnyOrder("ZERO_WASTE", "PLOGGING");
+        assertThat(result).extracting("label").contains("제로웨이스트", "플로깅");
+    }
+
+    @Test
+    @DisplayName("ETC 제외 후 카테고리가 없으면 예외가 발생한다")
+    void getCategories_whenFilteredEmpty_throwsException() {
+        // given
+        given(categoryRepository.findAllByActivatedIsTrueOrderBySequenceNumberAsc())
+                .willReturn(List.of(etcCategory));
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.getCategories())
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.CHALLENGE_CATEGORY_LIST_EMPTY.getMessage());
+    }
+
+    @Test
+    @DisplayName("카테고리 조회 중 예외 발생 시 CustomException으로 변환된다")
+    void getCategories_whenRepositoryFails_throwsWrappedCustomException() {
+        // given
+        given(categoryRepository.findAllByActivatedIsTrueOrderBySequenceNumberAsc())
+                .willThrow(new RuntimeException("DB 오류"));
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.getCategories())
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.CHALLENGE_CATEGORY_READ_FAILED.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCreateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCreateServiceTest.java
@@ -1,0 +1,98 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.application.factory.GroupChallengeExampleImageAssembler;
+import ktb.leafresh.backend.domain.challenge.group.application.factory.GroupChallengeFactory;
+import ktb.leafresh.backend.domain.challenge.group.application.validator.AiChallengePolicyValidator;
+import ktb.leafresh.backend.domain.challenge.group.application.validator.GroupChallengeDomainValidator;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeCreateResponseDto;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.MemberErrorCode;
+import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeCreateService 테스트")
+class GroupChallengeCreateServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private GroupChallengeDomainValidator domainValidator;
+
+    @Mock
+    private AiChallengePolicyValidator aiValidator;
+
+    @Mock
+    private GroupChallengeFactory factory;
+
+    @Mock
+    private GroupChallengeExampleImageAssembler assembler;
+
+    @Mock
+    private GroupChallengeRepository groupChallengeRepository;
+
+    @InjectMocks private GroupChallengeCreateService createService;
+
+    private Member member;
+    private GroupChallenge challenge;
+    private GroupChallengeCreateRequestDto request;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.of();
+        challenge = GroupChallengeFixture.of(member, GroupChallengeCategoryFixture.defaultCategory());
+        request = mock(GroupChallengeCreateRequestDto.class);
+    }
+
+    @Test
+    @DisplayName("단체 챌린지 생성 성공 시 ID 반환")
+    void createGroupChallenge_withValidInput_returnsResponse() {
+        // given
+        Long memberId = 1L;
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        willDoNothing().given(domainValidator).validate(request);
+        willDoNothing().given(aiValidator).validate(memberId, request);
+        given(factory.create(request, member)).willReturn(challenge);
+        willDoNothing().given(assembler).assemble(challenge, request);
+        given(groupChallengeRepository.save(challenge)).willReturn(challenge);
+
+        // when
+        GroupChallengeCreateResponseDto response = createService.create(memberId, request);
+
+        // then
+        assertThat(response.id()).isEqualTo(challenge.getId());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원이면 예외 발생")
+    void createGroupChallenge_withInvalidMember_throwsException() {
+        // given
+        Long invalidMemberId = 999L;
+        given(memberRepository.findById(invalidMemberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> createService.create(invalidMemberId, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCreatedReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeCreatedReadServiceTest.java
@@ -1,0 +1,80 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCreatedQueryRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.CreatedGroupChallengeSummaryResponseDto;
+import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
+import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class GroupChallengeCreatedReadServiceTest {
+
+    @Mock
+    private GroupChallengeCreatedQueryRepository createdRepository;
+
+    @InjectMocks
+    private GroupChallengeCreatedReadService createdReadService;
+
+    @Test
+    @DisplayName("내가 생성한 단체 챌린지를 커서 기반으로 조회할 수 있다")
+    void getCreatedChallengesByMember_withValidInput_returnsPaginatedResult() {
+        // given
+        Long memberId = 1L;
+        Long cursorId = null;
+        String cursorTimestamp = null;
+        int size = 2;
+
+        var member = MemberFixture.of();
+        var category = GroupChallengeCategoryFixture.of("환경");
+        var challenge1 = GroupChallengeFixture.of(member, category);
+        var challenge2 = GroupChallengeFixture.of(member, category);
+        var challenge3 = GroupChallengeFixture.of(member, category);
+
+        // 2개만 조회 요청했지만, hasNext 검증을 위해 +1개 반환
+        LocalDateTime fixedCreatedAt = LocalDateTime.of(2024, 5, 1, 12, 0);
+        ReflectionTestUtils.setField(challenge1, "createdAt", fixedCreatedAt);
+        ReflectionTestUtils.setField(challenge2, "createdAt", fixedCreatedAt.plusMinutes(1));
+        ReflectionTestUtils.setField(challenge3, "createdAt", fixedCreatedAt.plusMinutes(2));
+        given(createdRepository.findCreatedByMember(memberId, cursorId, cursorTimestamp, size + 1))
+                .willReturn(List.of(challenge1, challenge2, challenge3));
+
+        // when
+        CursorPaginationResult<CreatedGroupChallengeSummaryResponseDto> result =
+                createdReadService.getCreatedChallengesByMember(memberId, cursorId, cursorTimestamp, size);
+
+        // then
+        assertThat(result.items()).hasSize(size);
+        assertThat(result.hasNext()).isTrue(); // 3개 중 2개만 반환되므로 다음 페이지 있음
+        assertThat(result.cursorInfo()).isNotNull();
+
+        var first = result.items().get(0);
+        assertThat(first.name()).isEqualTo(challenge1.getTitle());
+        assertThat(first.description()).isEqualTo(challenge1.getDescription());
+        assertThat(first.imageUrl()).isEqualTo(challenge1.getImageUrl());
+        assertThat(first.startDate()).isEqualTo(challenge1.getStartDate().toLocalDate().toString());
+        assertThat(first.endDate()).isEqualTo(challenge1.getEndDate().toLocalDate().toString());
+        assertThat(first.currentParticipantCount()).isEqualTo(challenge1.getCurrentParticipantCount());
+        assertThat(first.category()).isEqualTo(challenge1.getCategory().getName());
+
+        // 커서 시간은 UTC로 변환되었는지 검증
+        String expectedTime = challenge1.getCreatedAt().atOffset(java.time.ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        String actualTime = first.createdAt().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        assertThat(actualTime).isEqualTo(expectedTime);
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeDeleteServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeDeleteServiceTest.java
@@ -1,0 +1,139 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeParticipantRecordRepository;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static ktb.leafresh.backend.global.exception.ChallengeErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeDeleteService 테스트")
+class GroupChallengeDeleteServiceTest {
+
+    @Mock
+    private GroupChallengeRepository groupChallengeRepository;
+
+    @Mock
+    private GroupChallengeParticipantRecordRepository participantRecordRepository;
+
+    @InjectMocks
+    private GroupChallengeDeleteService groupChallengeDeleteService;
+
+    @Nested
+    @DisplayName("delete()는")
+    class Delete {
+
+        @Test
+        @DisplayName("작성자가 참여자 없는 챌린지를 삭제하면 soft delete되고 challengeId를 반환한다.")
+        void deleteGroupChallengeSuccessfully() {
+            // given
+            var member = MemberFixture.of();
+            ReflectionTestUtils.setField(member, "id", 1L);
+
+            var category = GroupChallengeCategoryFixture.defaultCategory();
+            var challenge = GroupChallengeFixture.of(member, category);
+            ReflectionTestUtils.setField(challenge, "id", 1L);
+
+            given(groupChallengeRepository.findById(1L)).willReturn(Optional.of(challenge));
+            given(participantRecordRepository.existsByGroupChallengeIdAndDeletedAtIsNull(1L)).willReturn(false);
+
+            // when
+            Long deletedId = groupChallengeDeleteService.delete(member.getId(), 1L);
+
+            // then
+            assertThat(deletedId).isEqualTo(1L);
+            assertThat(challenge.isDeleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 챌린지를 삭제하려 하면 예외를 던진다.")
+        void throwsExceptionIfChallengeNotFound() {
+            // given
+            given(groupChallengeRepository.findById(1L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> groupChallengeDeleteService.delete(1L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(GROUP_CHALLENGE_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 챌린지를 다시 삭제하려 하면 예외를 던진다.")
+        void throwsExceptionIfAlreadyDeleted() {
+            // given
+            var member = MemberFixture.of();
+            ReflectionTestUtils.setField(member, "id", 2L);
+
+            var category = GroupChallengeCategoryFixture.defaultCategory();
+            var challenge = GroupChallengeFixture.of(member, category);
+            challenge.softDelete();
+            ReflectionTestUtils.setField(challenge, "id", 1L);
+
+            given(groupChallengeRepository.findById(1L)).willReturn(Optional.of(challenge));
+
+            // when & then
+            assertThatThrownBy(() -> groupChallengeDeleteService.delete(member.getId(), 1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(CHALLENGE_ALREADY_DELETED.getMessage());
+        }
+
+        @Test
+        @DisplayName("작성자가 아닌 사용자가 삭제 요청하면 예외를 던진다.")
+        void throwsExceptionIfNotWriter() {
+            // given
+            var writer = MemberFixture.of("writer@leafresh.com", "작성자");
+            var other = MemberFixture.of("other@leafresh.com", "다른사람");
+
+            ReflectionTestUtils.setField(writer, "id", 1L);
+            ReflectionTestUtils.setField(other, "id", 2L);
+
+            var category = GroupChallengeCategoryFixture.defaultCategory();
+            var challenge = GroupChallengeFixture.of(writer, category);
+            ReflectionTestUtils.setField(challenge, "id", 1L);
+
+            given(groupChallengeRepository.findById(1L)).willReturn(Optional.of(challenge));
+
+            // when & then
+            assertThatThrownBy(() -> groupChallengeDeleteService.delete(other.getId(), 1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(CHALLENGE_ACCESS_DENIED.getMessage());
+        }
+
+        @Test
+        @DisplayName("참여자가 있는 챌린지를 삭제하려 하면 예외를 던진다.")
+        void throwsExceptionIfHasParticipants() {
+            // given
+            var member = MemberFixture.of();
+            ReflectionTestUtils.setField(member, "id", 3L);
+
+            var category = GroupChallengeCategoryFixture.defaultCategory();
+            var challenge = GroupChallengeFixture.of(member, category);
+            ReflectionTestUtils.setField(challenge, "id", 1L);
+
+            given(groupChallengeRepository.findById(1L)).willReturn(Optional.of(challenge));
+            given(participantRecordRepository.existsByGroupChallengeIdAndDeletedAtIsNull(1L)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> groupChallengeDeleteService.delete(member.getId(), 1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(CHALLENGE_HAS_PARTICIPANTS_DELETE_NOT_ALLOWED.getMessage());
+        }
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeDetailReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeDetailReadServiceTest.java
@@ -1,0 +1,127 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeDetailResponseDto;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.support.fixture.*;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.global.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static ktb.leafresh.backend.global.exception.ChallengeErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeDetailReadService 테스트")
+class GroupChallengeDetailReadServiceTest {
+
+    @Mock
+    private GroupChallengeRepository groupChallengeRepository;
+
+    @Mock
+    private GroupChallengeVerificationRepository verificationRepository;
+
+    @InjectMocks private GroupChallengeDetailReadService groupChallengeDetailReadService;
+
+    @Nested
+    @DisplayName("getChallengeDetail()은")
+    class GetChallengeDetail {
+
+        @Test
+        @DisplayName("정상적으로 상세 정보를 조회하고 응답 객체를 반환한다.")
+        void returnChallengeDetailSuccessfully() {
+            // given
+            Member member = MemberFixture.of();
+            ReflectionTestUtils.setField(member, "id", 1L);
+
+            GroupChallenge challenge = GroupChallengeFixture.of(member, GroupChallengeCategoryFixture.defaultCategory());
+            ReflectionTestUtils.setField(challenge, "id", 100L);
+
+            GroupChallengeParticipantRecord record = GroupChallengeParticipantRecordFixture.of(challenge, member);
+            GroupChallengeVerification verification = GroupChallengeVerificationFixture.of(record);
+            List<GroupChallengeVerification> verifications = List.of(verification);
+
+            given(groupChallengeRepository.findById(100L)).willReturn(Optional.of(challenge));
+            given(verificationRepository.findTop9ByParticipantRecord_GroupChallenge_IdOrderByCreatedAtDesc(100L))
+                    .willReturn(verifications);
+            given(verificationRepository.findTopByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_IdOrderByCreatedAtDesc(1L, 100L))
+                    .willReturn(Optional.of(verification));
+
+            // when
+            GroupChallengeDetailResponseDto result = groupChallengeDetailReadService.getChallengeDetail(1L, 100L);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.status()).isEqualTo(ChallengeStatus.SUCCESS);
+            assertThat(result.verificationImages()).containsExactly("https://dummy.image/verify.jpg");
+            assertThat(result.exampleImages()).hasSize(challenge.getExampleImages().size());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 챌린지를 조회할 경우 예외를 던진다.")
+        void throwsExceptionWhenChallengeNotFound() {
+            // given
+            given(groupChallengeRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> groupChallengeDetailReadService.getChallengeDetail(1L, 999L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(GROUP_CHALLENGE_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 챌린지를 조회할 경우 예외를 던진다.")
+        void throwsExceptionWhenAlreadyDeleted() {
+            // given
+            Member member = MemberFixture.of();
+            ReflectionTestUtils.setField(member, "id", 2L);
+
+            GroupChallenge challenge = GroupChallengeFixture.of(member, GroupChallengeCategoryFixture.defaultCategory());
+            challenge.softDelete(); // 삭제 처리
+            ReflectionTestUtils.setField(challenge, "id", 300L);
+
+            given(groupChallengeRepository.findById(300L)).willReturn(Optional.of(challenge));
+
+            // when & then
+            assertThatThrownBy(() -> groupChallengeDetailReadService.getChallengeDetail(2L, 300L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(GROUP_CHALLENGE_ALREADY_DELETED.getMessage());
+        }
+
+        @Test
+        @DisplayName("비로그인 사용자는 status가 NOT_SUBMITTED로 반환된다.")
+        void returnNotSubmittedForAnonymousUser() {
+            // given
+            Member member = MemberFixture.of();
+            GroupChallenge challenge = GroupChallengeFixture.of(member, GroupChallengeCategoryFixture.defaultCategory());
+            ReflectionTestUtils.setField(challenge, "id", 400L);
+
+            given(groupChallengeRepository.findById(400L)).willReturn(Optional.of(challenge));
+            given(verificationRepository.findTop9ByParticipantRecord_GroupChallenge_IdOrderByCreatedAtDesc(400L))
+                    .willReturn(List.of());
+
+            // when
+            GroupChallengeDetailResponseDto result = groupChallengeDetailReadService.getChallengeDetail(null, 400L);
+
+            // then
+            assertThat(result.status()).isEqualTo(ChallengeStatus.NOT_SUBMITTED);
+        }
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeParticipationReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeParticipationReadServiceTest.java
@@ -1,0 +1,130 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeParticipationRecordQueryRepository;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeVerificationQueryRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.query.GroupChallengeParticipationDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeParticipationCountResponseDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeParticipationCountSummaryDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeParticipationListResponseDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeParticipationSummaryDto.AchievementRecordDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeParticipationReadService 테스트")
+class GroupChallengeParticipationReadServiceTest {
+
+    @Mock
+    private GroupChallengeParticipationRecordQueryRepository participationQueryRepository;
+
+    @Mock
+    private GroupChallengeVerificationQueryRepository verificationQueryRepository;
+
+    @InjectMocks
+    private GroupChallengeParticipationReadService participationReadService;
+
+    @Nested
+    @DisplayName("getParticipationCounts()는")
+    class GetParticipationCounts {
+
+        @Test
+        @DisplayName("상태별 참여 챌린지 수를 조회해 반환한다.")
+        void returnsParticipationCounts() {
+            // given
+            Long memberId = 1L;
+            GroupChallengeParticipationCountSummaryDto summaryDto =
+                    new GroupChallengeParticipationCountSummaryDto(1, 2, 3);
+
+            given(participationQueryRepository.countParticipationByStatus(memberId))
+                    .willReturn(summaryDto);
+
+            // when
+            GroupChallengeParticipationCountResponseDto response =
+                    participationReadService.getParticipationCounts(memberId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.count().notStarted()).isEqualTo(1);
+            assertThat(response.count().ongoing()).isEqualTo(2);
+            assertThat(response.count().completed()).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("getParticipatedChallenges()는")
+    class GetParticipatedChallenges {
+
+        @Test
+        @DisplayName("참여한 챌린지 목록을 커서 기반으로 조회해 반환한다.")
+        void returnsParticipatedChallengesWithPagination() {
+            // given
+            Long memberId = 1L;
+            String status = "ONGOING";
+            Long cursorId = null;
+            String cursorTimestamp = null;
+            int size = 2;
+
+            GroupChallengeParticipationDto dto1 = new GroupChallengeParticipationDto(
+                    10L,
+                    "제로웨이스트",
+                    "https://dummy.image/challenge1.png",
+                    LocalDateTime.of(2024, 1, 1, 0, 0),
+                    LocalDateTime.of(2024, 1, 7, 23, 59),
+                    3L,
+                    5L,
+                    LocalDateTime.of(2024, 1, 1, 0, 0)
+            );
+
+            GroupChallengeParticipationDto dto2 = new GroupChallengeParticipationDto(
+                    11L,
+                    "플로깅",
+                    "https://dummy.image/challenge2.png",
+                    LocalDateTime.of(2024, 2, 1, 0, 0),
+                    LocalDateTime.of(2024, 2, 7, 23, 59),
+                    2L,
+                    5L,
+                    LocalDateTime.of(2024, 2, 1, 0, 0)
+            );
+
+            List<GroupChallengeParticipationDto> dtos = List.of(dto1, dto2);
+            List<AchievementRecordDto> record1 = List.of(new AchievementRecordDto(1, "SUCCESS"));
+            List<AchievementRecordDto> record2 = List.of(new AchievementRecordDto(2, "FAIL"));
+
+            Map<Long, List<AchievementRecordDto>> recordMap = Map.of(
+                    10L, record1,
+                    11L, record2
+            );
+
+            given(participationQueryRepository.findParticipatedByStatus(memberId, status, cursorId, cursorTimestamp, size + 1))
+                    .willReturn(dtos);
+
+            given(verificationQueryRepository.findVerificationsGroupedByChallenge(List.of(10L, 11L), memberId))
+                    .willReturn(recordMap);
+
+            // when
+            GroupChallengeParticipationListResponseDto response =
+                    participationReadService.getParticipatedChallenges(memberId, status, cursorId, cursorTimestamp, size);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.challenges()).hasSize(2);
+            assertThat(response.hasNext()).isFalse();
+            assertThat(response.challenges().get(0).achievement().success()).isEqualTo(3L);
+            assertThat(response.challenges().get(1).achievementRecords()).containsExactly(new AchievementRecordDto(2, "FAIL"));
+        }
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeParticipationServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeParticipationServiceTest.java
@@ -1,0 +1,96 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.service.GroupChallengeParticipantManager;
+import ktb.leafresh.backend.domain.challenge.group.domain.support.policy.GroupChallengePromotionPolicy;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import ktb.leafresh.backend.global.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeParticipationService 테스트")
+class GroupChallengeParticipationServiceTest {
+
+    @Mock
+    private GroupChallengeParticipantManager participantManager;
+
+    @Mock
+    private GroupChallengePromotionPolicy promotionPolicy;
+
+    @InjectMocks
+    private GroupChallengeParticipationService participationService;
+
+    private final Long memberId = 1L;
+    private final Long challengeId = 100L;
+
+    @Nested
+    @DisplayName("participate()는")
+    class Participate {
+
+        @Test
+        @DisplayName("정상적으로 챌린지에 참여할 수 있다.")
+        void participateSuccessfully() {
+            // given
+            given(participantManager.participate(memberId, challengeId)).willReturn(challengeId);
+
+            // when
+            Long result = participationService.participate(memberId, challengeId);
+
+            // then
+            assertThat(result).isEqualTo(challengeId);
+            then(participantManager).should().participate(memberId, challengeId);
+        }
+
+        @Test
+        @DisplayName("참여 중 예외가 발생하면 CustomException으로 감싸서 던진다.")
+        void throwsWrappedExceptionOnParticipateFailure() {
+            // given
+            RuntimeException cause = new RuntimeException("DB 오류");
+            given(participantManager.participate(memberId, challengeId)).willThrow(cause);
+
+            // when & then
+            assertThatThrownBy(() -> participationService.participate(memberId, challengeId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_PARTICIPATION_FAILED.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("drop()은")
+    class Drop {
+
+        @Test
+        @DisplayName("정상적으로 참여를 취소하고 다음 대기자를 승격시킨다.")
+        void dropSuccessfully() {
+            // when
+            participationService.drop(memberId, challengeId);
+
+            // then
+            then(participantManager).should().drop(memberId, challengeId);
+            then(promotionPolicy).should().promoteNextWaitingParticipant(challengeId);
+        }
+
+        @Test
+        @DisplayName("취소 중 예외가 발생하면 CustomException으로 감싸서 던진다.")
+        void throwsWrappedExceptionOnDropFailure() {
+            // given
+            willThrow(new RuntimeException("예상치 못한 에러"))
+                    .given(participantManager).drop(memberId, challengeId);
+
+            // when & then
+            assertThatThrownBy(() -> participationService.drop(memberId, challengeId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_PARTICIPATION_FAILED.getMessage());
+        }
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeSearchReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeSearchReadServiceTest.java
@@ -1,0 +1,118 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.enums.GroupChallengeCategoryName;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeSearchQueryRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeSummaryResponseDto;
+import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
+import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeSearchReadService 테스트")
+class GroupChallengeSearchReadServiceTest {
+
+    @Mock
+    private GroupChallengeSearchQueryRepository searchRepository;
+
+    @InjectMocks
+    private GroupChallengeSearchReadService searchReadService;
+
+    @Nested
+    @DisplayName("getGroupChallenges()는")
+    class GetGroupChallenges {
+
+        @Test
+        @DisplayName("검색어와 카테고리 없이 챌린지 목록을 조회하고 DTO로 매핑한다.")
+        void returnsChallengeListWithoutFilters() {
+            // given
+            var member = MemberFixture.of();
+            var category = GroupChallengeCategoryFixture.defaultCategory();
+            var challenge = GroupChallengeFixture.of(member, category);
+            ReflectionTestUtils.setField(challenge, "id", 1L);
+            ReflectionTestUtils.setField(challenge, "createdAt", challenge.getStartDate());
+
+            given(searchRepository.findByFilter(null, null, null, null, 6))
+                    .willReturn(List.of(challenge));
+
+            // when
+            CursorPaginationResult<GroupChallengeSummaryResponseDto> result = searchReadService
+                    .getGroupChallenges(null, null, null, null, 5);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.items()).hasSize(1);
+            assertThat(result.hasNext()).isFalse();
+            assertThat(result.cursorInfo()).isNotNull();
+            assertThat(result.items().get(0).title()).isEqualTo("제로웨이스트 챌린지");
+        }
+
+        @Test
+        @DisplayName("카테고리 필터가 있을 경우 category name으로 필터링이 적용된다.")
+        void filtersByCategory() {
+            // given
+            var member = MemberFixture.of();
+            var category = GroupChallengeCategoryFixture.of(GroupChallengeCategoryName.VEGAN);
+            var challenge = GroupChallengeFixture.of(member, category);
+            ReflectionTestUtils.setField(challenge, "id", 2L);
+            ReflectionTestUtils.setField(challenge, "createdAt", challenge.getStartDate());
+
+            given(searchRepository.findByFilter(null, "VEGAN", null, null, 6))
+                    .willReturn(List.of(challenge));
+
+            // when
+            var result = searchReadService.getGroupChallenges(null, GroupChallengeCategoryName.VEGAN, null, null, 5);
+
+            // then
+            assertThat(result.items()).hasSize(1);
+            assertThat(result.items().get(0).category()).isEqualTo("VEGAN");
+        }
+
+        @Test
+        @DisplayName("조회된 결과 수가 요청 수보다 많으면 hasNext가 true다.")
+        void hasNextIsTrueWhenResultsExceedPageSize() {
+            // given
+            var member = MemberFixture.of();
+            var category = GroupChallengeCategoryFixture.defaultCategory();
+
+            var challenge1 = GroupChallengeFixture.of(member, category);
+            var challenge2 = GroupChallengeFixture.of(member, category);
+            var challenge3 = GroupChallengeFixture.of(member, category);
+            var challenge4 = GroupChallengeFixture.of(member, category);
+
+            ReflectionTestUtils.setField(challenge1, "id", 1L);
+            ReflectionTestUtils.setField(challenge2, "id", 2L);
+            ReflectionTestUtils.setField(challenge3, "id", 3L);
+            ReflectionTestUtils.setField(challenge4, "id", 4L);
+            ReflectionTestUtils.setField(challenge1, "createdAt", challenge1.getStartDate());
+            ReflectionTestUtils.setField(challenge2, "createdAt", challenge2.getStartDate());
+            ReflectionTestUtils.setField(challenge3, "createdAt", challenge3.getStartDate());
+            ReflectionTestUtils.setField(challenge4, "createdAt", challenge4.getStartDate());
+
+            given(searchRepository.findByFilter(null, null, null, null, 4))
+                    .willReturn(List.of(challenge1, challenge2, challenge3, challenge4));
+
+            // when
+            var result = searchReadService.getGroupChallenges(null, null, null, null, 3);
+
+            // then
+            assertThat(result.items()).hasSize(3);
+            assertThat(result.hasNext()).isTrue();
+        }
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeUpdateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeUpdateServiceTest.java
@@ -1,0 +1,137 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.application.service.updater.GroupChallengeCategoryUpdater;
+import ktb.leafresh.backend.domain.challenge.group.application.service.updater.GroupChallengeExampleImageUpdater;
+import ktb.leafresh.backend.domain.challenge.group.application.service.updater.GroupChallengeUpdater;
+import ktb.leafresh.backend.domain.challenge.group.application.validator.GroupChallengeDomainValidator;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeParticipantRecordRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto.*;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeUpdateService 테스트")
+class GroupChallengeUpdateServiceTest {
+
+    @Mock
+    private GroupChallengeUpdater challengeUpdater;
+
+    @Mock
+    private GroupChallengeExampleImageUpdater imageUpdater;
+
+    @Mock
+    private GroupChallengeCategoryUpdater categoryUpdater;
+
+    @Mock
+    private GroupChallengeDomainValidator domainValidator;
+
+    @Mock
+    private GroupChallengeParticipantRecordRepository participantRecordRepository;
+
+    @InjectMocks private GroupChallengeUpdateService updateService;
+
+    @Test
+    @DisplayName("참여자가 존재하면 수정 불가 예외를 던진다.")
+    void update_withParticipants_throwsException() {
+        // given
+        given(participantRecordRepository.existsByGroupChallengeIdAndDeletedAtIsNull(1L)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> updateService.update(1L, 1L, mock(GroupChallengeUpdateRequestDto.class)))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.CHALLENGE_HAS_PARTICIPANTS_UPDATE_NOT_ALLOWED.getMessage());
+    }
+
+    @Test
+    @DisplayName("유효성 검사 및 업데이트 로직이 정상적으로 호출된다.")
+    void update_withoutParticipants_success() {
+        // given
+        var member = MemberFixture.of();
+        var category = GroupChallengeCategoryFixture.defaultCategory();
+        var challenge = GroupChallengeFixture.of(member, category);
+
+        var dto = createValidRequest();
+
+        given(participantRecordRepository.existsByGroupChallengeIdAndDeletedAtIsNull(1L)).willReturn(false);
+        willDoNothing().given(domainValidator).validate(dto);
+        given(challengeUpdater.updateChallengeInfo(1L, 1L, dto)).willReturn(challenge);
+        willDoNothing().given(categoryUpdater).updateCategory(challenge, dto.category());
+        willDoNothing().given(imageUpdater).updateImages(challenge, dto.exampleImages());
+
+        // when
+        updateService.update(1L, 1L, dto);
+
+        // then
+        then(domainValidator).should().validate(dto);
+        then(challengeUpdater).should().updateChallengeInfo(1L, 1L, dto);
+        then(categoryUpdater).should().updateCategory(challenge, dto.category());
+        then(imageUpdater).should().updateImages(challenge, dto.exampleImages());
+    }
+
+    @Test
+    @DisplayName("SecurityException 발생 시 이미지 권한 에러로 변환된다.")
+    void update_throwsSecurityException_wrappedAsCustomException() {
+        // given
+        var dto = createValidRequest();
+        given(participantRecordRepository.existsByGroupChallengeIdAndDeletedAtIsNull(1L)).willReturn(false);
+        willThrow(SecurityException.class).given(domainValidator).validate(dto);
+
+        // when & then
+        assertThatThrownBy(() -> updateService.update(1L, 1L, dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.CHALLENGE_UPDATE_IMAGE_PERMISSION_DENIED.getMessage());
+    }
+
+    @Test
+    @DisplayName("알 수 없는 예외가 발생하면 서버 오류로 처리된다.")
+    void update_throwsUnknownException_wrappedAsCustomException() {
+        // given
+        var dto = createValidRequest();
+        given(participantRecordRepository.existsByGroupChallengeIdAndDeletedAtIsNull(1L)).willReturn(false);
+        willThrow(RuntimeException.class).given(domainValidator).validate(dto);
+
+        // when & then
+        assertThatThrownBy(() -> updateService.update(1L, 1L, dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_UPDATE_FAILED.getMessage());
+    }
+
+    private GroupChallengeUpdateRequestDto createValidRequest() {
+        return new GroupChallengeUpdateRequestDto(
+                "새 제목",
+                "새 설명",
+                "ZERO_WASTE",
+                100,
+                "https://dummy.image/thumbnail.png",
+                OffsetDateTime.parse("2024-01-01T00:00:00Z"),
+                OffsetDateTime.parse("2024-01-07T23:59:00Z"),
+                LocalTime.of(6, 0),
+                LocalTime.of(22, 0),
+                new ExampleImages(
+                        List.of(new ExampleImages.KeepImage(1L, 1)),
+                        List.of(new ExampleImages.NewImage("https://dummy.image/new.png", ExampleImageType.SUCCESS, "예시", 2)),
+                        List.of(3L)
+                )
+        );
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeVerificationHistoryServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeVerificationHistoryServiceTest.java
@@ -1,0 +1,123 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.service.GroupChallengeVerificationHistoryCalculator;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeParticipantRecordRepository;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeVerificationQueryRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeVerificationHistoryResponseDto;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.support.fixture.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeVerificationHistoryService 테스트")
+class GroupChallengeVerificationHistoryServiceTest {
+
+    @Mock
+    private GroupChallengeRepository challengeRepository;
+
+    @Mock
+    private GroupChallengeParticipantRecordRepository recordRepository;
+
+    @Mock
+    private GroupChallengeVerificationQueryRepository verificationRepository;
+
+    @Mock
+    private GroupChallengeVerificationHistoryCalculator calculator;
+
+    @InjectMocks
+    private GroupChallengeVerificationHistoryService historyService;
+
+    @Test
+    @DisplayName("정상 조회 시 검증 결과를 반환한다.")
+    void getVerificationHistory_success() {
+        // given
+        Long memberId = 1L;
+        Long challengeId = 10L;
+
+        var member = MemberFixture.of();
+        var category = GroupChallengeCategoryFixture.defaultCategory();
+        var challenge = GroupChallengeFixture.of(member, category);
+        var record = GroupChallengeParticipantRecordFixture.of(challenge, member);
+        var verifications = List.of(GroupChallengeVerificationFixture.of(record));
+
+        var expectedResponse = GroupChallengeVerificationHistoryResponseDto.builder()
+                .id(challengeId)
+                .title("제로웨이스트 챌린지")
+                .achievement(GroupChallengeVerificationHistoryResponseDto.AchievementDto.builder()
+                        .success(1)
+                        .failure(0)
+                        .remaining(6)
+                        .build())
+                .verifications(List.of())
+                .todayStatus("PENDING_APPROVAL")
+                .build();
+
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+        given(recordRepository.findByMemberIdAndGroupChallengeIdAndDeletedAtIsNull(memberId, challengeId)).willReturn(Optional.of(record));
+        given(verificationRepository.findByParticipantRecordId(record.getId())).willReturn(verifications);
+        given(calculator.calculate(challenge, record, verifications)).willReturn(expectedResponse);
+
+        // when
+        var result = historyService.getVerificationHistory(memberId, challengeId);
+
+        // then
+        assertThat(result).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 챌린지 ID라면 예외를 던진다.")
+    void getVerificationHistory_challengeNotFound() {
+        // given
+        Long memberId = 1L, challengeId = 999L;
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> historyService.getVerificationHistory(memberId, challengeId))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_VERIFICATION_CHALLENGE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("참여 기록이 없다면 예외를 던진다.")
+    void getVerificationHistory_participantNotFound() {
+        // given
+        Long memberId = 1L, challengeId = 999L;
+        var member = MemberFixture.of();
+        var category = GroupChallengeCategoryFixture.defaultCategory();
+        var challenge = GroupChallengeFixture.of(member, category);
+
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+        given(recordRepository.findByMemberIdAndGroupChallengeIdAndDeletedAtIsNull(memberId, challengeId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> historyService.getVerificationHistory(memberId, challengeId))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_VERIFICATION_ACCESS_DENIED.getMessage());
+    }
+
+    @Test
+    @DisplayName("예기치 못한 예외가 발생하면 공통 실패 코드로 예외를 던진다.")
+    void getVerificationHistory_unknownError() {
+        // given
+        Long memberId = 1L, challengeId = 10L;
+        given(challengeRepository.findById(challengeId)).willThrow(new RuntimeException("DB ERROR"));
+
+        // when & then
+        assertThatThrownBy(() -> historyService.getVerificationHistory(memberId, challengeId))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_VERIFICATION_READ_FAILED.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeVerificationReadServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeVerificationReadServiceTest.java
@@ -1,0 +1,251 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeVerificationQueryRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeVerificationDetailResponseDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeVerificationSummaryDto;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.verification.application.dto.VerificationStatSnapshot;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.cache.VerificationStatCacheService;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.LikeRepository;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import ktb.leafresh.backend.global.util.pagination.CursorPaginationResult;
+import ktb.leafresh.backend.global.util.redis.VerificationStatRedisLuaService;
+import ktb.leafresh.backend.support.fixture.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("GroupChallengeVerificationReadService 테스트")
+@ExtendWith(MockitoExtension.class)
+class GroupChallengeVerificationReadServiceTest {
+
+    @Mock
+    private GroupChallengeRepository groupChallengeRepository;
+
+    @Mock
+    private GroupChallengeVerificationRepository groupChallengeVerificationRepository;
+
+    @Mock
+    private GroupChallengeVerificationQueryRepository groupChallengeVerificationQueryRepository;
+
+    @Mock
+    private VerificationStatCacheService verificationStatCacheService;
+
+    @Mock
+    private LikeRepository likeRepository;
+
+    @Mock
+    private VerificationStatRedisLuaService verificationStatRedisLuaService;
+
+    @InjectMocks
+    private GroupChallengeVerificationReadService readService;
+
+    private Member member;
+    private GroupChallenge challenge;
+    private GroupChallengeParticipantRecord record;
+    private GroupChallengeVerification verification;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.of();
+        GroupChallengeCategory category = GroupChallengeCategoryFixture.of("제로웨이스트");
+        challenge = GroupChallengeFixture.of(member, category);
+        record = GroupChallengeParticipantRecordFixture.of(challenge, member);
+        verification = GroupChallengeVerificationFixture.of(record);
+        ReflectionTestUtils.setField(verification, "id", 10L);
+        ReflectionTestUtils.setField(verification, "updatedAt", LocalDateTime.of(2024, 1, 1, 10, 0));
+    }
+
+    @Test
+    @DisplayName("인증 목록 조회 성공 - 로그인 사용자 있음")
+    void getVerifications_withLoginMember_returnsPaginatedResult() {
+        // given
+        Long loginMemberId = 1L;
+        List<GroupChallengeVerification> list = List.of(verification);
+        Map<Object, Object> stats = Map.of("viewCount", "10", "likeCount", "2", "commentCount", "5");
+
+        given(groupChallengeRepository.existsById(challenge.getId())).willReturn(true);
+        given(groupChallengeVerificationQueryRepository.findByChallengeId(challenge.getId(), null, null, 11))
+                .willReturn(list);
+        given(verificationStatCacheService.getStats(verification.getId())).willReturn(stats);
+        given(likeRepository.findLikedVerificationIdsByMemberId(loginMemberId, List.of(verification.getId())))
+                .willReturn(Set.of(verification.getId()));
+
+        // when
+        CursorPaginationResult<GroupChallengeVerificationSummaryDto> result =
+                readService.getVerifications(challenge.getId(), null, null, 10, loginMemberId);
+
+        // then
+        assertThat(result.items()).hasSize(1);
+        GroupChallengeVerificationSummaryDto dto = result.items().get(0);
+        assertThat(dto.id()).isEqualTo(verification.getId());
+        assertThat(dto.counts().view()).isEqualTo(10);
+        assertThat(dto.isLiked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("인증 목록 조회 실패 - 챌린지 없음")
+    void getVerifications_whenChallengeNotFound_throwsException() {
+        // given
+        given(groupChallengeRepository.existsById(anyLong())).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() ->
+                readService.getVerifications(999L, null, null, 10, null))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("인증 상세 조회 성공 - 비로그인 사용자")
+    void getVerificationDetail_success_withNullLoginMember() {
+        // given
+        Long verificationId = verification.getId();
+        Long challengeId = challenge.getId();
+        Map<Object, Object> stats = Map.of("viewCount", "9", "likeCount", "1", "commentCount", "0");
+
+        given(groupChallengeVerificationQueryRepository.findByChallengeIdAndId(challengeId, verificationId))
+                .willReturn(Optional.of(verification));
+        given(verificationStatCacheService.getStats(verificationId)).willReturn(stats);
+
+        // when
+        GroupChallengeVerificationDetailResponseDto dto =
+                readService.getVerificationDetail(challengeId, verificationId, null);
+
+        // then
+        assertThat(dto.id()).isEqualTo(verificationId);
+        assertThat(dto.counts().like()).isEqualTo(1);
+        assertThat(dto.isLiked()).isFalse(); // 로그인 안 했으므로 false
+    }
+
+    @Test
+    @DisplayName("단체 챌린지 인증 상세 조회 성공")
+    void getVerificationDetail_success() {
+        // given
+        Long verificationId = verification.getId();
+        Long challengeId = challenge.getId();
+        Long loginMemberId = 1L;
+        Map<Object, Object> stats = Map.of("viewCount", "11", "likeCount", "3", "commentCount", "1");
+
+        given(groupChallengeVerificationQueryRepository.findByChallengeIdAndId(challengeId, verificationId))
+                .willReturn(Optional.of(verification));
+        given(verificationStatCacheService.getStats(verificationId)).willReturn(stats);
+        given(likeRepository.findLikedVerificationIdsByMemberId(loginMemberId, List.of(verificationId)))
+                .willReturn(Set.of(verificationId));
+
+        // when
+        GroupChallengeVerificationDetailResponseDto dto =
+                readService.getVerificationDetail(challengeId, verificationId, loginMemberId);
+
+        // then
+        assertThat(dto.id()).isEqualTo(verificationId);
+        assertThat(dto.counts().like()).isEqualTo(3);
+        assertThat(dto.isLiked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("인증 상세 조회 실패 - 인증 없음")
+    void getVerificationDetail_whenNotFound_throwsException() {
+        // given
+        given(groupChallengeVerificationQueryRepository.findByChallengeIdAndId(anyLong(), anyLong()))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> readService.getVerificationDetail(1L, 2L, 3L))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(VerificationErrorCode.VERIFICATION_DETAIL_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("Redis 캐시 복구 - 캐시가 없는 경우")
+    void recoverVerificationStatWithLock_shouldInitializeWhenCacheIsMissing() {
+        // given
+        Long verificationId = verification.getId();
+        given(verificationStatCacheService.getStats(verificationId)).willReturn(Map.of());
+        VerificationStatSnapshot snapshot = new VerificationStatSnapshot(
+                verification.getId(),
+                verification.getViewCount(),
+                verification.getLikeCount(),
+                verification.getCommentCount()
+        );
+
+        given(groupChallengeVerificationRepository.findStatById(verificationId))
+                .willReturn(Optional.of(snapshot));
+
+        // when
+        readService.recoverVerificationStatWithLock(verificationId);
+
+        // then
+        verify(verificationStatCacheService).initializeVerificationStats(
+                eq(verificationId),
+                eq(verification.getViewCount()),
+                eq(verification.getLikeCount()),
+                eq(verification.getCommentCount())
+        );
+    }
+
+    @Test
+    @DisplayName("인증 상세 조회 성공 - 캐시가 없는 경우 복구 후 반환")
+    void getVerificationDetail_withEmptyCache_recoversAndReturns() {
+        // given
+        Long verificationId = verification.getId();
+        Long challengeId = challenge.getId();
+        Long loginMemberId = 1L;
+        Map<Object, Object> emptyStats = Map.of();
+        Map<Object, Object> recoveredStats = Map.of("viewCount", "11", "likeCount", "3", "commentCount", "1");
+
+        given(groupChallengeVerificationQueryRepository.findByChallengeIdAndId(challengeId, verificationId))
+                .willReturn(Optional.of(verification));
+        given(verificationStatCacheService.getStats(verificationId))
+                .willReturn(emptyStats) // 첫 번째 호출: 캐시 없음
+                .willReturn(recoveredStats); // 두 번째 호출: 복구 후 재조회
+        given(likeRepository.findLikedVerificationIdsByMemberId(loginMemberId, List.of(verificationId)))
+                .willReturn(Set.of(verificationId));
+
+        // when
+        GroupChallengeVerificationDetailResponseDto dto =
+                readService.getVerificationDetail(challengeId, verificationId, loginMemberId);
+
+        // then
+        assertThat(dto.id()).isEqualTo(verificationId);
+        assertThat(dto.counts().like()).isEqualTo(3);
+        assertThat(dto.isLiked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("규약 조회 실패 - 존재하지 않는 챌린지")
+    void getChallengeRules_whenNotFound_throwsException() {
+        // given
+        given(groupChallengeRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> readService.getChallengeRules(123L))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_RULE_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/updater/GroupChallengeCategoryUpdaterTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/updater/GroupChallengeCategoryUpdaterTest.java
@@ -1,0 +1,72 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service.updater;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeCategoryUpdater 테스트")
+class GroupChallengeCategoryUpdaterTest {
+
+    @Mock
+    private GroupChallengeCategoryRepository categoryRepository;
+
+    @InjectMocks
+    private GroupChallengeCategoryUpdater categoryUpdater;
+
+    @Test
+    @DisplayName("카테고리를 성공적으로 변경할 수 있다")
+    void updateCategory_withValidCategoryName_updatesCategory() {
+        // given
+        Member member = MemberFixture.of();
+        GroupChallengeCategory originalCategory = GroupChallengeCategoryFixture.of("ZERO_WASTE");
+        GroupChallenge challenge = GroupChallengeFixture.of(member, originalCategory);
+
+        GroupChallengeCategory newCategory = GroupChallengeCategoryFixture.of("VEGAN");
+
+        given(categoryRepository.findByName("VEGAN"))
+                .willReturn(Optional.of(newCategory));
+
+        // when
+        categoryUpdater.updateCategory(challenge, "VEGAN");
+
+        // then
+        assertThat(challenge.getCategory()).isEqualTo(newCategory);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카테고리 이름으로 변경 시 예외가 발생한다")
+    void updateCategory_withInvalidCategoryName_throwsException() {
+        // given
+        Member member = MemberFixture.of();
+        GroupChallengeCategory category = GroupChallengeCategoryFixture.of("ZERO_WASTE");
+        GroupChallenge challenge = GroupChallengeFixture.of(member, category);
+
+        String invalidCategoryName = "NOT_EXIST";
+
+        given(categoryRepository.findByName(invalidCategoryName))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> categoryUpdater.updateCategory(challenge, invalidCategoryName))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.CHALLENGE_CATEGORY_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/updater/GroupChallengeExampleImageUpdaterTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/updater/GroupChallengeExampleImageUpdaterTest.java
@@ -1,0 +1,140 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service.updater;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeExampleImage;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeExampleImageRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.util.image.ImageEntityUpdater;
+import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.verify;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("GroupChallengeExampleImageUpdater 테스트")
+@ExtendWith(MockitoExtension.class)
+class GroupChallengeExampleImageUpdaterTest {
+
+    @Mock
+    private GroupChallengeExampleImageRepository imageRepository;
+
+    @Mock
+    private ImageEntityUpdater imageEntityUpdater;
+
+    @InjectMocks
+    private GroupChallengeExampleImageUpdater updater;
+
+    private GroupChallenge challenge;
+    private Member member;
+    private GroupChallengeExampleImage existingImage;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.of();
+        ReflectionTestUtils.setField(member, "id", 100L);
+
+        GroupChallengeCategory category = GroupChallengeCategoryFixture.defaultCategory();
+        challenge = GroupChallengeFixture.of(member, category);
+
+        existingImage = GroupChallengeExampleImage.of(challenge, "https://image.com/existing.png",
+                ExampleImageType.SUCCESS, "기존 이미지", 1);
+        ReflectionTestUtils.setField(existingImage, "id", 1L);
+    }
+
+    @Test
+    @DisplayName("예시 이미지 목록을 정상적으로 업데이트할 수 있다")
+    void updateImages_withValidInput_updatesImagesSuccessfully() {
+        // given
+        var keepImage = new GroupChallengeUpdateRequestDto.ExampleImages.KeepImage(1L, 2);
+        var newImage = new GroupChallengeUpdateRequestDto.ExampleImages.NewImage(
+                "https://image.com/new.png", ExampleImageType.FAILURE, "새 이미지", 3
+        );
+        var deletedIds = List.of(5L);
+
+        GroupChallengeUpdateRequestDto.ExampleImages exampleImages =
+                new GroupChallengeUpdateRequestDto.ExampleImages(
+                        List.of(keepImage),
+                        List.of(newImage),
+                        deletedIds
+                );
+
+        given(imageRepository.findById(1L)).willReturn(Optional.of(existingImage));
+        given(imageRepository.findById(5L)).willReturn(Optional.of(existingImage)); // 같은 owner로 간주
+
+        // when
+        updater.updateImages(challenge, exampleImages);
+
+        // then
+        verify(imageEntityUpdater).update(eq(challenge),
+                eq(List.of(new ImageEntityUpdater.KeepImage(1L, 2))),
+                argThat(newEntities -> newEntities.size() == 1 &&
+                        newEntities.get(0).getImageUrl().equals("https://image.com/new.png")),
+                eq(deletedIds),
+                eq(imageRepository)
+        );
+    }
+
+    @Test
+    @DisplayName("keep 이미지의 소유자가 다르면 예외가 발생한다")
+    void updateImages_keepImageOwnedByOther_throwsException() {
+        // given
+        Member another = MemberFixture.of("other@leafresh.com", "다른사람");
+        ReflectionTestUtils.setField(another, "id", 200L);
+
+        GroupChallenge otherChallenge = GroupChallengeFixture.of(another, GroupChallengeCategoryFixture.defaultCategory());
+        GroupChallengeExampleImage otherImage = GroupChallengeExampleImage.of(otherChallenge, "url", ExampleImageType.SUCCESS, "desc", 1);
+        ReflectionTestUtils.setField(otherImage, "id", 99L);
+
+        GroupChallengeUpdateRequestDto.ExampleImages exampleImages =
+                new GroupChallengeUpdateRequestDto.ExampleImages(
+                        List.of(new GroupChallengeUpdateRequestDto.ExampleImages.KeepImage(99L, 1)),
+                        List.of(),
+                        List.of()
+                );
+
+        given(imageRepository.findById(99L)).willReturn(Optional.of(otherImage));
+
+        // when & then
+        assertThatThrownBy(() -> updater.updateImages(challenge, exampleImages))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.CHALLENGE_UPDATE_IMAGE_PERMISSION_DENIED.getMessage());
+    }
+
+    @Test
+    @DisplayName("deleted 이미지가 존재하지 않으면 예외가 발생한다")
+    void updateImages_deletedImageNotFound_throwsException() {
+        // given
+        GroupChallengeUpdateRequestDto.ExampleImages exampleImages =
+                new GroupChallengeUpdateRequestDto.ExampleImages(
+                        List.of(),
+                        List.of(),
+                        List.of(404L)
+                );
+
+        given(imageRepository.findById(404L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> updater.updateImages(challenge, exampleImages))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/updater/GroupChallengeUpdaterTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/service/updater/GroupChallengeUpdaterTest.java
@@ -1,0 +1,120 @@
+package ktb.leafresh.backend.domain.challenge.group.application.service.updater;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.GlobalErrorCode;
+import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("GroupChallengeUpdater 테스트")
+@ExtendWith(MockitoExtension.class)
+class GroupChallengeUpdaterTest {
+
+    @Mock
+    private GroupChallengeRepository repository;
+
+    @InjectMocks
+    private GroupChallengeUpdater updater;
+
+    private Member member;
+    private GroupChallenge challenge;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.of();
+        ReflectionTestUtils.setField(member, "id", 10L);
+
+        GroupChallengeCategory category = GroupChallengeCategoryFixture.defaultCategory();
+        challenge = GroupChallengeFixture.of(member, category);
+        ReflectionTestUtils.setField(challenge, "id", 1L);
+    }
+
+    @Test
+    @DisplayName("정상적으로 챌린지를 수정할 수 있다")
+    void updateChallengeInfo_withValidInput_success() {
+        // given
+        GroupChallengeUpdateRequestDto dto = new GroupChallengeUpdateRequestDto(
+                "새로운 타이틀",
+                "새로운 설명",
+                "ZERO_WASTE",
+                50,
+                "https://image.new-thumbnail.com/image.jpg",
+                OffsetDateTime.parse("2025-01-01T00:00:00+09:00"),
+                OffsetDateTime.parse("2025-01-10T23:59:00+09:00"),
+                LocalTime.of(5, 0),
+                LocalTime.of(21, 0),
+                null // 이미지 업데이트는 해당 로직에서 제외
+        );
+
+        given(repository.findById(1L)).willReturn(Optional.of(challenge));
+
+        // when
+        GroupChallenge updated = updater.updateChallengeInfo(10L, 1L, dto);
+
+        // then
+        assertThat(updated.getTitle()).isEqualTo(dto.title());
+        assertThat(updated.getDescription()).isEqualTo(dto.description());
+        assertThat(updated.getImageUrl()).isEqualTo(dto.thumbnailImageUrl());
+        assertThat(updated.getMaxParticipantCount()).isEqualTo(dto.maxParticipantCount());
+        assertThat(updated.getStartDate().truncatedTo(ChronoUnit.MINUTES))
+                .isEqualTo(dto.startDate().toLocalDateTime().truncatedTo(ChronoUnit.MINUTES));
+        assertThat(updated.getEndDate().truncatedTo(ChronoUnit.MINUTES))
+                .isEqualTo(dto.endDate().toLocalDateTime().truncatedTo(ChronoUnit.MINUTES));
+        assertThat(updated.getVerificationStartTime()).isEqualTo(dto.verificationStartTime());
+        assertThat(updated.getVerificationEndTime()).isEqualTo(dto.verificationEndTime());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 챌린지를 수정하려 하면 예외가 발생한다")
+    void updateChallengeInfo_notFound_throwsException() {
+        // given
+        GroupChallengeUpdateRequestDto dto = mock(GroupChallengeUpdateRequestDto.class);
+
+        given(repository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> updater.updateChallengeInfo(10L, 999L, dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("작성자가 아닌 사용자가 수정하려 하면 예외가 발생한다")
+    void updateChallengeInfo_invalidMember_throwsAccessDenied() {
+        // given
+        Member other = MemberFixture.of("other@leafresh.com", "다른사람");
+        ReflectionTestUtils.setField(other, "id", 999L);
+
+        GroupChallengeUpdateRequestDto dto = mock(GroupChallengeUpdateRequestDto.class);
+
+        given(repository.findById(1L)).willReturn(Optional.of(challenge));
+
+        // when & then
+        assertThatThrownBy(() -> updater.updateChallengeInfo(999L, 1L, dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(GlobalErrorCode.ACCESS_DENIED.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/validator/AiChallengePolicyValidatorTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/validator/AiChallengePolicyValidatorTest.java
@@ -1,0 +1,177 @@
+package ktb.leafresh.backend.domain.challenge.group.application.validator;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.client.AiChallengeValidationClient;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.dto.request.AiChallengeValidationRequestDto;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.dto.response.AiChallengeValidationResponseDto;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto.ExampleImageRequestDto;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AiChallengePolicyValidator 테스트")
+class AiChallengePolicyValidatorTest {
+
+    @Mock
+    private AiChallengeValidationClient aiChallengeValidationClient;
+
+    @Mock
+    private GroupChallengeRepository groupChallengeRepository;
+
+    @InjectMocks
+    private AiChallengePolicyValidator aiChallengePolicyValidator;
+
+    private GroupChallengeCreateRequestDto validRequest;
+
+    @BeforeEach
+    void setUp() {
+        validRequest = new GroupChallengeCreateRequestDto(
+                "제로웨이스트 챌린지",
+                "지속가능한 삶을 위한 실천",
+                "ZERO_WASTE",
+                100,
+                "https://dummy.image/challenge.png",
+                OffsetDateTime.of(2025, 1, 1, 0, 0, 0, 0, UTC),
+                OffsetDateTime.of(2025, 1, 7, 23, 59, 0, 0, UTC),
+                LocalTime.of(6, 0),
+                LocalTime.of(22, 0),
+                List.of(new ExampleImageRequestDto("https://dummy.image/img.png", ExampleImageType.SUCCESS, "성공 예시", 1))
+        );
+    }
+
+    @Nested
+    @DisplayName("validate() 정상 케이스")
+    class ValidateSuccess {
+
+        @Test
+        @DisplayName("유효한 요청일 경우 예외 없이 검증 통과")
+        void validate_withValidInput_shouldPass() {
+            // given
+            Long memberId = 1L;
+            GroupChallenge dummyChallenge = GroupChallengeFixture.of(null, null);
+            given(groupChallengeRepository.findAllValidAndOngoing(any(LocalDateTime.class)))
+                    .willReturn(List.of(dummyChallenge));
+            given(aiChallengeValidationClient.validateChallenge(any(AiChallengeValidationRequestDto.class)))
+                    .willReturn(new AiChallengeValidationResponseDto(true));
+
+            // when & then
+            assertThatCode(() -> aiChallengePolicyValidator.validate(memberId, validRequest))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("validate() 필수 항목 검증 실패")
+    class ValidateRequiredFieldFailure {
+
+        @Test
+        @DisplayName("memberId가 null이면 예외 발생")
+        void validate_withNullMemberId_shouldThrowException() {
+            assertThatThrownBy(() -> aiChallengePolicyValidator.validate(null, validRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_VALIDATION_MISSING_MEMBER_ID.getMessage());
+        }
+
+        @Test
+        @DisplayName("title이 null이면 예외 발생")
+        void validate_withNullTitle_shouldThrowException() {
+            GroupChallengeCreateRequestDto dto = new GroupChallengeCreateRequestDto(
+                    null, validRequest.description(), validRequest.category(),
+                    validRequest.maxParticipantCount(), validRequest.thumbnailImageUrl(),
+                    validRequest.startDate(), validRequest.endDate(),
+                    validRequest.verificationStartTime(), validRequest.verificationEndTime(),
+                    validRequest.exampleImages()
+            );
+
+            assertThatThrownBy(() -> aiChallengePolicyValidator.validate(1L, dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_VALIDATION_MISSING_TITLE.getMessage());
+        }
+
+        @Test
+        @DisplayName("startDate가 null이면 예외 발생")
+        void validate_withNullStartDate_shouldThrowException() {
+            GroupChallengeCreateRequestDto dto = new GroupChallengeCreateRequestDto(
+                    validRequest.title(), validRequest.description(), validRequest.category(),
+                    validRequest.maxParticipantCount(), validRequest.thumbnailImageUrl(),
+                    null, validRequest.endDate(),
+                    validRequest.verificationStartTime(), validRequest.verificationEndTime(),
+                    validRequest.exampleImages()
+            );
+
+            assertThatThrownBy(() -> aiChallengePolicyValidator.validate(1L, dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_VALIDATION_MISSING_START_DATE.getMessage());
+        }
+
+        @Test
+        @DisplayName("endDate가 null이면 예외 발생")
+        void validate_withNullEndDate_shouldThrowException() {
+            GroupChallengeCreateRequestDto dto = new GroupChallengeCreateRequestDto(
+                    validRequest.title(), validRequest.description(), validRequest.category(),
+                    validRequest.maxParticipantCount(), validRequest.thumbnailImageUrl(),
+                    validRequest.startDate(), null,
+                    validRequest.verificationStartTime(), validRequest.verificationEndTime(),
+                    validRequest.exampleImages()
+            );
+
+            assertThatThrownBy(() -> aiChallengePolicyValidator.validate(1L, dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_VALIDATION_MISSING_END_DATE.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("validate() AI 거절 또는 예외 케이스")
+    class ValidateAiFailure {
+
+        @Test
+        @DisplayName("AI 응답 결과가 false이면 예외 발생")
+        void validate_whenAiRejects_shouldThrowException() {
+            // given
+            given(groupChallengeRepository.findAllValidAndOngoing(any())).willReturn(List.of());
+            given(aiChallengeValidationClient.validateChallenge(any()))
+                    .willReturn(new AiChallengeValidationResponseDto(false));
+
+            // when & then
+            assertThatThrownBy(() -> aiChallengePolicyValidator.validate(1L, validRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_VALIDATION_PROCESSING_FAILED.getMessage());
+        }
+
+        @Test
+        @DisplayName("예외 발생 시 AI 처리 실패 예외로 전환")
+        void validate_whenClientThrows_shouldThrowProcessingFailed() {
+            given(groupChallengeRepository.findAllValidAndOngoing(LocalDateTime.now())).willReturn(List.of());
+            given(aiChallengeValidationClient.validateChallenge(any()))
+                    .willThrow(new RuntimeException("AI 서버 오류"));
+
+            assertThatThrownBy(() -> aiChallengePolicyValidator.validate(1L, validRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_VALIDATION_PROCESSING_FAILED.getMessage());
+        }
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/validator/GroupChallengeDomainValidatorTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/application/validator/GroupChallengeDomainValidatorTest.java
@@ -1,0 +1,232 @@
+package ktb.leafresh.backend.domain.challenge.group.application.validator;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.enums.GroupChallengeCategoryName;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeCategoryRepository;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeCreateRequestDto.ExampleImageRequestDto;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.request.GroupChallengeUpdateRequestDto;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import ktb.leafresh.backend.global.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeDomainValidator 테스트")
+class GroupChallengeDomainValidatorTest {
+
+    @Mock
+    private GroupChallengeCategoryRepository categoryRepository;
+
+    @InjectMocks
+    private GroupChallengeDomainValidator validator;
+
+    private static final OffsetDateTime START = OffsetDateTime.of(2025, 7, 1, 0, 0, 0, 0, UTC);
+    private static final OffsetDateTime END = OffsetDateTime.of(2025, 7, 7, 23, 59, 0, 0, UTC);
+    private static final LocalTime VERIFY_START = LocalTime.of(6, 0);
+    private static final LocalTime VERIFY_END = LocalTime.of(22, 0);
+
+    private GroupChallengeCreateRequestDto baseDto;
+
+    @BeforeEach
+    void setUp() {
+        baseDto = new GroupChallengeCreateRequestDto(
+                "제로웨이스트 챌린지",
+                "설명",
+                "ZERO_WASTE",
+                100,
+                "https://dummy.image/thumb.png",
+                START,
+                END,
+                VERIFY_START,
+                VERIFY_END,
+                List.of(new ExampleImageRequestDto("https://dummy.image/img1.png", ExampleImageType.SUCCESS, "성공 예시", 1))
+        );
+
+        GroupChallengeCategory category = GroupChallengeCategory.builder()
+                .name("ZERO_WASTE")
+                .imageUrl(GroupChallengeCategoryName.getImageUrl("ZERO_WASTE"))
+                .sequenceNumber(GroupChallengeCategoryName.getSequence("ZERO_WASTE"))
+                .activated(true)
+                .build();
+
+        lenient().when(categoryRepository.findByName("ZERO_WASTE"))
+                .thenReturn(Optional.of(category));
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class Success {
+
+        @Test
+        @DisplayName("정상 요청 시 예외 발생하지 않음")
+        void validate_withValidInput_shouldPass() {
+            assertThatCode(() -> validator.validate(baseDto)).doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스 - 공통 검증")
+    class CommonValidationFailure {
+
+        @Test
+        @DisplayName("종료일이 시작일보다 이전이면 예외 발생")
+        void validate_withInvalidDateRange_shouldThrow() {
+            GroupChallengeCreateRequestDto dto = new GroupChallengeCreateRequestDto(
+                    baseDto.title(), baseDto.description(), baseDto.category(),
+                    baseDto.maxParticipantCount(), baseDto.thumbnailImageUrl(),
+                    END, START, VERIFY_START, VERIFY_END, baseDto.exampleImages()
+            );
+
+            assertThatThrownBy(() -> validator.validate(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.INVALID_DATE_RANGE.getMessage());
+        }
+
+        @Test
+        @DisplayName("챌린지 기간이 하루 미만이면 예외 발생")
+        void validate_withTooShortDuration_shouldThrow() {
+            GroupChallengeCreateRequestDto dto = new GroupChallengeCreateRequestDto(
+                    baseDto.title(), baseDto.description(), baseDto.category(),
+                    baseDto.maxParticipantCount(), baseDto.thumbnailImageUrl(),
+                    START, START.plusHours(12), VERIFY_START, VERIFY_END, baseDto.exampleImages()
+            );
+
+            assertThatThrownBy(() -> validator.validate(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.CHALLENGE_DURATION_TOO_SHORT.getMessage());
+        }
+
+        @Test
+        @DisplayName("인증 종료 시간이 시작 시간보다 빠르면 예외 발생")
+        void validate_withInvalidVerificationTime_shouldThrow() {
+            GroupChallengeCreateRequestDto dto = new GroupChallengeCreateRequestDto(
+                    baseDto.title(), baseDto.description(), baseDto.category(),
+                    baseDto.maxParticipantCount(), baseDto.thumbnailImageUrl(),
+                    START, END, VERIFY_END, VERIFY_START, baseDto.exampleImages()
+            );
+
+            assertThatThrownBy(() -> validator.validate(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.INVALID_VERIFICATION_TIME.getMessage());
+        }
+
+        @Test
+        @DisplayName("인증 시간 차이가 10분 미만이면 예외 발생")
+        void validate_withShortVerificationDuration_shouldThrow() {
+            LocalTime shortEnd = VERIFY_START.plusMinutes(5);
+            GroupChallengeCreateRequestDto dto = new GroupChallengeCreateRequestDto(
+                    baseDto.title(), baseDto.description(), baseDto.category(),
+                    baseDto.maxParticipantCount(), baseDto.thumbnailImageUrl(),
+                    START, END, VERIFY_START, shortEnd, baseDto.exampleImages()
+            );
+
+            assertThatThrownBy(() -> validator.validate(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.VERIFICATION_DURATION_TOO_SHORT.getMessage());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 카테고리이면 예외 발생")
+        void validate_withInvalidCategory_shouldThrow() {
+            given(categoryRepository.findByName("INVALID_CATEGORY")).willReturn(Optional.empty());
+
+            GroupChallengeCreateRequestDto dto = new GroupChallengeCreateRequestDto(
+                    baseDto.title(), baseDto.description(), "INVALID_CATEGORY",
+                    baseDto.maxParticipantCount(), baseDto.thumbnailImageUrl(),
+                    START, END, VERIFY_START, VERIFY_END, baseDto.exampleImages()
+            );
+
+            assertThatThrownBy(() -> validator.validate(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.CHALLENGE_CATEGORY_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스 - 예시 이미지")
+    class ImageValidationFailure {
+
+        @Test
+        @DisplayName("예시 이미지가 없으면 예외 발생")
+        void validate_withEmptyImages_shouldThrow() {
+            GroupChallengeCreateRequestDto dto = new GroupChallengeCreateRequestDto(
+                    baseDto.title(), baseDto.description(), baseDto.category(),
+                    baseDto.maxParticipantCount(), baseDto.thumbnailImageUrl(),
+                    START, END, VERIFY_START, VERIFY_END, List.of()
+            );
+
+            assertThatThrownBy(() -> validator.validate(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_REQUIRES_SUCCESS_IMAGE.getMessage());
+        }
+
+        @Test
+        @DisplayName("성공 이미지가 하나도 없으면 예외 발생")
+        void validate_withNoSuccessImage_shouldThrow() {
+            GroupChallengeCreateRequestDto dto = new GroupChallengeCreateRequestDto(
+                    baseDto.title(), baseDto.description(), baseDto.category(),
+                    baseDto.maxParticipantCount(), baseDto.thumbnailImageUrl(),
+                    START, END, VERIFY_START, VERIFY_END,
+                    List.of(new ExampleImageRequestDto("https://dummy.image/img.png", ExampleImageType.FAILURE, "실패 예시", 1))
+            );
+
+            assertThatThrownBy(() -> validator.validate(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_REQUIRES_SUCCESS_IMAGE.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스 - 업데이트 시 성공 이미지 없음")
+    class UpdateImageValidationFailure {
+
+        @Test
+        @DisplayName("신규 성공 이미지 없고 기존 유지 이미지도 없으면 예외 발생")
+        void validateUpdate_withNoSuccessImage_shouldThrow() {
+            GroupChallengeUpdateRequestDto dto = new GroupChallengeUpdateRequestDto(
+                    "제로웨이스트 챌린지",
+                    "설명",
+                    "ZERO_WASTE",
+                    100,
+                    "https://dummy.image/thumb.png",
+                    START,
+                    END,
+                    VERIFY_START,
+                    VERIFY_END,
+                    new GroupChallengeUpdateRequestDto.ExampleImages(
+                            List.of(), // keep 없음
+                            List.of(new GroupChallengeUpdateRequestDto.ExampleImages.NewImage(
+                                    "https://dummy.image/fail.png",
+                                    ExampleImageType.FAILURE,
+                                    "실패 예시",
+                                    1
+                            )),
+                            List.of() // deleted 없음
+                    )
+            );
+
+            assertThatThrownBy(() -> validator.validate(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ChallengeErrorCode.GROUP_CHALLENGE_REQUIRES_SUCCESS_IMAGE.getMessage());
+        }
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/domain/service/GroupChallengeRemainingDayCalculatorTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/domain/service/GroupChallengeRemainingDayCalculatorTest.java
@@ -1,0 +1,47 @@
+package ktb.leafresh.backend.domain.challenge.group.domain.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
+
+class GroupChallengeRemainingDayCalculatorTest {
+
+    @Test
+    @DisplayName("시작일이 오늘과 같거나 이전이면 남은 일수는 0이다")
+    void calculate_withTodayOrPastDate_returnsZero() {
+        // given
+        LocalDate today = LocalDate.of(2025, 7, 5);
+
+        try (MockedStatic<LocalDate> mocked = mockStatic(LocalDate.class, CALLS_REAL_METHODS)) {
+            mocked.when(LocalDate::now).thenReturn(today);
+
+            // when & then
+            assertThat(GroupChallengeRemainingDayCalculator.calculate(today)).isZero();
+            assertThat(GroupChallengeRemainingDayCalculator.calculate(today.minusDays(1))).isZero();
+        }
+    }
+
+    @Test
+    @DisplayName("시작일이 오늘 이후라면 남은 일수를 반환한다")
+    void calculate_withFutureDate_returnsDaysBetweenTodayAndStartDate() {
+        // given
+        LocalDate today = LocalDate.of(2025, 7, 5);
+        LocalDate futureDate = today.plusDays(3);
+
+        try (MockedStatic<LocalDate> mocked = mockStatic(LocalDate.class, CALLS_REAL_METHODS)) {
+            mocked.when(LocalDate::now).thenReturn(today);
+
+            // when
+            int remainingDays = GroupChallengeRemainingDayCalculator.calculate(futureDate);
+
+            // then
+            assertThat(remainingDays).isEqualTo(3);
+        }
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/domain/service/GroupChallengeVerificationHistoryCalculatorTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/domain/service/GroupChallengeVerificationHistoryCalculatorTest.java
@@ -1,0 +1,134 @@
+package ktb.leafresh.backend.domain.challenge.group.domain.service;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.challenge.group.presentation.dto.response.GroupChallengeVerificationHistoryResponseDto;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
+import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeParticipantRecordFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeVerificationFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.*;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("GroupChallengeVerificationHistoryCalculator 단위 테스트")
+class GroupChallengeVerificationHistoryCalculatorTest {
+
+    private GroupChallengeVerificationHistoryCalculator calculator;
+
+    @BeforeEach
+    void setUp() {
+        calculator = new GroupChallengeVerificationHistoryCalculator();
+    }
+
+    @Test
+    @DisplayName("인증 기록이 있는 경우 성공/실패/todayStatus 포함 결과 반환")
+    void calculate_withVerifications_returnsResponseDto() {
+        // given
+        Member member = MemberFixture.of();
+        GroupChallengeCategory category = GroupChallengeCategoryFixture.defaultCategory();
+        GroupChallenge challenge = GroupChallengeFixture.of(member, category);
+        GroupChallengeParticipantRecord participantRecord = GroupChallengeParticipantRecordFixture.of(challenge, member);
+
+        GroupChallengeVerification successVerification = GroupChallengeVerificationFixture.of(participantRecord, ChallengeStatus.SUCCESS);
+        GroupChallengeVerification failureVerification = GroupChallengeVerificationFixture.of(participantRecord, ChallengeStatus.FAILURE);
+        List<GroupChallengeVerification> verifications = List.of(successVerification, failureVerification);
+
+        // 오늘 날짜 기준 설정
+        LocalDate todayKST = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDateTime startDate = todayKST.atStartOfDay(); // 자정
+        LocalDateTime endDate = todayKST.plusDays(6).atTime(23, 59);
+
+        ReflectionTestUtils.setField(challenge, "startDate", startDate);
+        ReflectionTestUtils.setField(challenge, "endDate", endDate);
+
+        LocalDateTime baseTime = todayKST.atTime(12, 0)
+                .atZone(ZoneId.of("Asia/Seoul"))
+                .withZoneSameInstant(ZoneOffset.UTC)
+                .toLocalDateTime();
+        ReflectionTestUtils.setField(successVerification, "createdAt", baseTime.plusMinutes(1));
+        ReflectionTestUtils.setField(failureVerification, "createdAt", baseTime);
+
+        // when
+        GroupChallengeVerificationHistoryResponseDto result = calculator.calculate(challenge, participantRecord, verifications);
+
+        // then
+        assertThat(result.id()).isEqualTo(challenge.getId());
+        assertThat(result.title()).isEqualTo(challenge.getTitle());
+
+        GroupChallengeVerificationHistoryResponseDto.AchievementDto achievement = result.achievement();
+        assertThat(achievement.success()).isEqualTo(1);
+        assertThat(achievement.failure()).isEqualTo(1);
+        assertThat(achievement.remaining()).isEqualTo(8);
+
+        assertThat(result.verifications()).hasSize(2);
+        assertThat(result.verifications()).extracting("day").containsOnly(1);
+        assertThat(result.verifications()).extracting("status")
+                .containsExactly(ChallengeStatus.SUCCESS, ChallengeStatus.FAILURE);
+
+        assertThat(result.todayStatus()).isEqualTo("DONE");
+    }
+
+    @Test
+    @DisplayName("인증 기록이 없을 경우 todayStatus는 NOT_SUBMITTED이고 remaining 계산됨")
+    void calculate_withoutVerifications_returnsEmptyListAndNotSubmitted() {
+        // given
+        Member member = MemberFixture.of();
+        GroupChallengeCategory category = GroupChallengeCategoryFixture.defaultCategory();
+        GroupChallenge challenge = GroupChallengeFixture.of(member, category);
+        GroupChallengeParticipantRecord participantRecord = GroupChallengeParticipantRecordFixture.of(challenge, member);
+
+        List<GroupChallengeVerification> verifications = List.of();
+
+        // when
+        GroupChallengeVerificationHistoryResponseDto result = calculator.calculate(challenge, participantRecord, verifications);
+
+        // then
+        assertThat(result.verifications()).isEmpty();
+        assertThat(result.todayStatus()).isEqualTo("NOT_SUBMITTED");
+
+        GroupChallengeVerificationHistoryResponseDto.AchievementDto achievement = result.achievement();
+        assertThat(achievement.success()).isZero();
+        assertThat(achievement.failure()).isZero();
+        assertThat(achievement.remaining()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("오늘 인증 상태가 PENDING_APPROVAL인 경우 todayStatus는 PENDING_APPROVAL")
+    void calculate_todayVerificationPendingApproval_returnsPending() {
+        // given
+        Member member = MemberFixture.of();
+        GroupChallengeCategory category = GroupChallengeCategoryFixture.defaultCategory();
+        GroupChallenge challenge = GroupChallengeFixture.of(member, category);
+        GroupChallengeParticipantRecord participantRecord = GroupChallengeParticipantRecordFixture.of(challenge, member);
+
+        GroupChallengeVerification pendingVerification = GroupChallengeVerificationFixture.of(participantRecord, ChallengeStatus.PENDING_APPROVAL);
+
+        // createdAt을 오늘 날짜로 맞춤 (KST 기준 12:00)
+        LocalDate todayKST = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDateTime createdAtUTC = todayKST.atTime(12, 0)
+                .atZone(ZoneId.of("Asia/Seoul"))
+                .withZoneSameInstant(ZoneOffset.UTC)
+                .toLocalDateTime();
+        ReflectionTestUtils.setField(pendingVerification, "createdAt", createdAtUTC);
+
+        List<GroupChallengeVerification> verifications = List.of(pendingVerification);
+
+        // when
+        GroupChallengeVerificationHistoryResponseDto result = calculator.calculate(challenge, participantRecord, verifications);
+
+        // then
+        assertThat(result.todayStatus()).isEqualTo("PENDING_APPROVAL");
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/domain/support/policy/GroupChallengePromotionPolicyTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/domain/support/policy/GroupChallengePromotionPolicyTest.java
@@ -1,0 +1,80 @@
+package ktb.leafresh.backend.domain.challenge.group.domain.support.policy;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeParticipantRecordRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ParticipantStatus;
+import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeParticipantRecordFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengePromotionPolicy 테스트")
+class GroupChallengePromotionPolicyTest {
+
+    @Mock
+    private GroupChallengeParticipantRecordRepository participantRepository;
+
+    @InjectMocks
+    private GroupChallengePromotionPolicy promotionPolicy;
+
+    @Test
+    @DisplayName("대기자 존재 시 첫 대기자를 ACTIVE로 승격하고 인원 수 증가")
+    void promoteNextWaitingParticipant_withWaiting_promotesAndIncreasesCount() {
+        // given
+        Member member = MemberFixture.of();
+        GroupChallengeCategory category = GroupChallengeCategoryFixture.defaultCategory();
+        GroupChallenge challenge = GroupChallengeFixture.of(member, category);
+        int originalCount = challenge.getCurrentParticipantCount();
+
+        GroupChallengeParticipantRecord waitingParticipant =
+                GroupChallengeParticipantRecordFixture.of(challenge, member, ParticipantStatus.WAITING);
+        ReflectionTestUtils.setField(waitingParticipant, "groupChallenge", challenge);
+
+        given(participantRepository.findFirstByGroupChallengeIdAndStatusOrderByCreatedAtAsc(
+                challenge.getId(), ParticipantStatus.WAITING
+        )).willReturn(Optional.of(waitingParticipant));
+
+        // when
+        promotionPolicy.promoteNextWaitingParticipant(challenge.getId());
+
+        // then
+        assertThat(waitingParticipant.getStatus()).isEqualTo(ParticipantStatus.ACTIVE);
+        assertThat(challenge.getCurrentParticipantCount()).isEqualTo(originalCount + 1);
+
+        then(participantRepository).should(times(1))
+                .findFirstByGroupChallengeIdAndStatusOrderByCreatedAtAsc(challenge.getId(), ParticipantStatus.WAITING);
+    }
+
+    @Test
+    @DisplayName("대기자가 없으면 아무 동작도 하지 않음")
+    void promoteNextWaitingParticipant_withoutWaiting_doesNothing() {
+        // given
+        Long challengeId = 1L;
+        given(participantRepository.findFirstByGroupChallengeIdAndStatusOrderByCreatedAtAsc(
+                challengeId, ParticipantStatus.WAITING
+        )).willReturn(Optional.empty());
+
+        // when
+        promotionPolicy.promoteNextWaitingParticipant(challengeId);
+
+        // then
+        then(participantRepository).should(times(1))
+                .findFirstByGroupChallengeIdAndStatusOrderByCreatedAtAsc(challengeId, ParticipantStatus.WAITING);
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/domain/challenge/group/domain/support/validator/GroupChallengeParticipationValidatorTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/challenge/group/domain/support/validator/GroupChallengeParticipationValidatorTest.java
@@ -1,0 +1,115 @@
+package ktb.leafresh.backend.domain.challenge.group.domain.support.validator;
+
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeCategory;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.challenge.group.infrastructure.repository.GroupChallengeParticipantRecordRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.global.common.entity.enums.ParticipantStatus;
+import ktb.leafresh.backend.global.exception.ChallengeErrorCode;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.support.fixture.GroupChallengeCategoryFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeFixture;
+import ktb.leafresh.backend.support.fixture.GroupChallengeParticipantRecordFixture;
+import ktb.leafresh.backend.support.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupChallengeParticipationValidator 테스트")
+class GroupChallengeParticipationValidatorTest {
+
+    @Mock
+    private GroupChallengeParticipantRecordRepository participantRepository;
+
+    @InjectMocks
+    private GroupChallengeParticipationValidator validator;
+
+    @Test
+    @DisplayName("이미 참여한 경우 예외 발생")
+    void validateNotAlreadyParticipated_alreadyExists_throwsException() {
+        // given
+        Long challengeId = 1L;
+        Long memberId = 2L;
+
+        given(participantRepository.existsByGroupChallengeIdAndMemberIdAndDeletedAtIsNull(challengeId, memberId))
+                .willReturn(true);
+
+        // expect
+        assertThatThrownBy(() ->
+                validator.validateNotAlreadyParticipated(challengeId, memberId)
+        ).isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.CHALLENGE_ALREADY_PARTICIPATED.getMessage());
+
+        then(participantRepository).should().existsByGroupChallengeIdAndMemberIdAndDeletedAtIsNull(challengeId, memberId);
+    }
+
+    @Test
+    @DisplayName("참여 기록이 없으면 예외 없이 통과")
+    void validateNotAlreadyParticipated_notExists_passes() {
+        // given
+        Long challengeId = 1L;
+        Long memberId = 2L;
+
+        given(participantRepository.existsByGroupChallengeIdAndMemberIdAndDeletedAtIsNull(challengeId, memberId))
+                .willReturn(false);
+
+        // expect
+        assertThatCode(() ->
+                validator.validateNotAlreadyParticipated(challengeId, memberId)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("DROPPED 상태일 경우 예외 발생")
+    void validateDroppable_dropped_throwsException() {
+        validateDroppableWithInvalidStatus(ParticipantStatus.DROPPED);
+    }
+
+    @Test
+    @DisplayName("FINISHED 상태일 경우 예외 발생")
+    void validateDroppable_finished_throwsException() {
+        validateDroppableWithInvalidStatus(ParticipantStatus.FINISHED);
+    }
+
+    @Test
+    @DisplayName("BANNED 상태일 경우 예외 발생")
+    void validateDroppable_banned_throwsException() {
+        validateDroppableWithInvalidStatus(ParticipantStatus.BANNED);
+    }
+
+    @Test
+    @DisplayName("ACTIVE 상태일 경우 예외 발생하지 않음")
+    void validateDroppable_active_passes() {
+        // given
+        Member member = MemberFixture.of();
+        GroupChallengeCategory category = GroupChallengeCategoryFixture.defaultCategory();
+        GroupChallenge challenge = GroupChallengeFixture.of(member, category);
+        GroupChallengeParticipantRecord record = GroupChallengeParticipantRecordFixture.of(challenge, member, ParticipantStatus.ACTIVE);
+
+        // expect
+        assertThatCode(() -> validator.validateDroppable(record))
+                .doesNotThrowAnyException();
+    }
+
+    private void validateDroppableWithInvalidStatus(ParticipantStatus status) {
+        // given
+        Member member = MemberFixture.of();
+        GroupChallengeCategory category = GroupChallengeCategoryFixture.defaultCategory();
+        GroupChallenge challenge = GroupChallengeFixture.of(member, category);
+        GroupChallengeParticipantRecord record = GroupChallengeParticipantRecordFixture.of(challenge, member, status);
+
+        // expect
+        assertThatThrownBy(() -> validator.validateDroppable(record))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ChallengeErrorCode.CHALLENGE_ALREADY_DROPPED.getMessage());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/global/initializer/BadgeInitializerTest.java
+++ b/src/test/java/ktb/leafresh/backend/global/initializer/BadgeInitializerTest.java
@@ -1,0 +1,61 @@
+package ktb.leafresh.backend.global.initializer;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Badge;
+import ktb.leafresh.backend.domain.member.domain.entity.enums.BadgeType;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.BadgeRepository;
+import ktb.leafresh.backend.support.fixture.BadgeFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BadgeInitializer 테스트")
+class BadgeInitializerTest {
+
+    @Mock
+    private BadgeRepository badgeRepository;
+
+    @InjectMocks
+    private BadgeInitializer badgeInitializer;
+
+    @Test
+    @DisplayName("뱃지가 존재하지 않으면 저장된다")
+    void run_whenBadgeNotExists_thenSavesBadge() throws Exception {
+        // given
+        String badgeName = "제로 히어로";
+        given(badgeRepository.findByName(badgeName)).willReturn(Optional.empty());
+
+        // when
+        badgeInitializer.run();
+
+        // then
+        then(badgeRepository).should(atLeastOnce()).save(argThat(badge ->
+                badge.getName().equals(badgeName)
+                        && badge.getType() == BadgeType.GROUP
+                        && badge.getCondition() != null
+                        && badge.getImageUrl() != null
+        ));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 뱃지는 저장되지 않는다")
+    void run_whenBadgeExists_thenDoesNotSave() throws Exception {
+        // given
+        String badgeName = "제로 히어로";
+        Badge existingBadge = BadgeFixture.of(badgeName, BadgeType.GROUP);
+        given(badgeRepository.findByName(badgeName)).willReturn(Optional.of(existingBadge));
+
+        // when
+        badgeInitializer.run();
+
+        // then
+        then(badgeRepository).should(never()).save(existingBadge);
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/global/initializer/PersonalChallengeInitializerTest.java
+++ b/src/test/java/ktb/leafresh/backend/global/initializer/PersonalChallengeInitializerTest.java
@@ -1,0 +1,69 @@
+package ktb.leafresh.backend.global.initializer;
+
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallenge;
+import ktb.leafresh.backend.domain.challenge.personal.domain.entity.PersonalChallengeExampleImage;
+import ktb.leafresh.backend.domain.challenge.personal.infrastructure.repository.PersonalChallengeExampleImageRepository;
+import ktb.leafresh.backend.domain.challenge.personal.infrastructure.repository.PersonalChallengeRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ExampleImageType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PersonalChallengeInitializer 테스트")
+class PersonalChallengeInitializerTest {
+
+    @Mock
+    private PersonalChallengeRepository challengeRepository;
+
+    @Mock
+    private PersonalChallengeExampleImageRepository imageRepository;
+
+    @InjectMocks
+    private PersonalChallengeInitializer initializer;
+
+    @Test
+    @DisplayName("이미 개인 챌린지가 존재하면 초기화되지 않는다")
+    void run_whenPersonalChallengesExist_thenDoNothing() throws Exception {
+        // given
+        given(challengeRepository.count()).willReturn(5L);
+
+        // when
+        initializer.run();
+
+        // then
+        then(challengeRepository).should(never()).save(any());
+        then(imageRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("개인 챌린지가 존재하지 않으면 저장된다")
+    void run_whenNoChallenges_thenSavesAll() throws Exception {
+        // given
+        given(challengeRepository.count()).willReturn(0L);
+        given(challengeRepository.save(any(PersonalChallenge.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        initializer.run();
+
+        // then
+        then(imageRepository).should(atLeastOnce()).saveAll(argThat(images -> {
+            List<PersonalChallengeExampleImage> list = StreamSupport
+                    .stream(images.spliterator(), false)
+                    .collect(Collectors.toList());
+
+            return list.size() == 2 &&
+                    list.get(0).getType() == ExampleImageType.SUCCESS &&
+                    list.get(1).getType() == ExampleImageType.FAILURE;
+        }));
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/global/initializer/TreeLevelInitializerTest.java
+++ b/src/test/java/ktb/leafresh/backend/global/initializer/TreeLevelInitializerTest.java
@@ -1,0 +1,86 @@
+package ktb.leafresh.backend.global.initializer;
+
+import ktb.leafresh.backend.domain.member.domain.entity.TreeLevel;
+import ktb.leafresh.backend.domain.member.domain.entity.enums.TreeLevelName;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.TreeLevelRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TreeLevelInitializer 테스트")
+class TreeLevelInitializerTest {
+
+    @Mock
+    private TreeLevelRepository treeLevelRepository;
+
+    @InjectMocks
+    private TreeLevelInitializer initializer;
+
+    @Test
+    @DisplayName("모든 TreeLevel이 저장되어 있지 않으면 저장 로직이 실행된다")
+    void run_whenAllLevelsNotExist_thenSaveEach() {
+        // given
+        for (TreeLevelName name : TreeLevelName.values()) {
+            given(treeLevelRepository.findByName(name)).willReturn(Optional.empty());
+        }
+
+        // when
+        initializer.run();
+
+        // then
+        for (TreeLevelName name : TreeLevelName.values()) {
+            then(treeLevelRepository).should().save(
+                    argThat(treeLevel ->
+                            treeLevel.getName() == name &&
+                                    treeLevel.getMinLeafPoint() >= 0 &&
+                                    treeLevel.getImageUrl().contains(name.name()) &&
+                                    treeLevel.getDescription().contains("단계")
+                    )
+            );
+        }
+    }
+
+    @Test
+    @DisplayName("일부 TreeLevel만 저장되어 있는 경우 나머지만 저장된다")
+    void run_whenSomeLevelsExist_thenSaveMissingOnly() {
+        // given
+        given(treeLevelRepository.findByName(TreeLevelName.SPROUT)).willReturn(Optional.of(mock(TreeLevel.class)));
+        given(treeLevelRepository.findByName(TreeLevelName.YOUNG)).willReturn(Optional.empty());
+        given(treeLevelRepository.findByName(TreeLevelName.SMALL_TREE)).willReturn(Optional.empty());
+        given(treeLevelRepository.findByName(TreeLevelName.TREE)).willReturn(Optional.of(mock(TreeLevel.class)));
+        given(treeLevelRepository.findByName(TreeLevelName.BIG_TREE)).willReturn(Optional.empty());
+
+        // when
+        initializer.run();
+
+        // then
+        then(treeLevelRepository).should(never()).save(argThat(treeLevel -> treeLevel.getName() == TreeLevelName.SPROUT));
+        then(treeLevelRepository).should(never()).save(argThat(treeLevel -> treeLevel.getName() == TreeLevelName.TREE));
+
+        then(treeLevelRepository).should().save(argThat(treeLevel -> treeLevel.getName() == TreeLevelName.YOUNG));
+        then(treeLevelRepository).should().save(argThat(treeLevel -> treeLevel.getName() == TreeLevelName.SMALL_TREE));
+        then(treeLevelRepository).should().save(argThat(treeLevel -> treeLevel.getName() == TreeLevelName.BIG_TREE));
+    }
+
+    @Test
+    @DisplayName("모든 TreeLevel이 이미 저장되어 있는 경우 저장하지 않는다")
+    void run_whenAllLevelsExist_thenDoNothing() {
+        // given
+        for (TreeLevelName name : TreeLevelName.values()) {
+            given(treeLevelRepository.findByName(name)).willReturn(Optional.of(mock(TreeLevel.class)));
+        }
+
+        // when
+        initializer.run();
+
+        // then
+        then(treeLevelRepository).should(never()).save(any());
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/global/initializer/VerificationStatCacheInitializerTest.java
+++ b/src/test/java/ktb/leafresh/backend/global/initializer/VerificationStatCacheInitializerTest.java
@@ -1,0 +1,135 @@
+package ktb.leafresh.backend.global.initializer;
+
+import ktb.leafresh.backend.domain.verification.infrastructure.cache.VerificationStatCacheService;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.CommentRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.LikeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VerificationStatCacheInitializer 테스트")
+class VerificationStatCacheInitializerTest {
+
+    @Mock
+    private GroupChallengeVerificationRepository verificationRepository;
+
+    @Mock
+    private LikeRepository likeRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private VerificationStatCacheService verificationStatCacheService;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @InjectMocks
+    private VerificationStatCacheInitializer initializer;
+
+    @Test
+    @DisplayName("Redis에 캐시가 없는 경우 - 인증 ID별 캐시 초기화가 수행된다")
+    void initializeStats_whenNoRedisKeys_thenInitialize() {
+        // given
+        Object[] viewRow = new Object[]{1L, 10};
+        Object[] likeRow = new Object[]{1L, 5};
+        Object[] commentRow = new Object[]{1L, 2};
+
+        given(verificationRepository.findAllViewCountByVerificationId())
+                .willReturn(List.<Object[]>of(viewRow));
+
+        given(likeRepository.findAllLikeCountByVerificationId())
+                .willReturn(List.<Object[]>of(likeRow));
+
+        given(commentRepository.findAllCommentCountByVerificationId())
+                .willReturn(List.<Object[]>of(commentRow));
+
+        given(stringRedisTemplate.hasKey("verification:stat:1")).willReturn(false);
+
+        // when
+        initializer.initializeVerificationStats();
+
+        // then
+        then(verificationStatCacheService)
+                .should().initializeVerificationStats(1L, 10, 5, 2);
+    }
+
+    @Test
+    @DisplayName("Redis에 캐시가 이미 존재하는 경우 - 초기화를 수행하지 않는다")
+    void initializeStats_whenRedisKeyExists_thenSkipInitialization() {
+        // given
+        Object[] viewRow = new Object[]{1L, 10};
+
+        given(verificationRepository.findAllViewCountByVerificationId())
+                .willReturn(List.<Object[]>of(viewRow));
+        given(likeRepository.findAllLikeCountByVerificationId()).willReturn(List.of());
+        given(commentRepository.findAllCommentCountByVerificationId()).willReturn(List.of());
+
+        given(stringRedisTemplate.hasKey("verification:stat:1")).willReturn(true);
+
+        // when
+        initializer.initializeVerificationStats();
+
+        // then
+        then(verificationStatCacheService)
+                .should(never()).initializeVerificationStats(anyLong(), anyInt(), anyInt(), anyInt());
+    }
+
+    @Test
+    @DisplayName("뷰/좋아요/댓글이 일부 없는 경우에도 기본값 0으로 캐시가 초기화된다")
+    void initializeStats_withMissingMetrics_thenUseDefaultValues() {
+        // given
+        Object[] viewRow = new Object[]{1L, null}; // null 값 존재
+        // like, comment는 아예 없음
+
+        given(verificationRepository.findAllViewCountByVerificationId())
+                .willReturn(List.<Object[]>of(viewRow));
+        given(likeRepository.findAllLikeCountByVerificationId()).willReturn(List.of());
+        given(commentRepository.findAllCommentCountByVerificationId()).willReturn(List.of());
+
+        given(stringRedisTemplate.hasKey("verification:stat:1")).willReturn(false);
+
+        // when
+        initializer.initializeVerificationStats();
+
+        // then
+        then(verificationStatCacheService)
+                .should().initializeVerificationStats(1L, 0, 0, 0); // null → 0 처리 검증
+    }
+
+    @Test
+    @DisplayName("캐시 초기화 도중 예외가 발생해도 다른 ID의 초기화는 계속 진행된다")
+    void initializeStats_withException_thenContinueOthers() {
+        // given
+        Object[] viewRow1 = new Object[]{1L, 10};
+        Object[] viewRow2 = new Object[]{2L, 20};
+
+        given(verificationRepository.findAllViewCountByVerificationId()).willReturn(List.of(viewRow1, viewRow2));
+        given(likeRepository.findAllLikeCountByVerificationId()).willReturn(List.of());
+        given(commentRepository.findAllCommentCountByVerificationId()).willReturn(List.of());
+
+        given(stringRedisTemplate.hasKey("verification:stat:1")).willReturn(false);
+        given(stringRedisTemplate.hasKey("verification:stat:2")).willReturn(false);
+
+        willThrow(new RuntimeException("DB Error")).given(verificationStatCacheService)
+                .initializeVerificationStats(eq(1L), anyInt(), anyInt(), anyInt());
+
+        // when
+        initializer.initializeVerificationStats();
+
+        // then
+        then(verificationStatCacheService)
+                .should().initializeVerificationStats(2L, 20, 0, 0);
+    }
+}

--- a/src/test/java/ktb/leafresh/backend/support/fixture/GroupChallengeCategoryFixture.java
+++ b/src/test/java/ktb/leafresh/backend/support/fixture/GroupChallengeCategoryFixture.java
@@ -19,7 +19,6 @@ public class GroupChallengeCategoryFixture {
      */
     public static GroupChallengeCategory of(GroupChallengeCategoryName categoryName) {
         return GroupChallengeCategory.builder()
-                // ID는 설정하지 않음 (Best Practice #2)
                 .groupChallenges(Collections.emptyList())
                 .name(categoryName.name())
                 .imageUrl(GroupChallengeCategoryName.getImageUrl(categoryName.name()))
@@ -33,7 +32,6 @@ public class GroupChallengeCategoryFixture {
      */
     public static GroupChallengeCategory of(String name) {
         return GroupChallengeCategory.builder()
-                // ID는 설정하지 않음
                 .groupChallenges(Collections.emptyList())
                 .name(name)
                 .imageUrl("https://dummy.image/category/" + name.toLowerCase() + ".png")


### PR DESCRIPTION
## 작업 내용
- 단체 챌린지 도메인 및 서비스 레이어 단위 테스트 추가
- 테스트 전용 픽스처 클래스 및 유틸 추가
- 이니셜라이저(BadgeInitializer, PersonalChallengeInitializer 등) 테스트 코드 작성

## 주요 변경 사항
- GroupChallenge 도메인 및 애플리케이션 서비스에 대한 단위 테스트 커버리지 강화
- GroupChallengeParticipantManagerTest 충돌 해결 및 상태 복원 완료

## 커버리지 개선 대상
- 단체 챌린지 생성/수정/삭제/조회 흐름
- 참여자 검증 및 정책 적용 로직
- 각종 이니셜라이저 동작 확인

## 기타
- 향후 테스트 커버리지 보고서(JaCoCo 등) 기반으로 미커버리지 영역 보강 예정
