### PR TITLE
fix: 단체 챌린지 상세 조회 시 참여 상태 판단 기준을 인증 여부 → 참가 기록 여부로 수정

### DIFF
--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeDetailReadService.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/application/service/GroupChallengeDetailReadService.java
@@ -24,6 +24,7 @@ public class GroupChallengeDetailReadService {
 
     private final GroupChallengeRepository groupChallengeRepository;
     private final GroupChallengeVerificationRepository verificationRepository;
+    private final GroupChallengeParticipantRecordRepository participantRecordRepository;
     private final Clock clock;
 
     public GroupChallengeDetailResponseDto getChallengeDetail(Long memberIdOrNull, Long challengeId) {
@@ -75,11 +76,8 @@ public class GroupChallengeDetailReadService {
         GroupChallenge challenge = getChallengeOrThrow(challengeId);
 
         // 참가 여부 확인
-        boolean hasParticipated = verificationRepository
-                .existsByParticipantRecord_Member_IdAndParticipantRecord_GroupChallenge_Id(
-                        memberIdOrNull,
-                        challengeId
-                );
+        boolean hasParticipated = participantRecordRepository
+                .existsByMember_IdAndGroupChallenge_Id(memberIdOrNull, challengeId);
 
         if (!hasParticipated) {
             return ChallengeStatus.NOT_PARTICIPATED;

--- a/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeParticipantRecordRepository.java
+++ b/src/main/java/ktb/leafresh/backend/domain/challenge/group/infrastructure/repository/GroupChallengeParticipantRecordRepository.java
@@ -32,4 +32,6 @@ public interface GroupChallengeParticipantRecordRepository extends JpaRepository
     boolean existsSuccessInPastWeek(@Param("memberId") Long memberId, @Param("oneWeekAgo") LocalDateTime oneWeekAgo);
 
     List<GroupChallengeParticipantRecord> findAllByMemberId(Long memberId);
+
+    boolean existsByMember_IdAndGroupChallenge_Id(Long memberId, Long groupChallengeId);
 }


### PR DESCRIPTION
기존에는 인증(Verification)이 존재하는 경우에만 참여한 것으로 간주되어,
참여하기 버튼만 누르고 인증하지 않은 경우에도 NOT_PARTICIPATED로 표시되는 문제가 있었습니다.

이를 해결하기 위해 resolveChallengeStatus() 메서드 내 로직을
ParticipantRecord 존재 여부로 판단하도록 수정하였습니다.
