### PR TITLE
feat: GroupChallenge 인증 상태 NOT_PARTICIPATED 추가 및 참여 여부 판단 로직 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/GroupChallengeVerificationRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/repository/GroupChallengeVerificationRepository.java
@@ -169,4 +169,9 @@ public interface GroupChallengeVerificationRepository extends JpaRepository<Grou
 
     @Query("SELECT COUNT(g) FROM GroupChallengeVerification g")
     int countAll();
+
+    boolean existsByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_Id(
+            Long memberId,
+            Long challengeId
+    );
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/presentation/util/ChallengeStatusMessageResolver.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/presentation/util/ChallengeStatusMessageResolver.java
@@ -5,10 +5,11 @@ import ktb.leafresh.backend.global.common.entity.enums.ChallengeStatus;
 public class ChallengeStatusMessageResolver {
     public static String resolveMessage(ChallengeStatus status) {
         return switch (status) {
-            case SUCCESS -> "인증에 성공했습니다.";
-            case FAILURE -> "인증에 실패했습니다.";
+            case NOT_PARTICIPATED -> "아직 챌린지에 참여하지 않았습니다.";
             case NOT_SUBMITTED -> "아직 인증을 제출하지 않았습니다.";
             case PENDING_APPROVAL -> "아직 인증 결과가 도착하지 않았습니다.";
+            case SUCCESS -> "인증에 성공했습니다.";
+            case FAILURE -> "인증에 실패했습니다.";
         };
     }
 }

--- a/src/main/java/ktb/leafresh/backend/global/common/entity/enums/ChallengeStatus.java
+++ b/src/main/java/ktb/leafresh/backend/global/common/entity/enums/ChallengeStatus.java
@@ -1,8 +1,9 @@
 package ktb.leafresh.backend.global.common.entity.enums;
 
 public enum ChallengeStatus {
-    NOT_SUBMITTED,
-    PENDING_APPROVAL,
-    SUCCESS,
-    FAILURE
+    NOT_PARTICIPATED,   // 챌린지에 참여하지 않음
+    NOT_SUBMITTED,      // 오늘 인증 미제출
+    PENDING_APPROVAL,   // 오늘 인증 제출, 검토 대기
+    SUCCESS,            // 오늘 인증 성공
+    FAILURE             // 오늘 인증 실패
 }

--- a/src/main/java/ktb/leafresh/backend/global/config/ClockConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package ktb.leafresh.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}


### PR DESCRIPTION
## 주요 변경 사항
- `ChallengeStatus` enum에 `NOT_PARTICIPATED` 상태 추가 및 한글 설명 주석 추가
- 인증 상태 메시지 Resolver에 `NOT_PARTICIPATED` 케이스 및 메시지 추가
- Clock 의존성 주입을 위한 `ClockConfig` 설정 추가
- `GroupChallengeDetailReadService`에서 인증 상태 조회 시 챌린지 참여 여부 판단 로직 도입
- 인증 기록 유무로 상태를 판단하던 기존 방식에서 참여 여부 → 인증 가능 시간 → 인증 상태 순으로 판단 흐름 개선
- `GroupChallengeVerificationRepository`에 참여 여부 확인용 exists 쿼리 메서드 추가
- 테스트 코드에서 고정 시간(`FIXED_NOW`) 및 챌린지 참여/인증 여부에 따른 다양한 케이스 추가 검증