### PR TITLE
refactor: 환경별 lock-image-url 설정 분리 및 @Value 키 통일

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/member/application/service/BadgeReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/member/application/service/BadgeReadService.java
@@ -26,7 +26,7 @@ public class BadgeReadService {
     private final BadgeRepository badgeRepository;
     private final MemberRepository memberRepository;
 
-    @Value("${gcp.storage.lock-image-url}")
+    @Value("${lock-image-url}")
     private String lockImageUrl;
 
     public BadgeListResponseDto getAllBadges(Long memberId) {

--- a/src/main/resources/application-docker-local.yml
+++ b/src/main/resources/application-docker-local.yml
@@ -27,7 +27,6 @@ gcp:
     location: classpath:${GCP_CREDENTIALS_LOCATION}
   storage:
     bucket: ${GCP_STORAGE_BUCKET}
-    lock-image-url: ${LOCK_IMAGE_URL}
   pubsub:
     topics:
       order: ${GCP_PUBSUB_TOPIC_ORDER}
@@ -40,3 +39,5 @@ gcp:
       verification-dlq: ${GCP_PUBSUB_SUBSCRIPTION_IMAGE_VERIFICATION_RESULT_DLQ}
       feedback-result: ${GCP_PUBSUB_SUBSCRIPTION_FEEDBACK_RESULT}
       feedback-result-dlq: ${GCP_PUBSUB_SUBSCRIPTION_FEEDBACK_DLQ}
+
+lock-image-url: ${LOCK_IMAGE_URL}

--- a/src/main/resources/application-docker-prod.yml
+++ b/src/main/resources/application-docker-prod.yml
@@ -27,7 +27,6 @@ gcp:
     location: classpath:${GCP_CREDENTIALS_LOCATION}
   storage:
     bucket: ${GCP_STORAGE_BUCKET}
-    lock-image-url: ${LOCK_IMAGE_URL}
   pubsub:
     topics:
       order: ${GCP_PUBSUB_TOPIC_ORDER}
@@ -40,3 +39,5 @@ gcp:
       verification-dlq: ${GCP_PUBSUB_SUBSCRIPTION_IMAGE_VERIFICATION_RESULT_DLQ}
       feedback-result: ${GCP_PUBSUB_SUBSCRIPTION_FEEDBACK_RESULT}
       feedback-result-dlq: ${GCP_PUBSUB_SUBSCRIPTION_FEEDBACK_DLQ}
+
+lock-image-url: ${LOCK_IMAGE_URL}

--- a/src/main/resources/application-eks.yml
+++ b/src/main/resources/application-eks.yml
@@ -34,7 +34,6 @@ cloud:
 aws:
   s3:
     bucket: ${AWS_S3_BUCKET}
-    lock-image-url: ${LOCK_IMAGE_URL}
   sqs:
     feedback-request-queue-url: ${AWS_SQS_FEEDBACK_REQUEST_QUEUE_URL}
     feedback-result-queue-url: ${AWS_SQS_FEEDBACK_RESULT_QUEUE_URL}
@@ -46,3 +45,5 @@ aws:
 
     order-request-queue-url: ${AWS_SQS_ORDER_REQUEST_QUEUE_URL}
     order-dlq-queue-url: ${AWS_SQS_ORDER_DLQ_QUEUE_URL}
+
+lock-image-url: ${LOCK_IMAGE_URL}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -40,7 +40,6 @@ gcp:
     location: classpath:${GCP_CREDENTIALS_LOCATION}
   storage:
     bucket: ${GCP_STORAGE_BUCKET}
-    lock-image-url: ${LOCK_IMAGE_URL}
   pubsub:
     topics:
       order: ${GCP_PUBSUB_TOPIC_ORDER}
@@ -60,3 +59,5 @@ logging:
     org.hibernate.stat: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+lock-image-url: ${LOCK_IMAGE_URL}


### PR DESCRIPTION
환경(dev, prod)에 따라 lock-image-url을 외부 설정값으로 주입할 수 있도록 분리 설정하였습니다.  
또한, 기존 BadgeReadService에서 사용하던 @Value 키 `${gcp.storage.lock-image-url}`을 `${lock-image-url}`로 통일하여  
환경 프로파일에 따라 일관되게 주입되도록 수정하였습니다.

## 변경 사항
- `application-local.yml`, `application-docker-local.yml`, `application-docker-prod.yml`, `application-eks.yml`에서
  - `gcp.storage.lock-image-url: ${LOCK_IMAGE_URL}` → `lock-image-url: ${LOCK_IMAGE_URL}` 위치 변경
- `BadgeReadService.java`
  - `@Value("${gcp.storage.lock-image-url}")` → `@Value("${lock-image-url}")`로 수정하여 키 통일

## 기대 효과
- 환경에 따라 서로 다른 `lockImageUrl` 주입 가능 (ex. dev는 S3, prod는 GCS)
- 잘못된 프로퍼티 경로로 인한 주입 실패 방지
- 유지보수 및 설정 관리 간결화