### PR TITLE
feat: 피드백 결과 발행/수신 기능을 AWS SQS 기반 구현 및 Profile 분리

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/publisher/AiFeedbackPublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/publisher/AiFeedbackPublisher.java
@@ -1,0 +1,7 @@
+package ktb.leafresh.backend.domain.feedback.infrastructure.publisher;
+
+import ktb.leafresh.backend.domain.feedback.infrastructure.dto.request.AiFeedbackCreationRequestDto;
+
+public interface AiFeedbackPublisher {
+    void publishAsyncWithRetry(AiFeedbackCreationRequestDto dto);
+}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/publisher/AwsAiFeedbackSqsPublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/publisher/AwsAiFeedbackSqsPublisher.java
@@ -1,0 +1,84 @@
+package ktb.leafresh.backend.domain.feedback.infrastructure.publisher;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ktb.leafresh.backend.domain.feedback.domain.entity.FeedbackFailureLog;
+import ktb.leafresh.backend.domain.feedback.infrastructure.dto.request.AiFeedbackCreationRequestDto;
+import ktb.leafresh.backend.domain.feedback.infrastructure.repository.FeedbackFailureLogRepository;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@Profile("eks")
+@Slf4j
+@RequiredArgsConstructor
+public class AwsAiFeedbackSqsPublisher implements AiFeedbackPublisher {
+
+    private final AmazonSQSAsync amazonSQSAsync;
+    private final ObjectMapper objectMapper;
+    private final MemberRepository memberRepository;
+    private final FeedbackFailureLogRepository feedbackFailureLogRepository;
+
+    @Value("${aws.sqs.feedback-request-queue-url}")
+    private String queueUrl;
+
+    private static final int MAX_RETRY = 3;
+    private static final long INITIAL_BACKOFF_MS = 300;
+
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
+
+    @Override
+    public void publishAsyncWithRetry(AiFeedbackCreationRequestDto dto) {
+        try {
+            String json = objectMapper.writeValueAsString(dto);
+            sendWithRetry(json, dto, 1);
+        } catch (JsonProcessingException e) {
+            log.error("[SQS 직렬화 실패]", e);
+            logFailure(dto, null, "직렬화 실패: " + e.getMessage());
+        }
+    }
+
+    private void sendWithRetry(String body, AiFeedbackCreationRequestDto dto, int attempt) {
+        try {
+            amazonSQSAsync.sendMessage(queueUrl, body);
+            log.info("[SQS 피드백 발행 성공] attempt={}, dto={}", attempt, body);
+        } catch (Exception e) {
+            log.warn("[SQS 피드백 발행 실패] attempt={}, error={}", attempt, e.getMessage());
+
+            if (attempt < MAX_RETRY) {
+                long backoff = INITIAL_BACKOFF_MS * (1L << (attempt - 1));
+                scheduler.schedule(() -> sendWithRetry(body, dto, attempt + 1), backoff, TimeUnit.MILLISECONDS);
+            } else {
+                log.error("[SQS 피드백 발행 최종 실패] dto={}", dto);
+                logFailure(dto, body, "최대 재시도 초과: " + e.getMessage());
+            }
+        }
+    }
+
+    private void logFailure(AiFeedbackCreationRequestDto dto, String json, String reason) {
+        try {
+            Member member = memberRepository.findById(dto.memberId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+            feedbackFailureLogRepository.save(FeedbackFailureLog.builder()
+                    .member(member)
+                    .reason(reason)
+                    .requestBody(json != null ? json : "{}")
+                    .occurredAt(LocalDateTime.now())
+                    .build());
+        } catch (Exception e) {
+            log.warn("[FailureLog 저장 실패] {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/publisher/GcpAiFeedbackPubSubPublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/publisher/GcpAiFeedbackPubSubPublisher.java
@@ -16,6 +16,7 @@ import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -25,7 +26,8 @@ import java.util.concurrent.TimeUnit;
 
 @Component
 @Slf4j
-public class GcpAiFeedbackPubSubPublisher {
+@Profile("!eks")
+public class GcpAiFeedbackPubSubPublisher implements AiFeedbackPublisher {
 
     private final Publisher feedbackPublisher;
     private final ObjectMapper objectMapper;

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/subscriber/AwsAiFeedbackResultDlqSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/subscriber/AwsAiFeedbackResultDlqSubscriber.java
@@ -1,0 +1,89 @@
+package ktb.leafresh.backend.domain.feedback.infrastructure.subscriber;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.model.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.feedback.domain.entity.FeedbackFailureLog;
+import ktb.leafresh.backend.domain.feedback.infrastructure.repository.FeedbackFailureLogRepository;
+import ktb.leafresh.backend.domain.feedback.presentation.dto.request.FeedbackResultRequestDto;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@Profile("eks")
+@RequiredArgsConstructor
+public class AwsAiFeedbackResultDlqSubscriber {
+
+    private final AmazonSQSAsync sqs;
+    private final ObjectMapper objectMapper;
+    private final FeedbackFailureLogRepository failureLogRepository;
+    private final MemberRepository memberRepository;
+
+    @Value("${aws.sqs.feedback-result-dlq-queue-url}")
+    private String dlqUrl;
+
+    private static final int WAIT_TIME_SECONDS = 20;
+    private static final int MAX_MESSAGES = 5;
+
+    @PostConstruct
+    public void startDlqPolling() {
+        Executors.newSingleThreadScheduledExecutor()
+                .scheduleWithFixedDelay(this::pollDlqMessages, 0, 10, TimeUnit.SECONDS);
+        log.info("[SQS 피드백 DLQ Subscriber 시작] dlqUrl={}", dlqUrl);
+    }
+
+    public void pollDlqMessages() {
+        try {
+            ReceiveMessageRequest request = new ReceiveMessageRequest(dlqUrl)
+                    .withMaxNumberOfMessages(MAX_MESSAGES)
+                    .withWaitTimeSeconds(WAIT_TIME_SECONDS);
+
+            List<Message> messages = sqs.receiveMessage(request).getMessages();
+
+            for (Message message : messages) {
+                String body = message.getBody();
+                log.error("[SQS 피드백 DLQ 수신] messageId={}, body={}", message.getMessageId(), body);
+
+                try {
+                    FeedbackResultRequestDto dto = objectMapper.readValue(body, FeedbackResultRequestDto.class);
+
+                    Member member = memberRepository.findById(dto.memberId())
+                            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+                    failureLogRepository.save(FeedbackFailureLog.builder()
+                            .member(member)
+                            .reason("DLQ로 이동된 피드백 메시지입니다.")
+                            .requestBody(body)
+                            .occurredAt(LocalDateTime.now())
+                            .build());
+
+                } catch (Exception e) {
+                    log.warn("[DLQ 메시지 파싱 실패] 최소 정보로 로그 저장. error={}", e.getMessage());
+
+                    failureLogRepository.save(FeedbackFailureLog.builder()
+                            .reason("DLQ 메시지 파싱 실패: " + e.getMessage())
+                            .requestBody(body)
+                            .occurredAt(LocalDateTime.now())
+                            .build());
+                } finally {
+                    sqs.deleteMessage(new DeleteMessageRequest(dlqUrl, message.getReceiptHandle()));
+                }
+            }
+
+        } catch (Exception e) {
+            log.error("[SQS DLQ Polling 실패] {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/subscriber/AwsAiFeedbackResultSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/subscriber/AwsAiFeedbackResultSubscriber.java
@@ -1,0 +1,105 @@
+package ktb.leafresh.backend.domain.feedback.infrastructure.subscriber;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.model.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import ktb.leafresh.backend.domain.feedback.application.assembler.FeedbackDtoAssembler;
+import ktb.leafresh.backend.domain.feedback.application.service.FeedbackResultService;
+import ktb.leafresh.backend.domain.feedback.infrastructure.dto.request.AiFeedbackCreationRequestDto;
+import ktb.leafresh.backend.domain.feedback.infrastructure.publisher.AiFeedbackPublisher;
+import ktb.leafresh.backend.domain.feedback.presentation.dto.request.FeedbackResultRequestDto;
+import ktb.leafresh.backend.global.exception.CustomException;
+import ktb.leafresh.backend.global.exception.FeedbackErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@Profile("eks")
+@RequiredArgsConstructor
+public class AwsAiFeedbackResultSubscriber {
+
+    private final AmazonSQSAsync sqs;
+    private final ObjectMapper objectMapper;
+    private final FeedbackResultService feedbackResultService;
+    private final AiFeedbackPublisher aiFeedbackPublisher;
+    private final FeedbackDtoAssembler feedbackDtoAssembler;
+
+    @Value("${aws.sqs.feedback-result-queue-url}")
+    private String queueUrl;
+
+    private static final int WAIT_TIME_SECONDS = 20;
+    private static final int MAX_MESSAGES = 5;
+
+    @PostConstruct
+    public void startPolling() {
+        Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(this::pollMessages, 0, 5, TimeUnit.SECONDS);
+        log.info("[SQS 피드백 결과 Subscriber 시작] queueUrl={}", queueUrl);
+    }
+
+    public void pollMessages() {
+        try {
+            ReceiveMessageRequest request = new ReceiveMessageRequest(queueUrl)
+                    .withMaxNumberOfMessages(MAX_MESSAGES)
+                    .withWaitTimeSeconds(WAIT_TIME_SECONDS);
+
+            List<Message> messages = sqs.receiveMessage(request).getMessages();
+
+            for (Message message : messages) {
+                String body = message.getBody();
+                log.info("[SQS 피드백 결과 수신] messageId={}, body={}", message.getMessageId(), body);
+
+                try {
+                    FeedbackResultRequestDto dto = objectMapper.readValue(body, FeedbackResultRequestDto.class);
+
+                    if (dto.isSuccessResult()) {
+                        feedbackResultService.receiveFeedback(dto);
+
+                    } else if (dto.isRecoverableHttpError()) {
+                        log.warn("[AI 처리 오류 응답] memberId={}, httpStatus={}", dto.memberId(), dto.content());
+
+                        LocalDate monday = getLastWeekStart();
+                        LocalDate sunday = monday.plusDays(6);
+
+                        AiFeedbackCreationRequestDto retryDto =
+                                feedbackDtoAssembler.assemble(dto.memberId(), monday, sunday);
+
+                        aiFeedbackPublisher.publishAsyncWithRetry(retryDto);
+                        log.info("[SQS 피드백 요청 재발행 완료] memberId={}, monday={}, sunday={}", dto.memberId(), monday, sunday);
+
+                    } else {
+                        log.error("[알 수 없는 content 값] content={}, memberId={}", dto.content(), dto.memberId());
+                    }
+
+                    sqs.deleteMessage(new DeleteMessageRequest(queueUrl, message.getReceiptHandle()));
+
+                } catch (CustomException e) {
+                    if (e.getErrorCode() == FeedbackErrorCode.ALREADY_FEEDBACK_EXISTS) {
+                        log.warn("[중복된 피드백 응답] memberId={}, 무시하고 삭제", e.getMessage());
+                        sqs.deleteMessage(new DeleteMessageRequest(queueUrl, message.getReceiptHandle()));
+                    } else {
+                        log.error("[처리 실패 - CustomException] {}", e.getMessage(), e);
+                    }
+                } catch (Exception e) {
+                    log.error("[처리 실패 - Exception]", e);
+                }
+            }
+        } catch (Exception e) {
+            log.error("[SQS Polling 실패] {}", e.getMessage(), e);
+        }
+    }
+
+    private LocalDate getLastWeekStart() {
+        return LocalDate.now().with(DayOfWeek.MONDAY).minusWeeks(1);
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/subscriber/GcpAiFeedbackResultDlqSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/subscriber/GcpAiFeedbackResultDlqSubscriber.java
@@ -12,6 +12,7 @@ import ktb.leafresh.backend.domain.member.domain.entity.Member;
 import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +21,7 @@ import java.time.LocalDateTime;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Profile("!eks")
 public class GcpAiFeedbackResultDlqSubscriber {
 
     private final Environment environment;

--- a/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/subscriber/GcpAiFeedbackResultSubscriber.java
+++ b/src/main/java/ktb/leafresh/backend/domain/feedback/infrastructure/subscriber/GcpAiFeedbackResultSubscriber.java
@@ -14,6 +14,7 @@ import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.FeedbackErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +24,7 @@ import java.time.LocalDate;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Profile("!eks")
 public class GcpAiFeedbackResultSubscriber {
 
     private final Environment environment;

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/publisher/AwsAiVerificationSqsPublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/publisher/AwsAiVerificationSqsPublisher.java
@@ -3,25 +3,33 @@ package ktb.leafresh.backend.domain.verification.infrastructure.publisher;
 import com.amazonaws.services.sqs.AmazonSQSAsync;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import ktb.leafresh.backend.domain.member.domain.entity.Member;
+import ktb.leafresh.backend.domain.member.infrastructure.repository.MemberRepository;
+import ktb.leafresh.backend.domain.verification.domain.entity.VerificationFailureLog;
 import ktb.leafresh.backend.domain.verification.infrastructure.dto.request.AiVerificationRequestDto;
+import ktb.leafresh.backend.domain.verification.infrastructure.repository.VerificationFailureLogRepository;
+import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @Component
-@Profile("eks")
 @Slf4j
+@Profile("eks")
 @RequiredArgsConstructor
 public class AwsAiVerificationSqsPublisher implements AiVerificationPublisher {
 
     private final AmazonSQSAsync amazonSQSAsync;
     private final ObjectMapper objectMapper;
+    private final MemberRepository memberRepository;
+    private final VerificationFailureLogRepository failureLogRepository;
 
     @Value("${aws.sqs.verification-request-queue-url}")
     private String queueUrl;
@@ -34,10 +42,11 @@ public class AwsAiVerificationSqsPublisher implements AiVerificationPublisher {
     @Override
     public void publishAsyncWithRetry(AiVerificationRequestDto dto) {
         try {
-            String messageBody = objectMapper.writeValueAsString(dto);
-            sendWithRetry(messageBody, dto, 1);
+            String json = objectMapper.writeValueAsString(dto);
+            sendWithRetry(json, dto, 1);
         } catch (JsonProcessingException e) {
-            log.error("[SQS 직렬화 실패]", e);
+            log.error("[AI 인증 직렬화 실패]", e);
+            logFailure(dto, null, "직렬화 실패: " + e.getMessage());
         }
     }
 
@@ -52,8 +61,28 @@ public class AwsAiVerificationSqsPublisher implements AiVerificationPublisher {
                 long backoff = INITIAL_BACKOFF_MS * (1L << (attempt - 1));
                 scheduler.schedule(() -> sendWithRetry(body, dto, attempt + 1), backoff, TimeUnit.MILLISECONDS);
             } else {
-                log.error("[SQS 인증 요청 발행 최종 실패] dto={}", dto);
+                log.error("[SQS 인증 발행 최종 실패] dto={}, error={}", body, e.getMessage());
+                logFailure(dto, body, "최대 재시도 초과: " + e.getMessage());
             }
+        }
+    }
+
+    private void logFailure(AiVerificationRequestDto dto, String json, String reason) {
+        try {
+            Member member = memberRepository.findById(dto.memberId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+            failureLogRepository.save(VerificationFailureLog.builder()
+                    .member(member)
+                    .challengeType(dto.type() != null ? dto.type() : ChallengeType.GROUP)
+                    .challengeId(dto.challengeId())
+                    .verificationId(dto.verificationId())
+                    .reason(reason)
+                    .requestBody(json != null ? json : "{}")
+                    .occurredAt(LocalDateTime.now())
+                    .build());
+        } catch (Exception e) {
+            log.warn("[FailureLog 저장 실패] {}", e.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 작업 내용
- 기존 GCP Pub/Sub 기반 피드백 결과 수신 로직과 동작을 동일하게 유지하면서 AWS SQS 환경에서 작동하는 클래스를 추가 구현하였습니다.
- eks 프로파일 여부에 따라 GCP와 AWS의 subscriber가 분기되어 동작하도록 구성했습니다.
- DLQ 처리, 피드백 발행 로직도 SQS용으로 분리하여 유연한 클라우드 전환 또는 멀티 클라우드 대응이 가능하게 하였습니다.

## 주요 변경 사항
- AwsAiFeedbackResultSubscriber: SQS 기반 피드백 결과 메시지 처리 로직 구현
- AwsAiFeedbackResultDlqSubscriber: SQS 기반 DLQ 메시지 처리 구현
- AwsAiFeedbackSqsPublisher: 피드백 요청 SQS 발행 로직 구현
- AiFeedbackPublisher: 인터페이스 역할 수행