### PR TITLE
fix: 타임딜 구매 로직 보강 및 DLQ 처리 방식 개선

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/subscriber/PurchaseMessageSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/subscriber/PurchaseMessageSubscriber.java
@@ -42,7 +42,7 @@ public class PurchaseMessageSubscriber {
             // DLQ 대상이면 더 이상 처리하지 않고 ack() 후 종료
             if (attempt != null && attempt >= 5) {
                 log.warn("[deliveryAttempt {}] DLQ 대상 - nack 처리하여 DLQ로 이동 시도", attempt);
-                consumer.nack(); // GCP가 DLQ로 이동시킴
+                consumer.ack(); // GCP가 DLQ로 이동시킴
                 return;
             }
 

--- a/src/main/java/ktb/leafresh/backend/global/exception/TimedealErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/TimedealErrorCode.java
@@ -10,8 +10,9 @@ public enum TimedealErrorCode implements BaseErrorCode {
     INVALID_PRICE(HttpStatus.BAD_REQUEST, "할인 가격은 1 이상이어야 합니다."),
     INVALID_PERCENT(HttpStatus.BAD_REQUEST, "할인율은 1 이상이어야 합니다."),
     INVALID_STOCK(HttpStatus.BAD_REQUEST, "재고는 0 이상이어야 합니다."),
-    TIMEDEAL_LOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "타임딜 상품을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.");
-
+    TIMEDEAL_LOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "타임딜 상품을 불러오지 못했습니다. 잠시 후 다시 시도해주세요."),
+    TIMEDEAL_POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 타임딜 정책을 찾을 수 없습니다."),
+    INVALID_PRODUCT_FOR_TIMEDEAL(HttpStatus.BAD_REQUEST, "해당 상품은 선택한 타임딜 정책에 속하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
- ProductPurchaseProcessingService
  - 타임딜 정책 존재 여부 및 상품 일치 여부 검증 로직 명시적으로 분리
  - 유효하지 않은 타임딜 정책에 대해 CustomException 발생
  - Optional 기반 로직 제거하고 명시적 null 체크 방식으로 전환

- PurchaseMessageSubscriber
  - deliveryAttempt ≥ 5일 경우 consumer.nack() → consumer.ack()로 변경
  - GCP DLQ로 안전하게 이동되도록 처리

- TimedealErrorCode
  - TIMEDEAL_POLICY_NOT_FOUND, INVALID_PRODUCT_FOR_TIMEDEAL 에러 코드 추가