### PR TITLE
fix: Configure test environment for GitHub Actions CI compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,9 @@ test {
 	systemProperty 'user.timezone', 'UTC'
 	systemProperty 'java.awt.headless', 'true'
 	
+	// 테스트 프로파일 명시적 설정
+	systemProperty 'spring.profiles.active', 'test'
+	
 	// 메모리 설정
 	minHeapSize = "512m"
 	maxHeapSize = "2g"
@@ -159,6 +162,13 @@ test {
 		exceptionFormat "full"
 		showStandardStreams = false
 	}
+	
+	// CI 환경에서 테스트 타임아웃 설정
+	timeout = Duration.ofMinutes(30)
+	
+	// Docker 테스트컨테이너가 CI 환경에서 작동하도록 설정
+	systemProperty 'testcontainers.reuse.enable', 'false'
+	systemProperty 'testcontainers.ryuk.disabled', 'true'
 }
 
 jacocoTestReport {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
     username: sa
     password: 
@@ -12,6 +12,7 @@ spring:
     properties:
       hibernate:
         format_sql: false
+        globally_quoted_identifiers: true
   h2:
     console:
       enabled: false  # CI 환경에서 불필요한 기능 비활성화
@@ -27,4 +28,14 @@ logging:
     org.hibernate: WARN
     org.springframework: WARN
     org.testcontainers: WARN
-    ktb.leafresh: DEBUG
+    ktb.leafresh: INFO
+
+# JWT 테스트용 설정 (테스트 실패 방지)
+jwt:
+  secret: test-secret-key-for-unit-tests-minimum-length-32-characters-long-enough
+  expiration: 3600000
+
+# OAuth 테스트용 설정 (테스트 실패 방지)
+kakao:
+  client-id: test-client-id
+  client-secret: test-client-secret


### PR DESCRIPTION
- Add testcontainers CI settings to prevent hanging processes
- Configure test timeout to prevent infinite wait in CI
- Set explicit test profile for consistent environment
- Add JWT/OAuth dummy configurations for test stability
- Improve H2 database connection settings for CI

Changes:
- build.gradle: Add CI-specific test configurations and timeout
- application-test.yml: Add missing test configurations for JWT/OAuth