### PR TITLE
feat(sqs): SQS FIFO 큐 message group id 추가, deduplication ID를 SHA-256 기반으로 통일

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,9 @@ dependencies {
 	// AWS
 	implementation("com.amazonaws:aws-java-sdk-s3:1.12.700")
 	implementation("com.amazonaws:aws-java-sdk-sqs:1.12.700")
+
+	// sha256
+	implementation 'commons-codec:commons-codec:1.15'
 }
 
 dependencyManagement {

--- a/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/publisher/AwsPurchaseMessagePublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/store/order/infrastructure/publisher/AwsPurchaseMessagePublisher.java
@@ -1,6 +1,7 @@
 package ktb.leafresh.backend.domain.store.order.infrastructure.publisher;
 
 import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import ktb.leafresh.backend.domain.store.order.application.dto.PurchaseCommand;
@@ -8,6 +9,7 @@ import ktb.leafresh.backend.global.exception.CustomException;
 import ktb.leafresh.backend.global.exception.PurchaseErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -28,7 +30,14 @@ public class AwsPurchaseMessagePublisher implements PurchaseMessagePublisher {
     public void publish(PurchaseCommand command) {
         try {
             String message = objectMapper.writeValueAsString(command);
-            sqs.sendMessage(queueUrl, message);
+            SendMessageRequest request = new SendMessageRequest()
+                    .withQueueUrl(queueUrl)
+                    .withMessageBody(message)
+                    .withMessageGroupId("purchase")
+                    .withMessageDeduplicationId(generateDeduplicationId(message, command.memberId()));
+
+            sqs.sendMessage(request);
+
             log.info("[SQS 메시지 발행 성공] {}", message);
         } catch (JsonProcessingException e) {
             log.error("[SQS 직렬화 실패]", e);
@@ -37,5 +46,9 @@ public class AwsPurchaseMessagePublisher implements PurchaseMessagePublisher {
             log.error("[SQS 발행 실패]", e);
             throw new CustomException(PurchaseErrorCode.PURCHASE_PUBLISH_FAILED);
         }
+    }
+
+    private String generateDeduplicationId(String body, Long memberId) {
+        return memberId + "-" + DigestUtils.sha256Hex(body);
     }
 }

--- a/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/publisher/AwsAiVerificationSqsPublisher.java
+++ b/src/main/java/ktb/leafresh/backend/domain/verification/infrastructure/publisher/AwsAiVerificationSqsPublisher.java
@@ -1,6 +1,7 @@
 package ktb.leafresh.backend.domain.verification.infrastructure.publisher;
 
 import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import ktb.leafresh.backend.domain.member.domain.entity.Member;
@@ -11,6 +12,7 @@ import ktb.leafresh.backend.domain.verification.infrastructure.repository.Verifi
 import ktb.leafresh.backend.global.common.entity.enums.ChallengeType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -56,7 +58,14 @@ public class AwsAiVerificationSqsPublisher implements AiVerificationPublisher {
 
     private void sendWithRetry(String body, AiVerificationRequestDto dto, int attempt) {
         try {
-            amazonSQSAsync.sendMessage(queueUrl, body);
+            SendMessageRequest request = new SendMessageRequest()
+                    .withQueueUrl(queueUrl)
+                    .withMessageBody(body)
+                    .withMessageGroupId("group-challenge-verification")
+                    .withMessageDeduplicationId(generateDeduplicationId(body, dto.memberId()));
+
+            amazonSQSAsync.sendMessage(request);
+
             log.info("[SQS 인증 요청 발행 성공] attempt={}, dto={}", attempt, body);
         } catch (Exception e) {
             log.warn("[SQS 인증 요청 발행 실패] attempt={}, error={}", attempt, e.getMessage());
@@ -88,5 +97,9 @@ public class AwsAiVerificationSqsPublisher implements AiVerificationPublisher {
         } catch (Exception e) {
             log.warn("[FailureLog 저장 실패] {}", e.getMessage());
         }
+    }
+
+    private String generateDeduplicationId(String body, Long memberId) {
+        return memberId + "-" + DigestUtils.sha256Hex(body);
     }
 }


### PR DESCRIPTION
SQS FIFO 큐 사용 시 필수적으로 필요한 `MessageGroupId`와 `MessageDeduplicationId`를 모든 퍼블리셔에서 명시적으로 설정하도록 통일하였습니다.

- `MessageDeduplicationId`는 기존 System.currentTimeMillis() 기반 → SHA-256 해시 기반으로 변경하였습니다.
    - 해시 대상: 메시지 body + memberId 조합
    - 라이브러리: commons-codec 1.15 (`DigestUtils.sha256Hex(...)`)
- `MessageGroupId`는 각 도메인별로 상수 지정:
    - 인증 요청: `"group-challenge-verification"`
    - 피드백 요청: `"feedback-request"`
    - 주문 요청: `"purchase"`

이 변경을 통해 네트워크 재시도나 컨슈머 오류 발생 시에도 중복 메시지 발행을 최소화하며, FIFO 큐의 목적에 부합하는 메시지 흐름을 보장합니다.

- 관련 클래스:
  - `AwsAiVerificationSqsPublisher`
  - `AwsAiFeedbackSqsPublisher`
  - `AwsPurchaseMessagePublisher`

- 기타:
  - `build.gradle`에 SHA-256 계산을 위한 `commons-codec` 의존성 추가
