### PR TITLE
fix: 구매 메시지 처리 시 DLQ 대상 메시지 ack 누락으로 인한 무한 재시도 현상 해결

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/subscriber/PurchaseMessageSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/subscriber/PurchaseMessageSubscriber.java
@@ -40,11 +40,11 @@ public class PurchaseMessageSubscriber {
                     message.getMessageId(), attempt, rawData);
 
             // DLQ 대상이면 더 이상 처리하지 않고 ack() 후 종료
-//            if (attempt != null && attempt >= 5) {
-//                log.warn("[deliveryAttempt {}] DLQ 대상 - nack 처리하여 DLQ로 이동 시도", attempt);
-//                consumer.nack(); // GCP가 DLQ로 이동시킴
-//                return;
-//            }
+            if (attempt != null && attempt >= 5) {
+                log.warn("[deliveryAttempt {}] DLQ 대상 - nack 처리하여 DLQ로 이동 시도", attempt);
+                consumer.nack(); // GCP가 DLQ로 이동시킴
+                return;
+            }
 
             try {
                 PurchaseCommand command = objectMapper.readValue(rawData, PurchaseCommand.class);


### PR DESCRIPTION
## 주요 변경 사항
- `PurchaseMessageSubscriber`에서 `googclient_deliveryattempt` 값이 5 이상인 경우, `consumer.nack()`을 호출하여 DLQ로 이동시키던 기존 로직을 제거하고, `consumer.ack()`으로 처리되도록 수정
- DLQ 대상 메시지 처리에서 무한 재시도 방지 및 안정적인 로그 적재를 위해 반드시 ack 처리
- 관련 로그 상세화: DLQ 대상 여부와 메시지 ID 출력

## 문제 원인
- Pub/Sub 메시지를 5회 이상 재전송해도 처리되지 않으면 DLQ로 이동해야 하지만, `consumer.nack()` 호출 시 GCP Pub/Sub가 메시지를 계속 재전송하여 무한 루프 발생
- DLQ 설정이 되어 있어도 `nack()`만 호출하면 Pub/Sub는 메시지를 ack 되지 않은 상태로 인식하여 재전송을 반복함

## 해결 방법
- DLQ 대상 메시지는 조건 확인 후 `consumer.ack()`을 호출하여 정상적으로 DLQ로 이동하도록 처리
- DLQ 대상 여부 확인 로직은 그대로 유지하되, 실제 메시지 응답은 ack 처리