### PR TITLE
feat: Swagger 문서 자동 배포 인프라 추가

### DIFF
--- a/.github/workflows/swagger-deploy.yml
+++ b/.github/workflows/swagger-deploy.yml
@@ -1,0 +1,168 @@
+name: Deploy Swagger Documentation
+
+on:
+  push:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'corretto'
+        
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+      
+    - name: Cache Gradle packages
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+          
+    - name: Build and extract Swagger JSON
+      run: |
+        # 애플리케이션 빌드
+        ./gradlew build -x test
+        
+        # 백그라운드에서 애플리케이션 시작
+        nohup java -jar build/libs/*.jar --spring.profiles.active=local \
+          --server.port=8080 \
+          --spring.datasource.url=jdbc:h2:mem:testdb \
+          --spring.datasource.driver-class-name=org.h2.Driver \
+          --spring.jpa.hibernate.ddl-auto=create-drop \
+          --jwt.secret=dummy-secret-for-documentation-generation-only-not-for-production-use \
+          --kakao.client-id=dummy \
+          --kakao.client-secret=dummy > app.log 2>&1 &
+        
+        # 애플리케이션이 시작될 때까지 대기
+        echo "Waiting for application to start..."
+        for i in {1..60}; do
+          if curl -s http://localhost:8080/actuator/health > /dev/null; then
+            echo "Application is ready!"
+            break
+          fi
+          echo "Waiting... ($i/60)"
+          sleep 5
+        done
+        
+        # Swagger JSON 다운로드
+        curl -o swagger.json http://localhost:8080/v3/api-docs
+        
+        # 애플리케이션 종료
+        pkill -f "java -jar"
+        
+    - name: Create Swagger UI
+      run: |
+        mkdir -p docs
+        
+        # Swagger UI 파일들 생성
+        cat > docs/index.html << 'EOF'
+        <!DOCTYPE html>
+        <html lang="ko">
+        <head>
+          <meta charset="UTF-8">
+          <title>Leafresh API Documentation</title>
+          <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui.css" />
+          <style>
+            html {
+              box-sizing: border-box;
+              overflow: -moz-scrollbars-vertical;
+              overflow-y: scroll;
+            }
+            *, *:before, *:after {
+              box-sizing: inherit;
+            }
+            body {
+              margin:0;
+              background: #fafafa;
+            }
+          </style>
+        </head>
+        <body>
+          <div id="swagger-ui"></div>
+          <script src="https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui-bundle.js"></script>
+          <script src="https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui-standalone-preset.js"></script>
+          <script>
+            window.onload = function() {
+              const ui = SwaggerUIBundle({
+                url: './swagger.json',
+                dom_id: '#swagger-ui',
+                deepLinking: true,
+                presets: [
+                  SwaggerUIBundle.presets.apis,
+                  SwaggerUIStandalonePreset
+                ],
+                plugins: [
+                  SwaggerUIBundle.plugins.DownloadUrl
+                ],
+                layout: "StandaloneLayout"
+              });
+            };
+          </script>
+        </body>
+        </html>
+        EOF
+        
+        # Swagger JSON 파일 복사
+        cp swagger.json docs/
+        
+        # README 생성
+        cat > docs/README.md << 'EOF'
+        # Leafresh API Documentation
+        
+        이 페이지는 Leafresh 백엔드 API의 문서입니다.
+        
+        ## 사용 방법
+        
+        - [API 문서 보기](https://100-hours-a-week.github.io/15-Leafresh-BE/)
+        - [Swagger JSON 다운로드](https://100-hours-a-week.github.io/15-Leafresh-BE/swagger.json)
+        
+        ## API 엔드포인트
+        
+        ### 개발 환경
+        - Base URL: `https://springboot.dev-leafresh.app`
+        - Swagger UI: `https://springboot.dev-leafresh.app/swagger-ui.html`
+        
+        ### 프로덕션 환경
+        - Base URL: `https://api.leafresh.app`
+        - Swagger UI: `https://api.leafresh.app/swagger-ui.html`
+        
+        ## 인증
+        
+        대부분의 API는 JWT 토큰 인증이 필요합니다. 다음 헤더를 포함하여 요청하세요:
+        
+        ```
+        Authorization: Bearer YOUR_JWT_TOKEN
+        ```
+        
+        ## 주요 API 그룹
+        
+        - **인증 (Auth)**: 로그인, 로그아웃, 토큰 갱신
+        - **멤버 (Members)**: 사용자 관리
+        - **챌린지 (Challenges)**: 개인/그룹 챌린지 관리
+        - **검증 (Verifications)**: AI 기반 활동 검증
+        - **상점 (Store)**: 상품 및 주문 관리
+        - **챗봇 (Chatbot)**: AI 추천 서비스
+        - **이미지 (Images)**: 이미지 업로드 및 관리
+        EOF
+        
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs
+        publish_branch: gh-pages
+        force_orphan: true

--- a/README.md
+++ b/README.md
@@ -200,6 +200,60 @@ docker-compose -f docker-compose-local.yml up -d
 ./gradlew k6Test
 ```
 
+## API Documentation
+
+### Swagger UI Access
+
+**Development Environment**
+- Swagger UI: https://springboot.dev-leafresh.app/swagger-ui.html
+- OpenAPI JSON: https://springboot.dev-leafresh.app/v3/api-docs
+
+**Production Environment**
+- Swagger UI: https://api.leafresh.app/swagger-ui.html
+- OpenAPI JSON: https://api.leafresh.app/v3/api-docs
+
+**Local Development**
+```bash
+# Run Swagger documentation server
+./scripts/run-swagger.sh
+# Access at http://localhost:8080/swagger-ui.html
+```
+
+**Generate Swagger Documentation**
+```bash
+# Build application and start documentation server
+./gradlew runSwagger
+
+# Or use the shell script for a better experience
+chmod +x scripts/run-swagger.sh
+./scripts/run-swagger.sh
+```
+
+### GitHub Pages Documentation
+
+The API documentation is automatically deployed to GitHub Pages:
+- **Live Documentation**: https://100-hours-a-week.github.io/15-Leafresh-BE/
+- **Raw OpenAPI JSON**: https://100-hours-a-week.github.io/15-Leafresh-BE/swagger.json
+
+The documentation is automatically updated whenever changes are pushed to the `main` or `develop` branches.
+
+### API Overview
+
+**Authentication Required**
+Most endpoints require JWT token authentication. Include the following header:
+```
+Authorization: Bearer YOUR_JWT_TOKEN
+```
+
+**Main API Groups**
+- **인증 (Auth)**: OAuth2 로그인, JWT 토큰 관리
+- **멤버 (Members)**: 사용자 프로필, 배지, 포인트 관리
+- **챌린지 (Challenges)**: 개인/그룹 챌린지 CRUD 및 참여
+- **검증 (Verifications)**: AI 기반 이미지 검증 및 피드백
+- **상점 (Store)**: 상품 관리 및 주문 처리
+- **챗봇 (Chatbot)**: AI 기반 챌린지 추천
+- **이미지 (Images)**: 파일 업로드 및 관리
+
 ## Deployment
 
 ### Container Build

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,12 @@ dependencies {
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	// Database
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	
+	// H2 for documentation generation
+	implementation 'com.h2database:h2'
+	
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -177,4 +182,50 @@ tasks.named('test') {
 tasks.named('asciidoctor') {
 	inputs.dir snippetsDir
 	dependsOn test
+}
+
+// Swagger JSON 생성을 위한 태스크
+task generateSwaggerDocs(type: JavaExec) {
+	group = 'documentation'
+	description = 'Generate Swagger/OpenAPI documentation'
+	
+	classpath = sourceSets.main.runtimeClasspath
+	mainClass = 'ktb.leafresh.backend.BackendApplication'
+	
+	systemProperty 'spring.profiles.active', 'local'
+	systemProperty 'server.port', '0'  // 랜덤 포트 사용
+	systemProperty 'spring.datasource.url', 'jdbc:h2:mem:testdb'
+	systemProperty 'spring.datasource.driver-class-name', 'org.h2.Driver'
+	systemProperty 'spring.jpa.hibernate.ddl-auto', 'create-drop'
+	systemProperty 'jwt.secret', 'dummy-secret-for-documentation-generation-only'
+	systemProperty 'kakao.client-id', 'dummy'
+	systemProperty 'kakao.client-secret', 'dummy'
+	
+	doFirst {
+		mkdir "${buildDir}/swagger"
+	}
+}
+
+// 로컬에서 Swagger UI 실행하는 태스크
+task runSwagger(type: JavaExec) {
+	group = 'application'
+	description = 'Run application with Swagger UI for documentation'
+	
+	classpath = sourceSets.main.runtimeClasspath
+	mainClass = 'ktb.leafresh.backend.BackendApplication'
+	
+	systemProperty 'spring.profiles.active', 'local'
+	systemProperty 'server.port', '8080'
+	systemProperty 'spring.datasource.url', 'jdbc:h2:mem:testdb'
+	systemProperty 'spring.datasource.driver-class-name', 'org.h2.Driver'
+	systemProperty 'spring.jpa.hibernate.ddl-auto', 'create-drop'
+	systemProperty 'jwt.secret', 'dummy-secret-for-documentation-generation-only'
+	systemProperty 'kakao.client-id', 'dummy'
+	systemProperty 'kakao.client-secret', 'dummy'
+	
+	doFirst {
+		println "Starting Swagger UI server..."
+		println "Access Swagger UI at: http://localhost:8080/swagger-ui.html"
+		println "API Docs JSON at: http://localhost:8080/v3/api-docs"
+	}
 }

--- a/scripts/run-swagger.sh
+++ b/scripts/run-swagger.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# Leafresh Swagger 문서 서버 실행 스크립트
+
+set -e
+
+echo "🌱 Leafresh Swagger 문서 서버를 시작합니다..."
+
+# 색상 정의
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# 환경 변수 체크
+check_requirements() {
+    echo "📋 시스템 요구사항을 확인합니다..."
+    
+    if ! command -v java &> /dev/null; then
+        echo -e "${RED}❌ Java가 설치되지 않았습니다.${NC}"
+        echo "Java 21을 설치해주세요."
+        exit 1
+    fi
+    
+    java_version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | cut -d. -f1)
+    if [ "$java_version" -lt 21 ]; then
+        echo -e "${RED}❌ Java 21 이상이 필요합니다. 현재 버전: Java $java_version${NC}"
+        exit 1
+    fi
+    
+    echo -e "${GREEN}✅ Java $java_version 확인됨${NC}"
+}
+
+# 애플리케이션 빌드
+build_application() {
+    echo "🔨 애플리케이션을 빌드합니다..."
+    
+    if [ ! -f "./gradlew" ]; then
+        echo -e "${RED}❌ gradlew 파일을 찾을 수 없습니다. 프로젝트 루트 디렉토리에서 실행해주세요.${NC}"
+        exit 1
+    fi
+    
+    chmod +x ./gradlew
+    ./gradlew build -x test --quiet
+    
+    echo -e "${GREEN}✅ 빌드 완료${NC}"
+}
+
+# Swagger 서버 시작
+start_swagger_server() {
+    echo "🚀 Swagger 문서 서버를 시작합니다..."
+    
+    # H2 데이터베이스 사용하여 문서화 전용 서버 실행
+    java -jar build/libs/*.jar \
+        --spring.profiles.active=local \
+        --server.port=8080 \
+        --spring.datasource.url=jdbc:h2:mem:swagger \
+        --spring.datasource.driver-class-name=org.h2.Driver \
+        --spring.datasource.username=sa \
+        --spring.datasource.password= \
+        --spring.jpa.hibernate.ddl-auto=create-drop \
+        --spring.jpa.show-sql=false \
+        --jwt.secret=dummy-secret-for-documentation-generation-only-not-for-production \
+        --kakao.client-id=dummy \
+        --kakao.client-secret=dummy \
+        --logging.level.org.springframework.security=WARN \
+        --logging.level.ktb.leafresh.backend=WARN \
+        --logging.level.org.hibernate=WARN \
+        --logging.level.com.zaxxer.hikari=WARN &
+    
+    server_pid=$!
+    
+    # 서버 시작 대기
+    echo "⏳ 서버가 시작될 때까지 기다립니다..."
+    for i in {1..30}; do
+        if curl -s http://localhost:8080/actuator/health > /dev/null 2>&1; then
+            break
+        fi
+        sleep 2
+        echo -n "."
+    done
+    echo ""
+    
+    # 서버 상태 확인
+    if curl -s http://localhost:8080/actuator/health > /dev/null 2>&1; then
+        echo -e "${GREEN}✅ 서버가 성공적으로 시작되었습니다!${NC}"
+        echo ""
+        echo -e "${BLUE}📚 Swagger UI: ${YELLOW}http://localhost:8080/swagger-ui.html${NC}"
+        echo -e "${BLUE}📄 API Docs JSON: ${YELLOW}http://localhost:8080/v3/api-docs${NC}"
+        echo -e "${BLUE}🔍 Health Check: ${YELLOW}http://localhost:8080/actuator/health${NC}"
+        echo ""
+        echo -e "${YELLOW}💡 팁: Ctrl+C를 눌러 서버를 종료할 수 있습니다.${NC}"
+        echo ""
+        
+        # 종료 시그널 처리
+        trap "echo -e '\n${YELLOW}🛑 서버를 종료합니다...${NC}'; kill $server_pid; exit 0" INT TERM
+        
+        # 서버가 실행 중인 동안 대기
+        wait $server_pid
+    else
+        echo -e "${RED}❌ 서버 시작에 실패했습니다.${NC}"
+        kill $server_pid 2>/dev/null || true
+        exit 1
+    fi
+}
+
+# 메인 함수
+main() {
+    echo -e "${GREEN}"
+    echo "╔══════════════════════════════════════╗"
+    echo "║        🌱 Leafresh Swagger          ║"
+    echo "║      API Documentation Server       ║"
+    echo "╚══════════════════════════════════════╝"
+    echo -e "${NC}"
+    
+    check_requirements
+    build_application
+    start_swagger_server
+}
+
+# 도움말 표시
+show_help() {
+    echo "Leafresh Swagger 문서 서버 실행 스크립트"
+    echo ""
+    echo "사용법:"
+    echo "  $0                 Swagger 서버 시작"
+    echo "  $0 --help         도움말 표시"
+    echo ""
+    echo "서버가 시작되면 다음 URL에서 API 문서를 확인할 수 있습니다:"
+    echo "  - Swagger UI: http://localhost:8080/swagger-ui.html"
+    echo "  - API JSON: http://localhost:8080/v3/api-docs"
+}
+
+# 인자 처리
+case "${1:-}" in
+    --help|-h)
+        show_help
+        exit 0
+        ;;
+    *)
+        main
+        ;;
+esac


### PR DESCRIPTION
- GitHub Actions를 통한 Swagger 문서 자동 배포 워크플로우 추가
- 로컬 Swagger 문서 서버 실행을 위한 셸 스크립트 추가
- build.gradle에 Swagger 문서 생성 태스크 추가
- 문서 생성용 H2 데이터베이스 의존성 추가
- GitHub Pages API 문서 배포 설정 구성

GitHub Pages를 통한 API 문서 자동 배포와
로컬 개발용 Swagger UI 테스트 도구를 제공합니다.