### PR TITLE
fix: 포인트 부족 상태에서도 구매 성공되는 문제 수정 및 검증 로직 선반영

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/PointService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/PointService.java
@@ -1,0 +1,5 @@
+package ktb.leafresh.backend.domain.store.order.application.service;
+
+public interface PointService {
+    boolean hasEnoughPoints(Long memberId, int amount);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/PointServiceImpl.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/PointServiceImpl.java
@@ -1,0 +1,21 @@
+package ktb.leafresh.backend.domain.store.order.application.service;
+
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PointServiceImpl implements PointService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean hasEnoughPoints(Long memberId, int required) {
+        return memberRepository.findById(memberId)
+                .map(Member::getCurrentLeafPoints) // Integer 타입이어야 함
+                .map(p -> p >= required)
+                .orElse(false);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateService.java
@@ -32,6 +32,7 @@ public class ProductOrderCreateService {
     private final StockRedisLuaService stockRedisLuaService;
     private final PurchaseMessagePublisher purchaseMessagePublisher;
     private final ProductCacheLockFacade productCacheLockFacade;
+    private final PointService pointService;
 
     @DistributedLock(key = "'product:stock:' + #productId", waitTime = 0, leaseTime = 3)
     @Transactional
@@ -51,10 +52,17 @@ public class ProductOrderCreateService {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new CustomException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
-        // 3-1. 캐시 없으면 Redisson Lock 기반으로 캐싱 (스탬피드 방지)
+        // 4. 보유 포인트 검증
+        int totalPrice = product.getPrice() * quantity;
+        if (!pointService.hasEnoughPoints(memberId, totalPrice)) {
+            log.warn("[포인트 부족] memberId={}, 보유포인트<{}", memberId, totalPrice);
+            throw new CustomException(PurchaseErrorCode.INSUFFICIENT_POINTS);
+        }
+
+        // 5. 캐시 없으면 Redisson Lock 기반으로 캐싱 (스탬피드 방지)
         productCacheLockFacade.cacheProductStock(productId, product.getStock());
 
-        // 4. Redis 재고 선점
+        // 5. Redis 재고 선점
         String redisKey = ProductCacheKeys.productStock(productId);
         Long result = stockRedisLuaService.decreaseStock(redisKey, quantity);
 
@@ -63,7 +71,7 @@ public class ProductOrderCreateService {
 
         productCacheLockFacade.updateSingleProductCache(product);
 
-        // 5. 메시지 큐 발행
+        // 6. 메시지 큐 발행
         PurchaseCommand command = new PurchaseCommand(memberId, productId, null, quantity, idempotencyKey, LocalDateTime.now());
         purchaseMessagePublisher.publish(command);
 

--- a/src/main/java/ktb/leafresh/backend/global/exception/TimedealErrorCode.java
+++ b/src/main/java/ktb/leafresh/backend/global/exception/TimedealErrorCode.java
@@ -12,7 +12,8 @@ public enum TimedealErrorCode implements BaseErrorCode {
     INVALID_STOCK(HttpStatus.BAD_REQUEST, "재고는 0 이상이어야 합니다."),
     TIMEDEAL_LOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "타임딜 상품을 불러오지 못했습니다. 잠시 후 다시 시도해주세요."),
     TIMEDEAL_POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 타임딜 정책을 찾을 수 없습니다."),
-    INVALID_PRODUCT_FOR_TIMEDEAL(HttpStatus.BAD_REQUEST, "해당 상품은 선택한 타임딜 정책에 속하지 않습니다.");
+    INVALID_PRODUCT_FOR_TIMEDEAL(HttpStatus.BAD_REQUEST, "해당 상품은 선택한 타임딜 정책에 속하지 않습니다."),
+    INVALID_STATUS(HttpStatus.BAD_REQUEST, "현재는 구매할 수 없는 시간입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/ProductOrderCreateServiceTest.java
@@ -34,12 +34,26 @@ import org.springframework.dao.DataIntegrityViolationException;
 @ExtendWith(MockitoExtension.class)
 class ProductOrderCreateServiceTest {
 
-    @Mock private MemberRepository memberRepository;
-    @Mock private ProductRepository productRepository;
-    @Mock private PurchaseIdempotencyKeyRepository idempotencyRepository;
-    @Mock private StockRedisLuaService stockRedisLuaService;
-    @Mock private PurchaseMessagePublisher purchaseMessagePublisher;
-    @Mock private ProductCacheLockFacade productCacheLockFacade;
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private PurchaseIdempotencyKeyRepository idempotencyRepository;
+
+    @Mock
+    private StockRedisLuaService stockRedisLuaService;
+
+    @Mock
+    private PurchaseMessagePublisher purchaseMessagePublisher;
+
+    @Mock
+    private ProductCacheLockFacade productCacheLockFacade;
+
+    @Mock
+    private PointService pointService;
 
     @InjectMocks
     private ProductOrderCreateService productOrderCreateService;
@@ -63,6 +77,7 @@ class ProductOrderCreateServiceTest {
             // given
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
             given(productRepository.findById(10L)).willReturn(Optional.of(product));
+            given(pointService.hasEnoughPoints(eq(1L), anyInt())).willReturn(true);
             given(stockRedisLuaService.decreaseStock("stock:product:10", 1)).willReturn(1L);
 
             // when
@@ -115,6 +130,7 @@ class ProductOrderCreateServiceTest {
         void create_redisReturnsMinusOne() {
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
             given(productRepository.findById(10L)).willReturn(Optional.of(product));
+            given(pointService.hasEnoughPoints(eq(1L), anyInt())).willReturn(true);
             given(stockRedisLuaService.decreaseStock(any(), anyInt())).willReturn(-1L);
 
             assertThatThrownBy(() ->
@@ -128,6 +144,7 @@ class ProductOrderCreateServiceTest {
         void create_redisReturnsMinusTwo() {
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
             given(productRepository.findById(10L)).willReturn(Optional.of(product));
+            given(pointService.hasEnoughPoints(eq(1L), anyInt())).willReturn(true);
             given(stockRedisLuaService.decreaseStock(any(), anyInt())).willReturn(-2L);
 
             assertThatThrownBy(() ->

--- a/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/TimedealOrderCreateServiceTest.java
+++ b/src/test/java/ktb/leafresh/backend/domain/store/order/application/service/TimedealOrderCreateServiceTest.java
@@ -50,6 +50,9 @@ class TimedealOrderCreateServiceTest {
     @Mock
     private ProductCacheLockFacade productCacheLockFacade;
 
+    @Mock
+    private PointService pointService;
+
     @InjectMocks
     private TimedealOrderCreateService service;
 
@@ -88,6 +91,7 @@ class TimedealOrderCreateServiceTest {
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
         given(timedealPolicyRepository.findById(dealId)).willReturn(Optional.of(policy));
+        given(pointService.hasEnoughPoints(eq(memberId), anyInt())).willReturn(true);
         given(stockRedisLuaService.decreaseStock(anyString(), eq(quantity))).willReturn(1L);
         willDoNothing().given(productCacheLockFacade).updateSingleTimedealCache(policy);
 
@@ -136,6 +140,7 @@ class TimedealOrderCreateServiceTest {
         given(memberRepository.findById(anyLong())).willReturn(Optional.of(member));
         given(idempotencyRepository.save(any())).willReturn(null);
         given(timedealPolicyRepository.findById(anyLong())).willReturn(Optional.of(policy));
+        given(pointService.hasEnoughPoints(eq(1L), anyInt())).willReturn(true);
         given(stockRedisLuaService.decreaseStock(anyString(), anyInt())).willReturn(-2L);
 
         // when & then
@@ -174,6 +179,7 @@ class TimedealOrderCreateServiceTest {
         given(memberRepository.findById(anyLong())).willReturn(Optional.of(member));
         given(idempotencyRepository.save(any())).willReturn(null);
         given(timedealPolicyRepository.findById(anyLong())).willReturn(Optional.of(policy));
+        given(pointService.hasEnoughPoints(eq(1L), anyInt())).willReturn(true);
         given(stockRedisLuaService.decreaseStock(anyString(), anyInt())).willReturn(-1L);
 
         // when & then


### PR DESCRIPTION
## 주요 변경 사항
- 포인트 차감 시점을 MQ 소비 시점(PurchaseProcessor) → 구매 요청 시점으로 변경
- 구매 요청 시에 포인트 부족하면 예외를 발생시켜 구매 자체를 차단
- 이를 통해 Redis 재고가 감소했음에도 구매가 실패로 간주되는 불일치 현상 방지

## 테스트 코드 보완
- `PointService` 모킹 누락으로 인한 NPE 제거
- `hasEnoughPoints` stubbing을 통해 정상 흐름 및 예외 흐름 모두 검증

## 배경
- 기존 구조에서는 MQ 소비 시점에 포인트 차감이 이루어졌으나,
  Redis 재고는 이미 차감된 상태이기 때문에 구매 성공 처리와 포인트 부족 예외가 충돌
- 사용자가 실제로는 구매할 수 없는 상태인데도 성공 응답이 나가는 문제 해결 목적