### PR TITLE
fix: 일반 상품 구매 시 타임딜 가격 적용 버그 수정 및 재고 캐싱 로직 추가

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateService.java
@@ -61,6 +61,8 @@ public class ProductOrderCreateService {
         if (result == -1) throw new CustomException(ProductErrorCode.PRODUCT_NOT_FOUND);
         if (result == -2) throw new CustomException(ProductErrorCode.OUT_OF_STOCK);
 
+        productCacheLockFacade.updateSingleProductCache(product);
+
         // 5. 메시지 큐 발행
         PurchaseCommand command = new PurchaseCommand(memberId, productId, null, quantity, idempotencyKey, LocalDateTime.now());
         purchaseMessagePublisher.publish(command);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -40,13 +40,19 @@ gcp:
     location: classpath:${GCP_CREDENTIALS_LOCATION}
   storage:
     bucket: ${GCP_STORAGE_BUCKET}
+    lock-image-url: ${LOCK_IMAGE_URL}
   pubsub:
     topics:
       order: ${GCP_PUBSUB_TOPIC_ORDER}
       image-verification: ${GCP_PUBSUB_TOPIC_IMAGE_VERIFICATION}
+      feedback: ${GCP_PUBSUB_TOPIC_FEEDBACK}
     subscriptions:
       order: ${GCP_PUBSUB_SUBSCRIPTION_ORDER}
       dlq: ${GCP_PUBSUB_SUBSCRIPTION_ORDER_DLQ}
+      image-verification-result: ${GCP_PUBSUB_SUBSCRIPTION_IMAGE_VERIFICATION_RESULT}
+      verification-dlq: ${GCP_PUBSUB_SUBSCRIPTION_IMAGE_VERIFICATION_RESULT_DLQ}
+      feedback-result: ${GCP_PUBSUB_SUBSCRIPTION_FEEDBACK_RESULT}
+      feedback-result-dlq: ${GCP_PUBSUB_SUBSCRIPTION_FEEDBACK_DLQ}
 
 logging:
   level:


### PR DESCRIPTION
## 변경사항
- 일반 상품 구매 시, 타임딜 가격으로 잘못 구매되던 문제 수정
- 상품 구매 시 변경된 재고 정보를 캐시에 반영하도록 로직 추가
- 향후 GCP Pub/Sub 연동을 위한 설정(chore)도 포함됨

## 주요 수정 내역
- 재고 감소 후 `ProductCacheLockFacade.updateSingleTimedealCache()` 호출 로직 추가
- 일반 상품 구매 시 타임딜 정책을 참조하지 않도록 조건 분기
- GCP Pub/Sub 관련 기본 설정 파일 및 의존성 추가