### PR TITLE
feat: AWS SQS 기반 인증 요청 및 결과 처리 구현 및 GCP 분기 처리

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/publisher/AiVerificationPublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/publisher/AiVerificationPublisher.java
@@ -1,0 +1,7 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.publisher;
+
+import ktb.leafresh.backend.domain.verification.infrastructure.dto.request.AiVerificationRequestDto;
+
+public interface AiVerificationPublisher {
+    void publishAsyncWithRetry(AiVerificationRequestDto dto);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/publisher/AwsAiVerificationSqsPublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/publisher/AwsAiVerificationSqsPublisher.java
@@ -1,0 +1,59 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.publisher;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ktb.leafresh.backend.domain.verification.infrastructure.dto.request.AiVerificationRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@Profile("eks")
+@Slf4j
+@RequiredArgsConstructor
+public class AwsAiVerificationSqsPublisher implements AiVerificationPublisher {
+
+    private final AmazonSQSAsync amazonSQSAsync;
+    private final ObjectMapper objectMapper;
+
+    @Value("${aws.sqs.verification-request-queue-url}")
+    private String queueUrl;
+
+    private static final int MAX_RETRY = 3;
+    private static final long INITIAL_BACKOFF_MS = 300;
+
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(4);
+
+    @Override
+    public void publishAsyncWithRetry(AiVerificationRequestDto dto) {
+        try {
+            String messageBody = objectMapper.writeValueAsString(dto);
+            sendWithRetry(messageBody, dto, 1);
+        } catch (JsonProcessingException e) {
+            log.error("[SQS 직렬화 실패]", e);
+        }
+    }
+
+    private void sendWithRetry(String body, AiVerificationRequestDto dto, int attempt) {
+        try {
+            amazonSQSAsync.sendMessage(queueUrl, body);
+            log.info("[SQS 인증 요청 발행 성공] attempt={}, dto={}", attempt, body);
+        } catch (Exception e) {
+            log.warn("[SQS 인증 요청 발행 실패] attempt={}, error={}", attempt, e.getMessage());
+
+            if (attempt < MAX_RETRY) {
+                long backoff = INITIAL_BACKOFF_MS * (1L << (attempt - 1));
+                scheduler.schedule(() -> sendWithRetry(body, dto, attempt + 1), backoff, TimeUnit.MILLISECONDS);
+            } else {
+                log.error("[SQS 인증 요청 발행 최종 실패] dto={}", dto);
+            }
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/publisher/GcpAiVerificationPubSubPublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/publisher/GcpAiVerificationPubSubPublisher.java
@@ -17,6 +17,7 @@ import ktb.leafresh.backend.domain.verification.infrastructure.repository.Verifi
 import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -26,7 +27,8 @@ import java.util.concurrent.*;
 
 @Component
 @Slf4j
-public class GcpAiVerificationPubSubPublisher {
+@Profile("!eks")
+public class GcpAiVerificationPubSubPublisher implements AiVerificationPublisher {
 
     private final Publisher imageVerificationPublisher;
     private final ObjectMapper objectMapper;

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/subscriber/AwsVerificationResultDlqMessageSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/subscriber/AwsVerificationResultDlqMessageSubscriber.java
@@ -1,0 +1,91 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.subscriber;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.model.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.verification.domain.entity.VerificationFailureLog;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.VerificationFailureLogRepository;
+import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@Profile("eks")
+@RequiredArgsConstructor
+public class AwsVerificationResultDlqMessageSubscriber {
+
+    private final AmazonSQSAsync sqs;
+    private final ObjectMapper objectMapper;
+    private final VerificationFailureLogRepository failureLogRepository;
+    private final MemberRepository memberRepository;
+
+    @Value("${aws.sqs.verification-dlq-queue-url}")
+    private String queueUrl;
+
+    private static final int WAIT_TIME_SECONDS = 20;
+    private static final int MAX_MESSAGES = 5;
+
+    @PostConstruct
+    public void startPolling() {
+        Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(this::pollMessages, 0, 5, TimeUnit.SECONDS);
+        log.info("[SQS DLQ Subscriber 시작] queueUrl={}", queueUrl);
+    }
+
+    public void pollMessages() {
+        try {
+            ReceiveMessageRequest request = new ReceiveMessageRequest(queueUrl)
+                    .withMaxNumberOfMessages(MAX_MESSAGES)
+                    .withWaitTimeSeconds(WAIT_TIME_SECONDS);
+
+            List<Message> messages = sqs.receiveMessage(request).getMessages();
+
+            for (Message message : messages) {
+                String body = message.getBody();
+                log.error("[SQS DLQ 수신] messageId={}, body={}", message.getMessageId(), body);
+
+                try {
+                    VerificationResultRequestDto dto = objectMapper.readValue(body, VerificationResultRequestDto.class);
+
+                    Member member = memberRepository.findById(dto.memberId())
+                            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+                    failureLogRepository.save(VerificationFailureLog.builder()
+                            .member(member)
+                            .challengeType(dto.type())
+                            .challengeId(dto.challengeId())
+                            .verificationId(dto.verificationId())
+                            .reason("DLQ로 이동된 인증 메시지입니다.")
+                            .requestBody(body)
+                            .occurredAt(LocalDateTime.now())
+                            .build());
+
+                } catch (Exception e) {
+                    log.warn("[DLQ 메시지 파싱 실패 → 최소 정보로 로그 저장] {}", e.getMessage(), e);
+
+                    failureLogRepository.save(VerificationFailureLog.builder()
+                            .reason("DLQ 메시지 파싱 실패: " + e.getMessage())
+                            .requestBody(body)
+                            .occurredAt(LocalDateTime.now())
+                            .build());
+                } finally {
+                    // DLQ는 무조건 ack
+                    sqs.deleteMessage(new DeleteMessageRequest(queueUrl, message.getReceiptHandle()));
+                }
+            }
+        } catch (Exception e) {
+            log.error("[SQS DLQ Polling 실패] {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/subscriber/AwsVerificationResultSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/subscriber/AwsVerificationResultSubscriber.java
@@ -1,0 +1,117 @@
+package ktb.leafresh.backend.domain.verification.infrastructure.subscriber;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.model.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.challenge.group.domain.entity.GroupChallenge;
+import ktb.leafresh.backend.domain.verification.application.service.VerificationResultProcessor;
+import ktb.leafresh.backend.domain.verification.domain.entity.GroupChallengeVerification;
+import ktb.leafresh.backend.domain.verification.infrastructure.dto.request.AiVerificationRequestDto;
+import ktb.leafresh.backend.domain.verification.infrastructure.publisher.AiVerificationPublisher;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.GroupChallengeVerificationRepository;
+import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.VerificationErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@Profile("eks")
+@RequiredArgsConstructor
+public class AwsVerificationResultSubscriber {
+
+    private final AmazonSQSAsync sqs;
+    private final ObjectMapper objectMapper;
+    private final VerificationResultProcessor resultProcessor;
+    private final GroupChallengeVerificationRepository verificationRepository;
+    private final AiVerificationPublisher aiVerificationPublisher;
+
+    @Value("${aws.sqs.verification-result-queue-url}")
+    private String queueUrl;
+
+    private static final int WAIT_TIME_SECONDS = 20;
+    private static final int MAX_MESSAGES = 5;
+
+    @PostConstruct
+    public void startPolling() {
+        Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(this::pollMessages, 0, 5, TimeUnit.SECONDS);
+        log.info("[SQS 인증 결과 Subscriber 시작] queueUrl={}", queueUrl);
+    }
+
+//    @Async
+//    ScheduledExecutorService로 실행되므로 @Async는 효과 없음 => 제거해도 문제 X
+    public void pollMessages() {
+        try {
+            ReceiveMessageRequest request = new ReceiveMessageRequest(queueUrl)
+                    .withMaxNumberOfMessages(MAX_MESSAGES)
+                    .withWaitTimeSeconds(WAIT_TIME_SECONDS);
+
+            List<Message> messages = sqs.receiveMessage(request).getMessages();
+
+            for (Message message : messages) {
+                String body = message.getBody();
+                log.info("[SQS 인증 결과 수신] messageId={}, body={}", message.getMessageId(), body);
+
+                try {
+                    VerificationResultRequestDto dto = objectMapper.readValue(body, VerificationResultRequestDto.class);
+
+                    if (dto.isSuccessResult()) {
+                        resultProcessor.process(dto.verificationId(), dto);
+
+                    } else if (dto.isRecoverableHttpError()) {
+                        log.warn("[AI 처리 오류 응답] verificationId={}, httpStatus={}", dto.verificationId(), dto.result());
+
+                        GroupChallengeVerification verification = verificationRepository.findById(dto.verificationId())
+                                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 인증 ID"));
+
+                        GroupChallenge challenge = verification.getParticipantRecord().getGroupChallenge();
+
+                        AiVerificationRequestDto retryDto = AiVerificationRequestDto.builder()
+                                .verificationId(dto.verificationId())
+                                .type(dto.type())
+                                .imageUrl(verification.getImageUrl())
+                                .memberId(dto.memberId())
+                                .challengeId(dto.challengeId())
+                                .date(dto.date())
+                                .challengeName(challenge.getTitle())
+                                .challengeInfo(challenge.getDescription())
+                                .build();
+
+                        aiVerificationPublisher.publishAsyncWithRetry(retryDto);
+                        log.info("[SQS 인증 요청 재발행 완료] verificationId={}", dto.verificationId());
+
+                    } else {
+                        log.error("[알 수 없는 result 값] result={}", dto.result());
+                    }
+
+                    // 삭제
+                    sqs.deleteMessage(new DeleteMessageRequest(queueUrl, message.getReceiptHandle()));
+
+                } catch (CustomException e) {
+                    if (e.getErrorCode() == VerificationErrorCode.VERIFICATION_NOT_FOUND) {
+                        log.warn("[무시] 존재하지 않는 인증 ID. verificationId={} → 삭제", e.getMessage());
+                        sqs.deleteMessage(new DeleteMessageRequest(queueUrl, message.getReceiptHandle()));
+                    } else {
+                        log.error("[처리 실패 - CustomException] {}", e.getMessage(), e);
+                        // 삭제하지 않음 (재시도 유도)
+                    }
+                } catch (Exception e) {
+                    log.error("[처리 실패 - Exception] {}", e.getMessage(), e);
+                    // 삭제하지 않음 (재시도 유도)
+                }
+            }
+        } catch (Exception e) {
+            log.error("[SQS Polling 실패] {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/subscriber/GcpVerificationResultDlqMessageSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/subscriber/GcpVerificationResultDlqMessageSubscriber.java
@@ -12,6 +12,7 @@ import ktb.leafresh.backend.domain.verification.infrastructure.repository.Verifi
 import ktb.leafresh.backend.domain.verification.presentation.dto.request.VerificationResultRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +21,7 @@ import java.time.LocalDateTime;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Profile("!eks")
 public class GcpVerificationResultDlqMessageSubscriber {
 
     private final Environment environment;

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/subscriber/GcpVerificationResultSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/subscriber/GcpVerificationResultSubscriber.java
@@ -16,12 +16,14 @@ import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.VerificationErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Profile("!eks")
 public class GcpVerificationResultSubscriber {
 
     private final Environment environment;

--- a/src/main/resources/application-eks.yml
+++ b/src/main/resources/application-eks.yml
@@ -30,3 +30,16 @@ cloud:
       static: ap-northeast-2
     stack:
       auto: false
+
+aws:
+  sqs:
+    feedback-request-queue-url: ${AWS_SQS_FEEDBACK_REQUEST_QUEUE_URL}
+    feedback-result-queue-url: ${AWS_SQS_FEEDBACK_RESULT_QUEUE_URL}
+    feedback-result-dlq-queue-url: ${AWS_SQS_FEEDBACK_RESULT_DLQ_QUEUE_URL}
+
+    verification-request-queue-url: ${AWS_SQS_VERIFICATION_REQUEST_QUEUE_URL}
+    verification-result-queue-url: ${AWS_SQS_VERIFICATION_RESULT_QUEUE_URL}
+    verification-dlq-queue-url: ${AWS_SQS_VERIFICATION_DLQ_QUEUE_URL}
+
+    order-request-queue-url: ${AWS_SQS_ORDER_REQUEST_QUEUE_URL}
+    order-dlq-queue-url: ${AWS_SQS_ORDER_DLQ_QUEUE_URL}


### PR DESCRIPTION
기존 GCP Pub/Sub 기반 인증 처리 로직을 AWS SQS 기반으로 이관하였습니다.  
프로덕션(GCP)과 개발(EKS/AWS) 환경을 명확히 분리하고, 메시지 전송 및 수신 처리를 모두 지원하도록 구성하였습니다.

## 주요 변경사항
- `application-eks.yml`: SQS 관련 큐 URL 추가
- `AiVerificationPublisher`: 인증 메시지 발행 인터페이스 정의
- `AwsAiVerificationSqsPublisher`: 인증 요청을 SQS에 전송 (재시도 포함)
- `AwsVerificationResultSubscriber`: 인증 결과 수신 및 처리
- `AwsVerificationResultDlqMessageSubscriber`: DLQ 수신 및 실패 로깅
- GCP 관련 Publisher/Subscriber에 `@Profile("!eks")` 설정
- AWS 관련 클래스에 `@Profile("eks")` 설정