### PR TITLE
feat: GCP Pub/Sub 기반 피드백 전송 및 DLQ 로그 저장 기능 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackCommandService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackCommandService.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import ktb.leafresh.backend.domain.feedback.application.assembler.FeedbackDtoAssembler;
-import ktb.leafresh.backend.domain.feedback.infrastructure.client.FeedbackCreationClient;
 import ktb.leafresh.backend.domain.feedback.infrastructure.dto.request.AiFeedbackCreationRequestDto;
+import ktb.leafresh.backend.domain.feedback.infrastructure.publisher.GcpAiFeedbackPubSubPublisher;
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
 import ktb.leafresh.backend.global.exception.CustomException;
@@ -25,12 +25,13 @@ public class FeedbackCommandService {
 
     private final MemberRepository memberRepository;
     private final FeedbackDtoAssembler dtoAssembler;
-    private final FeedbackCreationClient feedbackCreationClient;
+//    private final FeedbackCreationClient feedbackCreationClient;
+    private final GcpAiFeedbackPubSubPublisher feedbackPublisher;
     private final ObjectMapper objectMapper;
 
     public void handleFeedbackCreationRequest(Long memberId) {
         log.info("[피드백 생성 요청 시작] memberId={}", memberId);
-        log.info("주입된 FeedbackCreationClient 구현체 = {}", feedbackCreationClient.getClass().getName());
+//        log.info("주입된 FeedbackCreationClient 구현체 = {}", feedbackCreationClient.getClass().getName());
 
         Member member = validateMember(memberId);
 
@@ -62,7 +63,8 @@ public class FeedbackCommandService {
 
             log.info("[AI 요청 전송 request body]\n{}", prettyJson);
 
-            feedbackCreationClient.requestWeeklyFeedback(requestDto);
+//            feedbackCreationClient.requestWeeklyFeedback(requestDto);
+            feedbackPublisher.publishAsyncWithRetry(requestDto);
             log.info("[피드백 요청 완료] memberId={}", memberId);
         } catch (JsonProcessingException e) {
             log.error("[JSON 변환 실패]", e);

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultQueryService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/application/service/FeedbackResultQueryService.java
@@ -22,26 +22,7 @@ public class FeedbackResultQueryService {
 
     private final MemberRepository memberRepository;
     private final FeedbackRepository feedbackRepository;
-//    private final FeedbackPollingExecutor feedbackPollingExecutor;
     private final RedisTemplate<String, Object> redisTemplate;
-
-//    public FeedbackResponseDto waitForFeedback(Long memberId) {
-//        Member member = memberRepository.findById(memberId)
-//                .orElseThrow(() -> new CustomException(GlobalErrorCode.UNAUTHORIZED));
-//
-//        if (!member.getActivated()) {
-//            throw new CustomException(GlobalErrorCode.ACCESS_DENIED);
-//        }
-//
-//        log.info("[피드백 롱폴링 시작] memberId={}", memberId);
-//
-//        try {
-//            return feedbackPollingExecutor.poll(() -> getLatestFeedback(member));
-//        } catch (Exception e) {
-//            log.error("[피드백 롱폴링 실패] memberId={}, error={}", memberId, e.getMessage(), e);
-//            throw new CustomException(FeedbackErrorCode.FEEDBACK_SERVER_ERROR);
-//        }
-//    }
 
     public FeedbackResponseDto getFeedbackResult(Long memberId) {
         Member member = memberRepository.findById(memberId)

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/domain/entity/FeedbackFailureLog.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/domain/entity/FeedbackFailureLog.java
@@ -1,0 +1,37 @@
+package ktb.leafresh.backend.domain.feedback.domain.entity;
+
+import jakarta.persistence.*;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "feedback_failure_logs")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class FeedbackFailureLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 실패 발생한 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    // 실패 사유
+    @Column(columnDefinition = "TEXT")
+    private String reason;
+
+    // 요청 본문 백업 (JSON)
+    @Column(name = "request_body", columnDefinition = "JSON")
+    private String requestBody;
+
+    // 발생 시각
+    @Column(name = "occurred_at", nullable = false)
+    private LocalDateTime occurredAt;
+}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/publisher/GcpAiFeedbackPubSubPublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/publisher/GcpAiFeedbackPubSubPublisher.java
@@ -1,0 +1,104 @@
+package ktb.leafresh.backend.domain.feedback.infrastructure.publisher;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import ktb.leafresh.backend.domain.feedback.domain.entity.FeedbackFailureLog;
+import ktb.leafresh.backend.domain.feedback.infrastructure.dto.request.AiFeedbackCreationRequestDto;
+import ktb.leafresh.backend.domain.feedback.infrastructure.repository.FeedbackFailureLogRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@Slf4j
+public class GcpAiFeedbackPubSubPublisher {
+
+    private final Publisher feedbackPublisher;
+    private final ObjectMapper objectMapper;
+    private final MemberRepository memberRepository;
+    private final FeedbackFailureLogRepository feedbackFailureLogRepository;
+
+    private static final int MAX_RETRY = 3;
+    private static final long INITIAL_BACKOFF_MS = 300;
+
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
+
+    public GcpAiFeedbackPubSubPublisher(
+            @Qualifier("feedbackPubSubPublisher") Publisher feedbackPublisher,
+            ObjectMapper objectMapper,
+            MemberRepository memberRepository,
+            FeedbackFailureLogRepository feedbackFailureLogRepository
+    ) {
+        this.feedbackPublisher = feedbackPublisher;
+        this.objectMapper = objectMapper;
+        this.memberRepository = memberRepository;
+        this.feedbackFailureLogRepository = feedbackFailureLogRepository;
+    }
+
+    public void publishAsyncWithRetry(AiFeedbackCreationRequestDto dto) {
+        try {
+            String json = objectMapper.writeValueAsString(dto);
+            sendWithRetry(json, 1);
+        } catch (JsonProcessingException e) {
+            log.error("[피드백 직렬화 실패]", e);
+            logFailure(dto, null, "직렬화 실패: " + e.getMessage());
+        }
+    }
+
+    private void sendWithRetry(String json, int attempt) {
+        PubsubMessage message = PubsubMessage.newBuilder()
+                .setData(ByteString.copyFromUtf8(json))
+                .build();
+
+        ApiFuture<String> future = feedbackPublisher.publish(message);
+
+        ApiFutures.addCallback(future, new ApiFutureCallback<>() {
+            @Override
+            public void onSuccess(String messageId) {
+                log.info("[피드백 발행 성공] attempt={}, messageId={}", attempt, messageId);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                log.warn("[피드백 발행 실패] attempt={}, error={}", attempt, t.getMessage());
+
+                if (attempt < MAX_RETRY) {
+                    long backoff = INITIAL_BACKOFF_MS * (1L << (attempt - 1));
+                    scheduler.schedule(() -> sendWithRetry(json, attempt + 1), backoff, TimeUnit.MILLISECONDS);
+                } else {
+                    log.error("[피드백 발행 최종 실패] json={}, error={}", json, t.getMessage());
+                }
+            }
+        }, MoreExecutors.directExecutor());
+    }
+
+    private void logFailure(AiFeedbackCreationRequestDto dto, String json, String reason) {
+        try {
+            Member member = memberRepository.findById(dto.memberId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+            feedbackFailureLogRepository.save(FeedbackFailureLog.builder()
+                    .member(member)
+                    .reason(reason)
+                    .requestBody(json != null ? json : "{}")
+                    .occurredAt(LocalDateTime.now())
+                    .build());
+        } catch (Exception e) {
+            log.warn("[FailureLog 저장 실패] {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/repository/FeedbackFailureLogRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/repository/FeedbackFailureLogRepository.java
@@ -1,0 +1,7 @@
+package ktb.leafresh.backend.domain.feedback.infrastructure.repository;
+
+import ktb.leafresh.backend.domain.feedback.domain.entity.FeedbackFailureLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedbackFailureLogRepository extends JpaRepository<FeedbackFailureLog, Long> {
+}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/subscriber/GcpAiFeedbackResultDlqSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/subscriber/GcpAiFeedbackResultDlqSubscriber.java
@@ -1,0 +1,70 @@
+package ktb.leafresh.backend.domain.feedback.infrastructure.subscriber;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.feedback.domain.entity.FeedbackFailureLog;
+import ktb.leafresh.backend.domain.feedback.infrastructure.repository.FeedbackFailureLogRepository;
+import ktb.leafresh.backend.domain.feedback.presentation.dto.request.FeedbackResultRequestDto;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GcpAiFeedbackResultDlqSubscriber {
+
+    private final Environment environment;
+    private final ObjectMapper objectMapper;
+    private final FeedbackFailureLogRepository failureLogRepository;
+    private final MemberRepository memberRepository;
+
+    @PostConstruct
+    public void subscribe() {
+        String projectId = environment.getProperty("gcp.project-id");
+        String subscriptionId = environment.getProperty("gcp.pubsub.subscriptions.feedback-result-dlq");
+
+        ProjectSubscriptionName dlqSubscription = ProjectSubscriptionName.of(projectId, subscriptionId);
+
+        MessageReceiver receiver = (message, consumer) -> {
+            String rawData = message.getData().toStringUtf8();
+            log.error("[피드백 DLQ 수신] messageId={}, data={}", message.getMessageId(), rawData);
+
+            try {
+                FeedbackResultRequestDto dto = objectMapper.readValue(rawData, FeedbackResultRequestDto.class);
+
+                Member member = memberRepository.findById(dto.memberId())
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+                failureLogRepository.save(FeedbackFailureLog.builder()
+                        .member(member)
+                        .reason("DLQ로 이동된 피드백 메시지입니다.")
+                        .requestBody(rawData)
+                        .occurredAt(LocalDateTime.now())
+                        .build());
+            } catch (Exception e) {
+                log.warn("[DLQ 메시지 파싱 실패] 최소 정보로 로그 저장. error={}", e.getMessage());
+
+                failureLogRepository.save(FeedbackFailureLog.builder()
+                        .reason("DLQ 메시지 파싱 실패: " + e.getMessage())
+                        .requestBody(rawData)
+                        .occurredAt(LocalDateTime.now())
+                        .build());
+            } finally {
+                consumer.ack(); // DLQ는 무조건 ack (루프 방지)
+            }
+        };
+
+        Subscriber subscriber = Subscriber.newBuilder(dlqSubscription, receiver).build();
+        subscriber.startAsync().awaitRunning();
+        log.info("[피드백 DLQ 구독 시작]");
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/subscriber/GcpAiFeedbackResultSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/subscriber/GcpAiFeedbackResultSubscriber.java
@@ -1,0 +1,93 @@
+package ktb.leafresh.backend.domain.feedback.infrastructure.subscriber;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.feedback.application.assembler.FeedbackDtoAssembler;
+import ktb.leafresh.backend.domain.feedback.application.service.FeedbackResultService;
+import ktb.leafresh.backend.domain.feedback.infrastructure.dto.request.AiFeedbackCreationRequestDto;
+import ktb.leafresh.backend.domain.feedback.infrastructure.publisher.GcpAiFeedbackPubSubPublisher;
+import ktb.leafresh.backend.domain.feedback.presentation.dto.request.FeedbackResultRequestDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.FeedbackErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GcpAiFeedbackResultSubscriber {
+
+    private final Environment environment;
+    private final ObjectMapper objectMapper;
+    private final FeedbackResultService feedbackResultService;
+    private final GcpAiFeedbackPubSubPublisher pubSubPublisher;
+    private final FeedbackDtoAssembler feedbackDtoAssembler;
+
+    @PostConstruct
+    public void subscribe() {
+        String projectId = environment.getProperty("gcp.project-id");
+        String subscriptionId = environment.getProperty("gcp.pubsub.subscriptions.feedback-result");
+
+        ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(projectId, subscriptionId);
+
+        MessageReceiver receiver = (message, consumer) -> {
+            String rawData = message.getData().toStringUtf8();
+            log.info("[피드백 결과 수신] messageId={}, data={}", message.getMessageId(), rawData);
+
+            try {
+                FeedbackResultRequestDto dto = objectMapper.readValue(rawData, FeedbackResultRequestDto.class);
+
+                if (dto.isSuccessResult()) {
+                    feedbackResultService.receiveFeedback(dto);
+
+                } else if (dto.isRecoverableHttpError()) {
+                    log.warn("[AI 처리 오류 응답] memberId={}, httpStatus={}", dto.memberId(), dto.content());
+
+                    // 지난 주 월~일 기준으로 피드백 요청 DTO 재생성
+                    LocalDate monday = getLastWeekStart();
+                    LocalDate sunday = monday.plusDays(6);
+                    AiFeedbackCreationRequestDto retryDto =
+                            feedbackDtoAssembler.assemble(dto.memberId(), monday, sunday);
+
+                    // 비동기 방식으로 재발행
+                    pubSubPublisher.publishAsyncWithRetry(retryDto);
+                    log.info("[AI 피드백 재발행 요청 전송] memberId={}, monday={}, sunday={}",
+                            dto.memberId(), monday, sunday);
+
+                } else {
+                    log.error("[알 수 없는 content 값] content={}, memberId={}", dto.content(), dto.memberId());
+                }
+
+                consumer.ack();
+
+            } catch (CustomException e) {
+                if (e.getErrorCode() == FeedbackErrorCode.ALREADY_FEEDBACK_EXISTS) {
+                    log.warn("[중복된 피드백 응답] memberId={}, 무시하고 ack", e.getMessage());
+                    consumer.ack(); // 무시하고 ack 처리 (테스트 용도로 AI 서버에서 id가 보낼 수 있기 때문)
+                } else {
+                    log.error("[피드백 결과 메시지 처리 실패 - CustomException] {}", e.getMessage(), e);
+                    consumer.nack(); // 다른 에러는 nack
+                }
+            } catch (Exception e) {
+                log.error("[피드백 결과 메시지 처리 실패 - 기타 Exception]", e);
+                consumer.nack();
+            }
+        };
+
+        Subscriber subscriber = Subscriber.newBuilder(subscriptionName, receiver).build();
+        subscriber.startAsync().awaitRunning();
+        log.info("[피드백 결과 메시지 구독 시작]");
+    }
+
+    private LocalDate getLastWeekStart() {
+        return LocalDate.now().with(DayOfWeek.MONDAY).minusWeeks(1);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/presentation/dto/request/FeedbackResultRequestDto.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/presentation/dto/request/FeedbackResultRequestDto.java
@@ -9,4 +9,25 @@ public record FeedbackResultRequestDto(
 
         @NotBlank(message = "feedback는 필수 항목입니다.")
         String content
-) {}
+) {
+        /**
+         * 응답이 피드백 메시지가 아닌 HTTP status code인 경우를 판단
+         */
+        public boolean isRecoverableHttpError() {
+                return content.matches("4\\d\\d|5\\d\\d");
+        }
+
+        /**
+         * content가 HTTP status code인 경우 정수로 변환 (예외 발생 가능성 있음 → 안전하게 parse 필요 시 사용)
+         */
+        public int resultAsHttpStatus() {
+                return Integer.parseInt(content);
+        }
+
+        /**
+         * 정상 피드백 응답인지 여부
+         */
+        public boolean isSuccessResult() {
+                return !isRecoverableHttpError();
+        }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/Member.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/domain/entity/Member.java
@@ -2,6 +2,7 @@ package ktb.leafresh.backend.domain.member.domain.entity;
 
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
 import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallengeParticipantRecord;
+import ktb.leafresh.backend.domain.feedback.domain.entity.FeedbackFailureLog;
 import ktb.leafresh.backend.domain.store.order.domain.entity.PurchaseFailureLog;
 import ktb.leafresh.backend.domain.store.order.domain.entity.PurchaseIdempotencyKey;
 import ktb.leafresh.backend.domain.verification.domain.entity.Comment;
@@ -85,6 +86,9 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<VerificationFailureLog> verificationFailureLogs = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<FeedbackFailureLog> feedbackFailureLogs = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)

--- a/src/main/java/ktb/leafresh/backend/global/config/PubSubPublisherConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/PubSubPublisherConfig.java
@@ -24,7 +24,7 @@ public class PubSubPublisherConfig {
         TopicName topicName = TopicName.of(projectId, topicId);
 
         return Publisher.newBuilder(topicName)
-                .setCredentialsProvider(() -> GoogleCredentials.getApplicationDefault())
+                .setCredentialsProvider(GoogleCredentials::getApplicationDefault)
                 .build();
     }
 
@@ -36,7 +36,19 @@ public class PubSubPublisherConfig {
         TopicName topicName = TopicName.of(projectId, topicId);
 
         return Publisher.newBuilder(topicName)
-                .setCredentialsProvider(() -> GoogleCredentials.getApplicationDefault())
+                .setCredentialsProvider(GoogleCredentials::getApplicationDefault)
+                .build();
+    }
+
+    @Bean(name = "feedbackPubSubPublisher")
+    public Publisher feedbackPubSubPublisher() throws IOException {
+        String projectId = environment.getProperty("gcp.project-id");
+        String topicId = environment.getProperty("gcp.pubsub.topics.feedback");
+
+        TopicName topicName = TopicName.of(projectId, topicId);
+
+        return Publisher.newBuilder(topicName)
+                .setCredentialsProvider(GoogleCredentials::getApplicationDefault)
                 .build();
     }
 }

--- a/src/main/resources/application-docker-local.yml
+++ b/src/main/resources/application-docker-local.yml
@@ -31,8 +31,11 @@ gcp:
     topics:
       order: ${GCP_PUBSUB_TOPIC_ORDER}
       image-verification: ${GCP_PUBSUB_TOPIC_IMAGE_VERIFICATION}
+      feedback: ${GCP_PUBSUB_TOPIC_FEEDBACK}
     subscriptions:
       order: ${GCP_PUBSUB_SUBSCRIPTION_ORDER}
       dlq: ${GCP_PUBSUB_SUBSCRIPTION_ORDER_DLQ}
       image-verification-result: ${GCP_PUBSUB_SUBSCRIPTION_IMAGE_VERIFICATION_RESULT}
       verification-dlq: ${GCP_PUBSUB_SUBSCRIPTION_IMAGE_VERIFICATION_RESULT_DLQ}
+      feedback-result: ${GCP_PUBSUB_SUBSCRIPTION_FEEDBACK_RESULT}
+      feedback-dlq: ${GCP_PUBSUB_SUBSCRIPTION_FEEDBACK_DLQ}


### PR DESCRIPTION
## 주요 변경 사항

### 1. GCP Pub/Sub 발행 Bean 등록
- `PubSubPublisherConfig`에 `feedbackPubSubPublisher` Bean 추가

### 2. 피드백 전송 로직 개선
- 기존 `feedbackCreationClient.requestWeeklyFeedback()` 호출을 제거하고, `GcpAiFeedbackPubSubPublisher.publishAsyncWithRetry()` 방식으로 비동기 전송하도록 변경

### 3. DLQ 메시지 처리 로직 도입
- `GcpAiFeedbackResultDlqSubscriber` 클래스 추가
- DLQ 메시지 수신 시 `FeedbackFailureLog` 테이블에 실패 내역 저장

### 4. 실패 로그 테이블 추가
- `FeedbackFailureLog` 엔티티 생성
  - 실패한 회원, 사유, request body, 발생 시간 저장
- `Member`와의 연관 관계 (`@ManyToOne`) 설정
- `Member` 엔티티에 `feedbackFailureLogs` 필드 추가 (`@OneToMany`)

### 5. 유틸성 메서드 추가
- `FeedbackResultRequestDto`에 status 판단을 위한 헬퍼 메서드 추가
  - `isRecoverableHttpError()`
  - `resultAsHttpStatus()`
  - `isSuccessResult()`

---

## 💡 추가 참고사항
- 피드백 결과 수신 후 실패한 메시지에 대해 월~일 기준으로 `AiFeedbackCreationRequestDto` 재생성
- 재전송은 `MAX_RETRY = 3`, `INITIAL_BACKOFF_MS = 300ms`의 backoff 로직으로 수행
- DLQ에서 회원 정보가 없는 경우에도 최소 정보로 로그 저장되도록 처리