### PR TITLE
feat: Add automated Swagger documentation deployment with API diff

### DIFF
--- a/.github/workflows/openapi-extract.yml
+++ b/.github/workflows/openapi-extract.yml
@@ -1,0 +1,85 @@
+name: openapi-extract and diff with develop
+
+# GitHub Pages 설정 필요:
+# Repository Settings -> Pages -> Source: Deploy from a branch -> gh-pages branch
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types: [ closed ]
+
+jobs:
+  build-main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main # main 브랜치
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Generate OpenAPI spec for main
+        run: ./gradlew clean generateOpenApiDocs
+
+      - uses: actions/upload-artifact@v4 # 아티팩트 업로드
+        with:
+          name: main-spec
+          path: build/openapi.json
+
+      - name: Swagger UI Action
+        uses: Legion2/swagger-ui-action@v1.3.0
+        with:
+          output: swagger-ui
+          spec-file: build/openapi.json
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3  #gh-pages 브랜치 root에 swagger-ui push
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: swagger-ui
+
+  build-develop:
+    runs-on: ubuntu-latest
+    needs: build-main
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop  # develop 브랜치와 비교
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Generate OpenAPI spec for develop
+        run: ./gradlew clean generateOpenApiDocs
+
+      - uses: actions/download-artifact@v4 # 아티팩트 다운로드
+        with:
+          name: main-spec
+          path: ./main
+
+      - name: List downloaded main artifact files # 경로 확인
+        run: ls -R ./main
+
+      - name: Run openapi-diff with docker # 도커 허브에서 이미지 사용
+        run: docker run --rm -v ${{ github.workspace }}:/specs openapitools/openapi-diff:latest /specs/main/openapi.json /specs/build/openapi.json --json /specs/diff.json
+
+      - name: Show diff result
+        run: |
+          echo "📊 API Diff Result (main vs develop):"
+          cat diff.json

--- a/README.md
+++ b/README.md
@@ -215,27 +215,32 @@ docker-compose -f docker-compose-local.yml up -d
 **Local Development**
 ```bash
 # Run Swagger documentation server
-./scripts/run-swagger.sh
+./gradlew runSwagger
 # Access at http://localhost:8080/swagger-ui.html
 ```
 
-**Generate Swagger Documentation**
+**Generate OpenAPI Documentation**
 ```bash
-# Build application and start documentation server
-./gradlew runSwagger
-
-# Or use the shell script for a better experience
-chmod +x scripts/run-swagger.sh
-./scripts/run-swagger.sh
+# Generate OpenAPI JSON file for deployment
+./gradlew generateOpenApiDocs
+# Output: build/openapi.json
 ```
 
 ### GitHub Pages Documentation
 
 The API documentation is automatically deployed to GitHub Pages:
 - **Live Documentation**: https://100-hours-a-week.github.io/15-Leafresh-BE/
-- **OpenAPI YAML**: https://100-hours-a-week.github.io/15-Leafresh-BE/swagger.yaml
+- **OpenAPI JSON**: Available after deployment via GitHub Actions
 
-The documentation is automatically updated whenever changes are pushed to the `main` branch or when the OpenAPI specification is updated.
+**Automatic Deployment**: The documentation is automatically updated when:
+- Changes are merged to the `main` branch
+- Pull requests are closed (triggers diff comparison)
+- Manual workflow dispatch is triggered
+
+**CI/CD Features**:
+- Automatic OpenAPI spec generation and comparison between prod/dev
+- Swagger UI deployment to GitHub Pages
+- API diff reporting for breaking changes detection
 
 ### API Overview
 

--- a/build.gradle
+++ b/build.gradle
@@ -234,25 +234,18 @@ bootJar {
 	}
 }
 
