### PR TITLE
feat: BloomFilter False Positive 확률 설정 구현

### DIFF
--- a/src/main/java/ktb/leafresh/backend/global/security/BloomFilterService.java
+++ b/src/main/java/ktb/leafresh/backend/global/security/BloomFilterService.java
@@ -1,0 +1,108 @@
+package ktb.leafresh.backend.global.security;
+
+import io.rebloom.client.Client;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Bloom Filter 초기화 및 관리 서비스
+ * False Positive 확률과 예상 삽입 수를 설정파일에서 읽어와 적용
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Getter
+@Profile("!swagger")
+public class BloomFilterService {
+
+    private final Client bloomClient;
+
+    @Value("${jwt.bloom-filter.key:accessTokenBlacklist}")
+    private String filterName;
+
+    @Value("${jwt.bloom-filter.expected-insertions:100000}")
+    private long expectedInsertions;
+
+    @Value("${jwt.bloom-filter.false-positive-probability:0.0001}")
+    private double falsePositiveProbability;
+
+    @PostConstruct
+    public void initializeBloomFilter() {
+        try {
+            // Bloom Filter 존재 여부 확인
+            if (!isFilterExists()) {
+                log.info("Bloom Filter 초기화 시작 - name: {}, expectedInsertions: {}, falsePositiveProbability: {}", 
+                    filterName, expectedInsertions, falsePositiveProbability);
+                
+                // BF.RESERVE 명령으로 Bloom Filter 생성 (확률과 용량 설정)
+                bloomClient.createFilter(filterName, expectedInsertions, falsePositiveProbability);
+                
+                log.info("Bloom Filter 초기화 완료 - 예상 False Positive 비율: {}%", 
+                    falsePositiveProbability * 100);
+            } else {
+                log.info("기존 Bloom Filter 사용 - name: {}", filterName);
+                logFilterInfo();
+            }
+        } catch (Exception e) {
+            log.error("Bloom Filter 초기화 실패", e);
+            throw new RuntimeException("Bloom Filter 초기화 실패", e);
+        }
+    }
+
+    /**
+     * Bloom Filter 존재 여부 확인
+     */
+    private boolean isFilterExists() {
+        try {
+            // BF.INFO 명령으로 필터 정보 확인
+            bloomClient.info(filterName);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Bloom Filter 정보 로깅
+     */
+    private void logFilterInfo() {
+        try {
+            var info = bloomClient.info(filterName);
+            log.info("현재 Bloom Filter 상태: {}", info);
+        } catch (Exception e) {
+            log.warn("Bloom Filter 정보 조회 실패", e);
+        }
+    }
+
+    /**
+     * 토큰을 Bloom Filter에 추가
+     */
+    public void addToken(String token) {
+        try {
+            bloomClient.add(filterName, token);
+            log.debug("토큰 추가됨 - token: {}", token);
+        } catch (Exception e) {
+            log.error("토큰 추가 실패 - token: {}", token, e);
+            throw new RuntimeException("Bloom Filter 토큰 추가 실패", e);
+        }
+    }
+
+    /**
+     * 토큰이 Bloom Filter에 존재할 가능성 확인
+     */
+    public boolean mightContain(String token) {
+        try {
+            return bloomClient.exists(filterName, token);
+        } catch (Exception e) {
+            log.error("토큰 존재 확인 실패 - token: {}", token, e);
+            // 안전을 위해 true 반환 (Redis에서 다시 확인)
+            return true;
+        }
+    }
+}

--- a/src/main/java/ktb/leafresh/backend/global/security/MetricsTrackingTokenBlacklistService.java
+++ b/src/main/java/ktb/leafresh/backend/global/security/MetricsTrackingTokenBlacklistService.java
@@ -1,9 +1,7 @@
 package ktb.leafresh.backend.global.security;
 
-import io.rebloom.client.Client;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -14,6 +12,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * JWT 블랙리스트 서비스 - 성능 메트릭 추적 기능 포함
  * Bloom Filter로 1차 필터링 후 Redis로 2차 정확한 검증하는 2단계 시스템
+ * False Positive 확률: 0.01% (application.yml 설정)
  */
 @Slf4j
 @Service("metricsTrackingTokenBlacklistService")
@@ -22,10 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class MetricsTrackingTokenBlacklistService implements TokenBlacklistService {
 
     private final StringRedisTemplate redisTemplate;
-    private final Client bloomClient;
-
-    @Value("${jwt.bloom-filter.key:accessTokenBlacklist}")
-    private String BLOOM_FILTER_NAME;
+    private final BloomFilterService bloomFilterService;
 
     // 성능 메트릭 추적용 카운터
     private final AtomicLong totalChecks = new AtomicLong(0);
@@ -36,22 +32,23 @@ public class MetricsTrackingTokenBlacklistService implements TokenBlacklistServi
 
     @Override
     public void blacklistAccessToken(String accessToken, long expirationTimeMillis) {
-        // Bloom Filter에 등록
-        bloomClient.add(BLOOM_FILTER_NAME, accessToken);
+        // Bloom Filter에 등록 (False Positive 확률: 0.01%)
+        bloomFilterService.addToken(accessToken);
 
         // Redis에 TTL과 함께 저장 (정확한 검증용)
         String key = "blacklist:" + accessToken;
         redisTemplate.opsForValue().set(key, "true", expirationTimeMillis, TimeUnit.MILLISECONDS);
 
-        log.info("[블랙리스트 등록] token={}, TTL={}ms", accessToken, expirationTimeMillis);
+        log.info("[블랙리스트 등록] token={}, TTL={}ms, falsePositiveProbability={}%", 
+            accessToken, expirationTimeMillis, bloomFilterService.getFalsePositiveProbability() * 100);
     }
 
     @Override
     public boolean isBlacklisted(String accessToken) {
         totalChecks.incrementAndGet();
 
-        // 1단계: Bloom Filter 검사
-        boolean mightExist = bloomClient.exists(BLOOM_FILTER_NAME, accessToken);
+        // 1단계: Bloom Filter 검사 (False Positive 확률: 0.01%)
+        boolean mightExist = bloomFilterService.mightContain(accessToken);
         
         if (!mightExist) {
             // Bloom Filter에서 확실히 없다고 판단 - Redis 조회 불필요
@@ -72,7 +69,8 @@ public class MetricsTrackingTokenBlacklistService implements TokenBlacklistServi
             actualBlacklistedTokens.incrementAndGet();
             log.debug("[실제 블랙리스트 토큰 발견] token={}", accessToken);
         } else {
-            log.debug("[False Positive] Bloom Filter 오판 - token={}", accessToken);
+            log.debug("[False Positive] Bloom Filter 오판 - token={}, 설정 확률: {}%", 
+                accessToken, bloomFilterService.getFalsePositiveProbability() * 100);
         }
 
         return isActuallyBlacklisted;
@@ -99,6 +97,8 @@ public class MetricsTrackingTokenBlacklistService implements TokenBlacklistServi
                 .actualBlacklistedTokens(actualBlacklisted)
                 .redisReductionRate(redisReductionRate)
                 .falsePositiveRate(falsePositiveRate)
+                .expectedInsertions(bloomFilterService.getExpectedInsertions())
+                .configuredFalsePositiveProbability(bloomFilterService.getFalsePositiveProbability())
                 .build();
     }
 
@@ -127,23 +127,34 @@ public class MetricsTrackingTokenBlacklistService implements TokenBlacklistServi
         private long actualBlacklistedTokens;
         private double redisReductionRate;
         private double falsePositiveRate;
+        private long expectedInsertions;
+        private double configuredFalsePositiveProbability;
 
         @Override
         public String toString() {
             return String.format("""
                 🎯 JWT 블랙리스트 성능 메트릭
                 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                📊 전체 검사: %,d회
-                🎯 Bloom Filter Hit: %,d회 (%.1f%%)
-                ❌ Bloom Filter Miss: %,d회 (%.1f%%)
-                🔍 Redis 조회: %,d회 (%.1f%%)
-                ⚠️  실제 블랙리스트: %,d회
+                ⚙️  Bloom Filter 설정:
+                   - 예상 삽입 수: %,d개
+                   - 설정 False Positive 확률: %.4f%% (1만회 중 %.0f회)
                 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                ✅ Redis 조회 감소율: %.1f%% (Bloom Filter 덕분에)
-                📈 False Positive 비율: %.1f%%
-                💡 성능 개선: Bloom Filter가 Redis 조회를 %,d회 절약
+                📊 실제 성능 지표:
+                   - 전체 검사: %,d회
+                   - Bloom Filter Hit: %,d회 (%.1f%%)
+                   - Bloom Filter Miss: %,d회 (%.1f%%)
+                   - Redis 조회: %,d회 (%.1f%%)
+                   - 실제 블랙리스트: %,d회
+                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                📈 성능 개선 결과:
+                   - Redis 조회 감소율: %.1f%% (Bloom Filter 덕분에)
+                   - 실제 False Positive 비율: %.4f%%
+                   - 설정 대비 오차: %.4f%% (설정 %.4f%% vs 실제 %.4f%%)
+                   - 절약된 Redis 조회: %,d회
                 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                 """,
+                expectedInsertions,
+                configuredFalsePositiveProbability * 100, configuredFalsePositiveProbability * 10000,
                 totalChecks,
                 bloomFilterHits, totalChecks > 0 ? (double) bloomFilterHits / totalChecks * 100 : 0,
                 bloomFilterMisses, totalChecks > 0 ? (double) bloomFilterMisses / totalChecks * 100 : 0,
@@ -151,6 +162,8 @@ public class MetricsTrackingTokenBlacklistService implements TokenBlacklistServi
                 actualBlacklistedTokens,
                 redisReductionRate,
                 falsePositiveRate,
+                Math.abs(falsePositiveRate - configuredFalsePositiveProbability * 100),
+                configuredFalsePositiveProbability * 100, falsePositiveRate,
                 bloomFilterMisses
             );
         }


### PR DESCRIPTION
- BloomFilterService 추가로 설정 기반 초기화
- False Positive 확률 0.01% (application.yml) 적용
- BF.RESERVE 명령으로 예상 삽입 수 10만개, 확률 0.0001 설정
- MetricsTrackingTokenBlacklistService 리팩토링
- 성능 메트릭에 설정값 vs 실제값 비교 기능 추가
- PostConstruct로 애플리케이션 시작 시 자동 초기화