### PR TITLE
fix: Optimize Gradle and Java settings for GitHub Actions comp…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,12 @@ plugins {
 
 group = 'ktb.leafresh'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '21'
-
 java {
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(21)
+		vendor = JvmVendorSpec.ORACLE
 	}
 }
 
@@ -24,7 +25,9 @@ configurations {
 
 repositories {
 	mavenCentral()
-	maven { url 'https://jitpack.io' }
+	maven { 
+		url = 'https://jitpack.io' 
+	}
 }
 
 ext {
@@ -137,6 +140,25 @@ jacoco {
 test {
 	useJUnitPlatform()
 	finalizedBy jacocoTestReport
+	
+	// CI 환경 최적화
+	systemProperty 'file.encoding', 'UTF-8'
+	systemProperty 'user.timezone', 'UTC'
+	systemProperty 'java.awt.headless', 'true'
+	
+	// 메모리 설정
+	minHeapSize = "512m"
+	maxHeapSize = "2g"
+	
+	// 테스트 실패 시 즉시 중단하지 않고 모든 테스트 실행
+	ignoreFailures = false
+	
+	// 테스트 로그 레벨
+	testLogging {
+		events "passed", "skipped", "failed"
+		exceptionFormat "full"
+		showStandardStreams = false
+	}
 }
 
 jacocoTestReport {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,10 @@
+# Gradle Configuration
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configureondemand=true
+
+# JVM Compatibility Settings
+systemProp.java.awt.headless=true
+systemProp.file.encoding=UTF-8
+systemProp.user.timezone=UTC

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,15 +8,23 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create-drop
-    show-sql: true
+    show-sql: false  # CI 환경에서 SQL 로그 줄이기
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
   h2:
     console:
-      enabled: true
+      enabled: false  # CI 환경에서 불필요한 기능 비활성화
   sql:
     init:
       mode: never
 
 # H2 Mode=MySQL enables MySQL compatibility including DATEDIFF function
+
+# CI 환경을 위한 로깅 설정
+logging:
+  level:
+    org.hibernate: WARN
+    org.springframework: WARN
+    org.testcontainers: WARN
+    ktb.leafresh: DEBUG


### PR DESCRIPTION
- Fix Java 21 compatibility with Oracle JDK vendor specification
- Add gradle.properties with optimized JVM settings and build configurations
- Update deprecated Gradle DSL syntax (maven url assignment)
- Optimize test environment settings for CI
- Add memory and performance tuning for tests
- Fix encoding issues in gradle.properties comments

Changes:
- build.gradle: Java toolchain, memory settings, test optimization
- gradle.properties: Global Gradle configuration for CI/CD
- application-test.yml: Reduced logging for CI performance