-// Swagger JSON 생성을 위한 태스크
-task generateSwaggerDocs(type: JavaExec) {
+// OpenAPI 문서 생성을 위한 태스크
+task generateOpenApiDocs(type: JavaExec) {
 	group = 'documentation'
-	description = 'Generate Swagger/OpenAPI documentation'
+	description = 'Generate OpenAPI documentation as JSON'
 	
 	classpath = sourceSets.main.runtimeClasspath
 	mainClass = 'ktb.leafresh.backend.BackendApplication'
 	
 	systemProperty 'spring.profiles.active', 'swagger'
-	systemProperty 'server.port', '0'  // 랜덤 포트 사용
-	systemProperty 'spring.datasource.url', 'jdbc:h2:mem:testdb'
-	systemProperty 'spring.datasource.driver-class-name', 'org.h2.Driver'
-	systemProperty 'spring.jpa.hibernate.ddl-auto', 'create-drop'
-	systemProperty 'jwt.secret', 'dummy-secret-for-documentation-generation-only-minimum-32-characters'
-	systemProperty 'kakao.client-id', 'dummy'
-	systemProperty 'kakao.client-secret', 'dummy'
 	
 	doFirst {
-		mkdir "${buildDir}/swagger"
+		file("${buildDir}").mkdirs()
 	}
 }
 
@@ -265,13 +258,6 @@ task runSwagger(type: JavaExec) {
 	mainClass = 'ktb.leafresh.backend.BackendApplication'
 	
 	systemProperty 'spring.profiles.active', 'swagger'
-	systemProperty 'server.port', '8080'
-	systemProperty 'spring.datasource.url', 'jdbc:h2:mem:testdb'
-	systemProperty 'spring.datasource.driver-class-name', 'org.h2.Driver'
-	systemProperty 'spring.jpa.hibernate.ddl-auto', 'create-drop'
-	systemProperty 'jwt.secret', 'dummy-secret-for-documentation-generation-only-minimum-32-characters'
-	systemProperty 'kakao.client-id', 'dummy'
-	systemProperty 'kakao.client-secret', 'dummy'
 	
 	doFirst {
 		println "Starting Swagger UI server..."

--- a/scripts/generate-swagger.sh
+++ b/scripts/generate-swagger.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Swagger 문서 생성 스크립트
+# Usage: ./scripts/generate-swagger.sh
+
+set -e
+
+echo "🚀 OpenAPI 문서 생성을 시작합니다..."
+
+# 프로젝트 루트 디렉토리로 이동
+cd "$(dirname "$0")/.."
+
+# 기존 build 디렉토리 정리
+echo "📁 기존 빌드 파일 정리 중..."
+rm -rf build/openapi.json
+
+# Gradle 빌드 및 OpenAPI 문서 생성
+echo "🔨 애플리케이션 빌드 중..."
+./gradlew clean build -x test
+
+echo "📄 OpenAPI 문서 생성 중..."
+# macOS에서 timeout 대신 background 실행 후 sleep 사용
+./gradlew generateOpenApiDocs &
+GRADLE_PID=$!
+
+# 60초 대기
+sleep 60
+
+# 프로세스가 아직 실행중이면 종료
+if kill -0 $GRADLE_PID 2>/dev/null; then
+    echo "⚠️ 시간 초과로 프로세스를 종료합니다..."
+    kill $GRADLE_PID 2>/dev/null || true
+    sleep 2
+    kill -9 $GRADLE_PID 2>/dev/null || true
+fi
+
+# 결과 확인
+if [ -f "build/openapi.json" ]; then
+    echo "✅ OpenAPI 문서 생성 완료!"
+    echo "📍 파일 위치: build/openapi.json"
+    echo "📊 파일 크기: $(du -h build/openapi.json | cut -f1)"
+    echo ""
+    echo "🔍 문서 정보:"
+    if command -v jq &> /dev/null; then
+        echo "  - Title: $(jq -r '.info.title // "N/A"' build/openapi.json)"
+        echo "  - Version: $(jq -r '.info.version // "N/A"' build/openapi.json)"
+        echo "  - Paths: $(jq '.paths | keys | length' build/openapi.json 2>/dev/null || echo "N/A")"
+    else
+        echo "  (jq가 설치되어 있지 않아 상세 정보를 표시할 수 없습니다)"
+    fi
+else
+    echo "❌ OpenAPI 문서 생성에 실패했습니다."
+    echo "💡 다음을 확인해보세요:"
+    echo "   - 애플리케이션이 정상적으로 시작되는지 확인"
+    echo "   - swagger 프로파일 설정이 올바른지 확인"
+    echo "   - 외부 의존성(Redis, MySQL 등) 설정 확인"
+    exit 1
+fi

--- a/scripts/run-swagger.sh
+++ b/scripts/run-swagger.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Swagger UI 로컬 실행 스크립트
+# Usage: ./scripts/run-swagger.sh [port]
+
+set -e
+
+# 포트 설정 (기본값: 8080)
+PORT=${1:-8080}
+
+echo "🚀 Swagger UI 서버를 시작합니다..."
+echo "📍 포트: $PORT"
+
+# 프로젝트 루트 디렉토리로 이동
+cd "$(dirname "$0")/.."
+
+# 기존 프로세스 종료
+echo "🧹 기존 프로세스 정리 중..."
+pkill -f "spring.profiles.active=swagger" 2>/dev/null || true
+
+# 애플리케이션 빌드
+echo "🔨 애플리케이션 빌드 중..."
+./gradlew build -x test
+
+# Swagger 프로파일로 실행
+echo "📄 Swagger UI 서버 시작 중..."
+echo "⏳ 서버 시작까지 잠시 대기해주세요..."
+echo ""
+echo "🔗 Swagger UI: http://localhost:$PORT/swagger-ui.html"
+echo "📋 OpenAPI JSON: http://localhost:$PORT/v3/api-docs"
+echo ""
+echo "⚠️  종료하려면 Ctrl+C를 눌러주세요"
+echo ""
+
+export SERVER_PORT=$PORT
+./gradlew runSwagger

--- a/src/main/java/ktb/leafresh/backend/global/config/OpenApiExportConfig.java
+++ b/src/main/java/ktb/leafresh/backend/global/config/OpenApiExportConfig.java
@@ -1,0 +1,99 @@
+package ktb.leafresh.backend.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Swagger 프로파일에서만 활성화되어 OpenAPI JSON 파일을 자동으로 생성하는 컴포넌트
+ */
+@Component
+@Profile("swagger")
+public class OpenApiExportConfig implements ApplicationListener<ApplicationReadyEvent> {
+
+    private final ObjectMapper objectMapper;
+    
+    @Value("${server.port:8080}")
+    private int serverPort;
+
+    public OpenApiExportConfig(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        // 별도 스레드에서 실행하여 애플리케이션 시작을 블록하지 않음
+        new Thread(() -> {
+            try {
+                extractOpenApiSpec();
+            } catch (Exception e) {
+                System.err.println("❌ OpenAPI spec 추출 중 오류 발생: " + e.getMessage());
+                e.printStackTrace();
+                System.exit(1);
+            }
+        }, "openapi-export-thread").start();
+    }
+
+    private void extractOpenApiSpec() throws IOException, InterruptedException {
+        System.out.println("🔄 OpenAPI 문서 생성을 시작합니다...");
+        
+        // 서버가 완전히 준비될 때까지 대기
+        int maxRetries = 30;
+        int retryCount = 0;
+        RestTemplate restTemplate = new RestTemplate();
+        
+        while (retryCount < maxRetries) {
+            try {
+                Thread.sleep(2000); // 2초 대기
+                
+                String apiUrl = "http://localhost:" + serverPort + "/v3/api-docs";
+                System.out.println("📡 API 문서 요청 중: " + apiUrl + " (시도 " + (retryCount + 1) + "/" + maxRetries + ")");
+                
+                String openApiJson = restTemplate.getForObject(apiUrl, String.class);
+                
+                if (openApiJson != null && !openApiJson.trim().isEmpty()) {
+                    saveOpenApiSpec(openApiJson);
+                    System.out.println("✅ OpenAPI 문서 생성 완료!");
+                    System.exit(0);
+                    return;
+                } else {
+                    throw new RuntimeException("빈 응답을 받았습니다");
+                }
+                
+            } catch (Exception e) {
+                retryCount++;
+                if (retryCount >= maxRetries) {
+                    throw new RuntimeException("최대 재시도 횟수 초과: " + e.getMessage(), e);
+                }
+                System.out.println("⚠️ 재시도 중... (" + retryCount + "/" + maxRetries + "): " + e.getMessage());
+            }
+        }
+    }
+    
+    private void saveOpenApiSpec(String openApiJson) throws IOException {
+        // JSON을 예쁘게 포맷팅
+        Object jsonObject = objectMapper.readValue(openApiJson, Object.class);
+        String prettyJson = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
+        
+        // build 디렉토리 생성
+        Files.createDirectories(Paths.get("build"));
+        
+        // build/openapi.json 파일로 저장
+        String outputPath = Paths.get("build", "openapi.json").toString();
+        try (FileWriter writer = new FileWriter(outputPath)) {
+            writer.write(prettyJson);
+        }
+        
+        System.out.println("📄 파일 저장 완료: " + outputPath);
+        System.out.println("📊 파일 크기: " + Files.size(Paths.get(outputPath)) + " bytes");
+    }
+}

--- a/src/main/resources/application-swagger.yml
+++ b/src/main/resources/application-swagger.yml
@@ -20,22 +20,21 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
         format_sql: false
-        
-  # 메시지 큐 비활성화
-  cloud:
-    gcp:
-      pubsub:
-        enabled: false
 
-  # Task Execution & Scheduling 비활성화
-  task:
-    execution:
-      pool:
-        core-size: 1
-        max-size: 1
-    scheduling:
-      pool:
-        size: 1
+  # Redis 비활성화
+  data:
+    redis:
+      repositories:
+        enabled: false
+        
+  # 자동 구성 제외
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
+      - org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubAutoConfiguration
+      - org.redisson.spring.starter.RedissonAutoConfiguration
 
 # Swagger UI 설정
 springdoc:
@@ -94,20 +93,10 @@ gcp:
   project-id: dummy-project
   pubsub:
     enabled: false
-    feedback:
-      topic: dummy-feedback-topic
-      subscription: dummy-feedback-subscription
-      dlq-subscription: dummy-feedback-dlq-subscription
-    verification:
-      topic: dummy-verification-topic
-      subscription: dummy-verification-subscription
-      dlq-subscription: dummy-verification-dlq-subscription
 
 # Redis 설정 (더미 값)
 redis:
   enabled: false
-  redisson:
-    address: "redis://localhost:6379"
   host: localhost
   port: 6379
 
@@ -124,21 +113,16 @@ ai:
 scheduling:
   enabled: false
 
-# ShedLock 비활성화
-shedlock:
-  defaults:
-    lock-at-most-for: PT30M
-    lock-at-least-for: PT5M
-
 logging:
   level:
     org.springframework.web: INFO
     org.springframework.security: INFO
-    org.springframework.cloud.gcp: WARN
-    com.google.cloud: WARN
     ktb.leafresh.backend: INFO
-    org.redisson: WARN
-    redis.clients.jedis: WARN
+    org.redisson: OFF
+    redis.clients.jedis: OFF
+    org.springframework.cloud.gcp: OFF
+    com.google.cloud: OFF
+    com.amazonaws: OFF
     
 # Management endpoints 설정 (Actuator)
 management:
@@ -149,11 +133,3 @@ management:
   endpoint:
     health:
       show-details: always
-      
-# 외부 의존성 Mock 활성화 플래그
-mock:
-  enabled: true
-  redis: true
-  aws: true
-  gcp: true
-  external-apis: true


### PR DESCRIPTION
- Add GitHub Actions workflow for OpenAPI spec generation and comparison
  - Compare main branch (production) vs develop branch APIs  
  - Auto-deploy Swagger UI to GitHub Pages on PR merge
  - Generate API diff reports using OpenAPI diff tool

- Update build.gradle with OpenAPI documentation tasks
  - Add generateOpenApiDocs task for JSON generation
  - Improve runSwagger task for local development
  - Remove unused springdoc-openapi-gradle-plugin

- Add OpenApiExportConfig for automated spec generation
  - Auto-generate OpenAPI JSON in swagger profile
  - Retry mechanism with proper error handling
  - Save formatted JSON to build/openapi.json

- Optimize swagger profile configuration
  - Disable external dependencies (Redis, AWS, GCP)
  - Use H2 in-memory database for documentation
  - Leverage existing SwaggerMockConfig for dependency mocking

- Add convenience scripts for local development
  - scripts/generate-swagger.sh: Generate OpenAPI documentation
  - scripts/run-swagger.sh: Run local Swagger UI server

- Update README.md with new documentation workflow
  - Document automated deployment process  
  - Add usage examples for local development
  - Explain CI/CD features and setup requirements

This enables automatic API documentation deployment and change tracking
between production and development environments, improving API governance
and developer experience.